### PR TITLE
Build GLnexus::range from bcf1_t using the END INFO field if present.

### DIFF
--- a/include/BCFKeyValueData.h
+++ b/include/BCFKeyValueData.h
@@ -32,7 +32,7 @@ public:
     
     Status dataset_bcf_header(const std::string& dataset,
                               std::shared_ptr<const bcf_hdr_t>& hdr) const override;
-    Status dataset_bcf(const std::string& dataset, const range& pos,
+    Status dataset_bcf(const std::string& dataset, const bcf_hdr_t* hdr, const range& pos,
                        std::vector<std::shared_ptr<bcf1_t> >& records) const override;
 
     /// Import a new dataset

--- a/include/BCFSerialize.h
+++ b/include/BCFSerialize.h
@@ -22,7 +22,6 @@ void bcf_raw_write_to_mem(bcf1_t *v, int reclen, char *addr);
 //  Read a BCF record from memory, return the length of the packed record in RAM.
 int bcf_raw_read_from_mem(const char *addr, bcf1_t *v);
 
-
 class BCFWriter {
  private:
     static int STACK_ALLOC_LIMIT;
@@ -33,11 +32,13 @@ class BCFWriter {
  public:
     BCFWriter();
 
+    /// Serializes BCF records into a memory buffer (without the header)
     static Status Open(std::unique_ptr<BCFWriter>& ans);
     ~BCFWriter();
     Status write(bcf1_t* x);
     Status contents(std::string& ans);
 
+    /// Writes a BCF header into a memory buffer
     static std::string write_header(const bcf_hdr_t *hdr);
 };
 
@@ -50,11 +51,13 @@ class BCFReader {
     BCFReader(const char* buf, size_t bufsz);
 
  public:
-    static Status Open(const char* buf, size_t bufsz,  std::unique_ptr<BCFReader>& ans);
+    /// Reads BCF records from a memory buffer (without the header)
+    static Status Open(const char* buf, size_t bufsz, std::unique_ptr<BCFReader>& ans);
     ~BCFReader();
     Status read(std::shared_ptr<bcf1_t>& ans);
 
-    static bcf_hdr_t* read_header(const char* buf, int len);
+    /// Reads a BCF header from a memory buffer
+    static Status read_header(const char* buf, int len, int& consumed, std::shared_ptr<bcf_hdr_t>& ans);
 };
 
 } // namespace GLnexus

--- a/include/data.h
+++ b/include/data.h
@@ -58,10 +58,11 @@ public:
 
     /// Each record x will already have been "unpacked" with
     /// bcf_unpack(x,BCF_UN_ALL). The records may be shared, so they must not
-    /// be mutated. They aren't declared const because some vcf.h accessor
-    /// functions don't take const bcf1_t*
+    /// be mutated. (They aren't declared const because some vcf.h accessor
+    /// functions don't take const bcf1_t*)
     ///
-    virtual Status dataset_bcf(const std::string& dataset, const range& pos,
+    /// The provided header must match the data set, otherwise the behavior is undefined!
+    virtual Status dataset_bcf(const std::string& dataset, const bcf_hdr_t* hdr, const range& pos,
                                std::vector<std::shared_ptr<bcf1_t> >& records) const = 0;
 };
 
@@ -83,8 +84,14 @@ public:
     Status sample_dataset(const std::string& sample, std::string& ans) const override;
     Status dataset_bcf_header(const std::string& dataset,
                               std::shared_ptr<const bcf_hdr_t>& hdr) const override;
-    Status dataset_bcf(const std::string& dataset, const range& pos,
+    Status dataset_bcf(const std::string& dataset, const bcf_hdr_t* hdr, const range& pos,
                        std::vector<std::shared_ptr<bcf1_t> >& records) const override;
+
+    /// Wrapper for dataset_bcf which also finds the required header from the
+    /// cache (useful if the caller doesn't already have the header in hand)
+    Status dataset_bcf(const std::string& dataset, const range& pos,
+                       std::shared_ptr<const bcf_hdr_t>& hdr,
+                       std::vector<std::shared_ptr<bcf1_t> >& records) const;
 
     const std::vector<std::pair<std::string,size_t> >& contigs() const;
     Status sampleset_datasets(const std::string& sampleset, std::shared_ptr<const std::set<std::string>>& ans) const;

--- a/src/BCFKeyValueData.cc
+++ b/src/BCFKeyValueData.cc
@@ -167,11 +167,10 @@ Status BCFKeyValueData::dataset_bcf_header(const string& dataset,
     S(body_->db->get(coll, dataset, data));
 
     // Parse the header
-    bcf_hdr_t *hdr_ref = BCFReader::read_header(data.c_str(), data.size());
-    if (hdr_ref == NULL) {
-        return Status::Invalid("Bad BCF header");
-    }
-    hdr = shared_ptr<bcf_hdr_t>(hdr_ref, &bcf_hdr_destroy);
+    shared_ptr<bcf_hdr_t> ans;
+    int consumed;
+    S(BCFReader::read_header(data.c_str(), data.size(), consumed, ans));
+    hdr = ans;
     return Status::OK();
 }
 

--- a/src/BCFKeyValueData.cc
+++ b/src/BCFKeyValueData.cc
@@ -174,7 +174,7 @@ Status BCFKeyValueData::dataset_bcf_header(const string& dataset,
     return Status::OK();
 }
 
-Status BCFKeyValueData::dataset_bcf(const string& dataset, const range& pos,
+Status BCFKeyValueData::dataset_bcf(const string& dataset, const bcf_hdr_t* hdr, const range& pos,
                                     vector<shared_ptr<bcf1_t> >& records) const {
     Status s;
 
@@ -193,7 +193,9 @@ Status BCFKeyValueData::dataset_bcf(const string& dataset, const range& pos,
     shared_ptr<bcf1_t> vt;
     while ((s = reader->read(vt)).ok()) {
         assert(vt);
-        if (pos.overlaps(vt.get())) {
+        range vt_rng;
+        S(range_of_bcf(hdr, vt, vt_rng));
+        if (pos.overlaps(vt_rng)) {
             if (bcf_unpack(vt.get(), BCF_UN_ALL) != 0) {
                 return Status::IOError("BCFKeyValueData::dataset_bcf bcf_unpack", dataset + "@" + pos.str());
             }

--- a/src/data.cc
+++ b/src/data.cc
@@ -40,8 +40,14 @@ Status DataCache::dataset_bcf_header(const string& dataset, shared_ptr<const bcf
     return body_->data->dataset_bcf_header(dataset, hdr);
 }
 
-Status DataCache::dataset_bcf(const string& dataset, const range& pos, vector<shared_ptr<bcf1_t> >& records) const {
-    return body_->data->dataset_bcf(dataset, pos, records);
+Status DataCache::dataset_bcf(const string& dataset, const bcf_hdr_t* hdr, const range& pos, vector<shared_ptr<bcf1_t> >& records) const {
+    return body_->data->dataset_bcf(dataset, hdr, pos, records);
+}
+
+Status DataCache::dataset_bcf(const string& dataset, const range& pos, shared_ptr<const bcf_hdr_t>& hdr, vector<shared_ptr<bcf1_t> >& records) const {
+    Status s;
+    S(dataset_bcf_header(dataset, hdr));
+    return dataset_bcf(dataset, hdr.get(), pos, records);
 }
 
 const vector<pair<string,size_t> >& DataCache::contigs() const {

--- a/src/service.cc
+++ b/src/service.cc
@@ -45,18 +45,16 @@ Status Service::discover_alleles(const string& sampleset, const range& pos, disc
     // extract alleles from each dataset
     ans.clear();
     for (const auto& dataset : *datasets) {
-        // read the header
-        shared_ptr<const bcf_hdr_t> dataset_header;
-        S(data_->dataset_bcf_header(dataset, dataset_header));
-
         // get dataset BCF records
+        shared_ptr<const bcf_hdr_t> dataset_header;
         vector<shared_ptr<bcf1_t>> records;
-        S(data_->dataset_bcf(dataset, pos, records));
+        S(data_->dataset_bcf(dataset, pos, dataset_header, records));
 
         // for each BCF record
         discovered_alleles dsals;
         for (const auto& record : records) {
-            range rng(*record);
+            range rng;
+            S(range_of_bcf(dataset_header, record, rng));
             vector<float> obs_counts(record->n_allele, 0.0);
 
             // count hard-called allele observations

--- a/src/types.cc
+++ b/src/types.cc
@@ -4,6 +4,48 @@ using namespace std;
 
 namespace GLnexus {
 
+string bcf_pos_errmsg(bcf1_t *bcf) {
+    ostringstream os;
+    os << '<' << bcf->rid << '>';
+    os << ':' << bcf->pos;
+    return os.str();
+}
+
+Status range_of_bcf(const bcf_hdr_t* hdr, bcf1_t* bcf, range& ans) {
+    if (hdr == nullptr || bcf == nullptr) {
+        return Status::Invalid("range_of_bcf null input");
+    }
+
+    bcf_info_t *info = bcf_get_info(hdr, bcf, "END");
+    if (info) {
+        if (info->type != BCF_BT_INT32) {
+            return Status::Invalid("range_of_bcf: END field has unexpected type", bcf_pos_errmsg(bcf));
+        }
+        if (info->len != 1) {
+            return Status::Invalid("range_of_bcf: multiple END fields", bcf_pos_errmsg(bcf));
+        }
+        if (info->v1.i < bcf->pos) {
+            return Status::Invalid("range_of_bcf: END < POS", bcf_pos_errmsg(bcf));
+        }
+        ans.end = info->v1.i;
+    } else {
+        ans.end = bcf->pos+bcf->rlen;
+    }
+
+    ans.rid = bcf->rid;
+    ans.beg = bcf->pos;
+    return Status::OK();
+}
+
+Status range_of_bcf(const bcf_hdr_t* hdr, const std::shared_ptr<bcf1_t>& bcf, range& ans) {
+    return range_of_bcf(hdr, bcf.get(), ans);
+}
+
+Status range_of_bcf(const std::shared_ptr<const bcf_hdr_t>& hdr,
+                    const std::shared_ptr<bcf1_t>& bcf, range& ans) {
+    return range_of_bcf(hdr.get(), bcf.get(), ans);
+}
+
 // Add src alleles to dest alleles. Identical alleles alleles ale merged,
 // using the sum of their observation_counts
 Status merge_discovered_alleles(const discovered_alleles& src, discovered_alleles& dest) {

--- a/test/BCFKeyValueData.cc
+++ b/test/BCFKeyValueData.cc
@@ -283,7 +283,7 @@ TEST_CASE("BCFKeyValueData BCF retrieval") {
         s = data->dataset_bcf_header("NA12878D", hdr);
         REQUIRE(s.ok());        
         vector<shared_ptr<bcf1_t>> records;
-        s = data->dataset_bcf("NA12878D", range(0, 0, 1000000000), records);
+        s = data->dataset_bcf("NA12878D", hdr.get(), range(0, 0, 1000000000), records);
         REQUIRE(s.ok());
 
         REQUIRE(records.size() == 5);
@@ -311,7 +311,7 @@ TEST_CASE("BCFKeyValueData BCF retrieval") {
         REQUIRE(bcf_get_info(hdr.get(), records[4].get(), "END")->v1.i == 10009471); // nb END stays 1-based!
 
         // subset of records
-        s = data->dataset_bcf("NA12878D", range(0, 10009463, 10009466), records);
+        s = data->dataset_bcf("NA12878D", hdr.get(), range(0, 10009463, 10009466), records);
         REQUIRE(s.ok());
 
         REQUIRE(records.size() == 2);
@@ -328,16 +328,16 @@ TEST_CASE("BCFKeyValueData BCF retrieval") {
         REQUIRE(string(records[1]->d.allele[1]) == "<NON_REF>");
 
         // empty results
-        s = data->dataset_bcf("NA12878D", range(0, 0, 1000), records);
+        s = data->dataset_bcf("NA12878D", hdr.get(), range(0, 0, 1000), records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 0);
 
-        s = data->dataset_bcf("NA12878D", range(1, 10009463, 10009466), records);
+        s = data->dataset_bcf("NA12878D", hdr.get(), range(1, 10009463, 10009466), records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 0);
 
         // bogus dataset
-        s = data->dataset_bcf("bogus", range(1, 10009463, 10009466), records);
+        s = data->dataset_bcf("bogus", hdr.get(), range(1, 10009463, 10009466), records);
         REQUIRE(s == StatusCode::NOT_FOUND);
     }
 }

--- a/test/rocks_integration.cc
+++ b/test/rocks_integration.cc
@@ -202,7 +202,7 @@ TEST_CASE("RocksDB BCF retrieval") {
         s = data->dataset_bcf_header("NA12878D", hdr);
         REQUIRE(s.ok());        
         vector<shared_ptr<bcf1_t>> records;
-        s = data->dataset_bcf("NA12878D", range(0, 0, 1000000000), records);
+        s = data->dataset_bcf("NA12878D", hdr.get(), range(0, 0, 1000000000), records);
         REQUIRE(s.ok());
 
         REQUIRE(records.size() == 5);
@@ -230,7 +230,7 @@ TEST_CASE("RocksDB BCF retrieval") {
         REQUIRE(bcf_get_info(hdr.get(), records[4].get(), "END")->v1.i == 10009471); // nb END stays 1-based!
 
         // subset of records
-        s = data->dataset_bcf("NA12878D", range(0, 10009463, 10009466), records);
+        s = data->dataset_bcf("NA12878D", hdr.get(), range(0, 10009463, 10009466), records);
         REQUIRE(s.ok());
 
         REQUIRE(records.size() == 2);
@@ -247,16 +247,16 @@ TEST_CASE("RocksDB BCF retrieval") {
         REQUIRE(string(records[1]->d.allele[1]) == "<NON_REF>");
 
         // empty results
-        s = data->dataset_bcf("NA12878D", range(0, 0, 1000), records);
+        s = data->dataset_bcf("NA12878D", hdr.get(), range(0, 0, 1000), records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 0);
 
-        s = data->dataset_bcf("NA12878D", range(1, 10009463, 10009466), records);
+        s = data->dataset_bcf("NA12878D", hdr.get(), range(1, 10009463, 10009466), records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 0);
 
         // bogus dataset
-        s = data->dataset_bcf("bogus", range(1, 10009463, 10009466), records);
+        s = data->dataset_bcf("bogus", hdr.get(), range(1, 10009463, 10009466), records);
         REQUIRE(s == StatusCode::NOT_FOUND);
     }
 }

--- a/test/service.cc
+++ b/test/service.cc
@@ -150,15 +150,17 @@ public:
         return Status::OK();
     }
 
-    Status dataset_bcf(const string& dataset, const range& pos, vector<shared_ptr<bcf1_t> >& records) const override {
+    Status dataset_bcf(const string& dataset, const bcf_hdr_t *hdr, const range& pos, vector<shared_ptr<bcf1_t> >& records) const override {
+        Status s;
         auto p = datasets_.find(dataset);
         if (p == datasets_.end()) {
             return Status::NotFound("unknown data set", dataset);
         }
-        //hdr = p->second.header;
         records.clear();
         for (const auto& bcf : p->second.records) {
-            if (range(bcf).overlaps(pos)) {
+            range rng;
+            S(range_of_bcf(hdr, bcf, rng));
+            if (rng.overlaps(pos)) {
                 records.push_back(bcf);
             }
         }

--- a/test/types.cc
+++ b/test/types.cc
@@ -40,3 +40,43 @@ TEST_CASE("range sort order") {
         REQUIRE(v[i] <= v[i+1]);
     }
 }
+
+TEST_CASE("range_of_bcf") {
+    #define UPD(T,name,ini,del) std::unique_ptr<T, void(*)(T*)> up_##name((ini), (del)); auto name = up_##name.get();
+    UPD(vcfFile, vcf, bcf_open("test/data/NA12878D_HiSeqX.21.10009462-10009469.gvcf", "r"), [](vcfFile* f) { bcf_close(f); });
+    UPD(bcf_hdr_t, hdr, bcf_hdr_read(vcf), &bcf_hdr_destroy);
+    shared_ptr<bcf1_t> vt;
+    vector<shared_ptr<bcf1_t>> records;
+
+    do {
+        if (vt) {
+            REQUIRE(bcf_unpack(vt.get(), BCF_UN_ALL) == 0);
+            records.push_back(vt);
+        }
+        vt = shared_ptr<bcf1_t>(bcf_init(), &bcf_destroy);
+    } while (bcf_read(vcf, hdr, vt.get()) == 0);
+
+    REQUIRE(records.size() == 5);
+
+    range rng;
+    Status s = range_of_bcf(hdr, records[0], rng);
+    REQUIRE(s.ok());
+    REQUIRE(rng.rid == 0);
+    REQUIRE(rng.beg == 10009461);
+    REQUIRE(rng.end == 10009463);
+    REQUIRE(rng.size() == 2);
+
+    s = range_of_bcf(hdr, records[1], rng);
+    REQUIRE(s.ok());
+    REQUIRE(rng.rid == 0);
+    REQUIRE(rng.beg == 10009463);
+    REQUIRE(rng.end == 10009465);
+    REQUIRE(rng.size() == 2);
+
+    s = range_of_bcf(hdr, records[2], rng);
+    REQUIRE(s.ok());
+    REQUIRE(rng.rid == 0);
+    REQUIRE(rng.beg == 10009465);
+    REQUIRE(rng.end == 10009466);
+    REQUIRE(rng.size() == 1);
+}


### PR DESCRIPTION
@orodeh here this is per [All About Genomic Ranges](https://github.com/dnanexus-rnd/GLnexus/wiki/All-About-Genomic-Ranges). A couple roadbumps:

1. The operation to build a `GLnexus::range` from a `bcf1_t` unfortunately can fail if the END field is invalid, so I pulled this out into a function returning `Status`.
1. Looking up the END INFO field also resurrects the need to reference the header in `BCFKeyValueData::dataset_bcf` :disappointed: