### PR TITLE
Change the way all-samples sample set works.

### DIFF
--- a/include/BCFKeyValueData.h
+++ b/include/BCFKeyValueData.h
@@ -37,6 +37,7 @@ public:
     Status sampleset_samples(const std::string& sampleset,
                              std::shared_ptr<const std::set<std::string> >& ans) const override;
     Status sample_dataset(const std::string& sample, std::string& ans) const override;
+    Status all_samples_sampleset(std::string& ans) override;
 
     // statistics
     std::shared_ptr<StatsRangeQuery> getRangeStats();

--- a/include/data.h
+++ b/include/data.h
@@ -19,8 +19,7 @@ namespace GLnexus {
 /// A data set contains all the allele/genotype/likelihood data for one or more
 /// samples -- just like a [V/B]CF file.
 /// All the GL data for each sample resides in exactly one data set.
-/// Sample sets and data sets are immutable once created/sealed, except
-/// possibly for a special "*" sample set representing all available samples.
+/// Sample sets and data sets are immutable.
 class Metadata {
 
 public:
@@ -43,6 +42,14 @@ public:
     ///
     /// The data set may contain other samples.
     virtual Status sample_dataset(const std::string& sample, std::string& ans) const = 0;
+
+    /// Return the name of a sample set representing all samples currently
+    /// available. This may either create a new sample set if needed, or
+    /// return an existing one if available. As always, the sample set is
+    /// immutable: it will not include samples added to the database later
+    /// (but one could call all_samples_sampleset again to get a different
+    /// sample set including them).
+    virtual Status all_samples_sampleset(std::string& ans) = 0;
 };
 
 
@@ -63,6 +70,7 @@ public:
     Status sampleset_samples(const std::string& sampleset,
                              std::shared_ptr<const std::set<std::string> >& ans) const override;
     Status sample_dataset(const std::string& sample, std::string& ans) const override;
+    Status all_samples_sampleset(std::string& ans) override;
 
     const std::vector<std::pair<std::string,size_t> >& contigs() const;
     Status sampleset_datasets(const std::string& sampleset,

--- a/src/data.cc
+++ b/src/data.cc
@@ -35,6 +35,10 @@ Status MetadataCache::sample_dataset(const string& sample, string& ans) const {
     return body_->inner->sample_dataset(sample, ans);
 }
 
+Status MetadataCache::all_samples_sampleset(string& ans) {
+    return body_->inner->all_samples_sampleset(ans);
+}
+
 const vector<pair<string,size_t> >& MetadataCache::contigs() const {
     return body_->contigs;
 }

--- a/test/BCFKeyValueData.cc
+++ b/test/BCFKeyValueData.cc
@@ -231,9 +231,16 @@ TEST_CASE("BCFKeyValueData::import_gvcf") {
     REQUIRE(MetadataCache::Start(*data, cache).ok());
     set<string> samples_imported;
 
-    SECTION("* sample set") {
+    SECTION("empty all_samples_sampleset") {
         shared_ptr<const set<string>> all;
         Status s = cache->sampleset_samples("*", all);
+        REQUIRE(s == StatusCode::NOT_FOUND);
+
+        string sampleset;
+        s = cache->all_samples_sampleset(sampleset);
+        REQUIRE(s.ok());
+
+        s = cache->sampleset_samples(sampleset, all);
         REQUIRE(s.ok());
         REQUIRE(all->size() == 0);
     }
@@ -248,6 +255,13 @@ TEST_CASE("BCFKeyValueData::import_gvcf") {
 
         shared_ptr<const set<string>> all;
         s = cache->sampleset_samples("*", all);
+        REQUIRE(s == StatusCode::NOT_FOUND);
+
+        string sampleset;
+        s = cache->all_samples_sampleset(sampleset);
+        REQUIRE(s.ok());
+
+        s = cache->sampleset_samples(sampleset, all);
         REQUIRE(s.ok());
         REQUIRE(all->size() == 1);
         REQUIRE(*(all->begin()) == "NA12878");

--- a/test/rocks_integration.cc
+++ b/test/rocks_integration.cc
@@ -386,15 +386,17 @@ static void queryDataset(T *data, const std::string &dataset) {
 // Query the '*' sampleset.
 static void querySampleset(T *data, int num_iter) {
     Status s;
-    const string allSS = std::string("*");
 
     for (int i=0; i < num_iter; i++) {
         if ((i % 10) == 0)
             cout << "querySampleset " << std::to_string(i) << endl;
 
         // map global sampleset to samples
+        string sampleset;
+        s = data->all_samples_sampleset(sampleset);
+        assert(s.ok());
         shared_ptr<const set<string> > samples;
-        s = data->sampleset_samples(allSS, samples);
+        s = data->sampleset_samples(sampleset, samples);
         assert(s.ok());
 
         // map samples to datasets
@@ -416,8 +418,12 @@ static void querySampleset(T *data, int num_iter) {
 
 // print the samples
 static void printDBSamples(T *data) {
+    string sampleset;
+    Status s = data->all_samples_sampleset(sampleset);
+    assert(s.ok());
+
     std::shared_ptr<const std::set<std::string> > samples;
-    Status s = data->sampleset_samples("*", samples);
+    s = data->sampleset_samples(sampleset, samples);
     assert(s.ok());
     assert(samples->size() == 4);
 

--- a/test/service.cc
+++ b/test/service.cc
@@ -141,6 +141,10 @@ public:
         return Status::NotFound("unknown sample set", sampleset);
     }
 
+    Status all_samples_sampleset(string& ans) override {
+        return Status::NotImplemented();
+    }
+
     Status sample_dataset(const string& sample, string& ans) const override {
         auto p = sample_datasets_.find(sample);
         if (p == sample_datasets_.end()) {


### PR DESCRIPTION
@orodeh This resolves the issue of inconsistent reads of sample sets during concurrent read/load operations. It can be optimized further in the future to memoize the sample set. Any comments?

Instead of a mutable * sample set, Metadata provides a method to return the name of an immutable sample set with all currently available samples. It creates a new one if necessary.