### PR TITLE
genotyper: optionally emit a symbolic allele for unrepresentable calls

### DIFF
--- a/cli/dxapplet/dxapp.json
+++ b/cli/dxapplet/dxapp.json
@@ -22,6 +22,11 @@
       "class": "array:string"
     },
     {
+      "name": "loss_symbolic_allele",
+      "class": "boolean",
+      "default": false
+    },
+    {
       "name": "output_name",
       "class": "string",
       "default": "GLnexus"

--- a/cli/dxapplet/src/code.sh
+++ b/cli/dxapplet/src/code.sh
@@ -36,13 +36,17 @@ main() {
     cp GLnexus.db/LOG "out/db_load_log/${output_name}.LOG"
 
     # genotype specified ranges
+    genotype_options=""
+    if [ "$loss_symbolic_allele" == "true" ]; then
+        genotype_options="$genotype_options --loss-symbolic-allele"
+    fi
     if [ "${#ranges_to_genotype[@]}" -gt "0" ]; then
         mkdir bcf
         i=0
         for range in "${ranges_to_genotype[@]}"; do
             range_sp=$(echo "$range" | tr -d "," | tr ":-" " ")
             outfn=$(printf "bcf/%05d.bcf" "$i")
-            time glnexus_cli genotype GLnexus.db $range_sp > "$outfn"
+            time glnexus_cli genotype $genotype_options GLnexus.db $range_sp > "$outfn"
             i=$(expr $i + 1)
         done
         ls -lh bcf

--- a/include/genotyper_config.h
+++ b/include/genotyper_config.h
@@ -26,12 +26,12 @@ struct genotyper_config {
     /// By default, GLnexus emits no-calls (.) in such situations, which is
     /// the same thing that'd appear if the sample had no overlapping gVCF data
     /// at all. Sometimes it might be useful to distinguish these cases.
-    /// If unrepr_symbolic_allele is set to a symbolic allele such as "?" or
+    /// If loss_symbolic_allele is set to a symbolic allele such as "?" or
     /// "NON_REF", then GLnexus will add this symbolic allele to the ALT of
-    /// all output records, and calls of it indicate an unrepresentable allele
-    /// call as described above.
+    /// all output records, and calls of it indicate a "lost" allele call as
+    /// described above.
     /// The symbolic allele must not contain angle brackets or whitespace.
-    std::string unrepr_symbolic_allele;
+    std::string loss_symbolic_allele;
 
     genotyper_config() = default;
 };

--- a/include/genotyper_config.h
+++ b/include/genotyper_config.h
@@ -13,11 +13,25 @@ struct genotyper_config {
     /// FORMAT field to consult for per-allele depth in VCF records
     std::string allele_dp_format = "AD";
 
-    /// The symbolic allele used in gVCF reference confidence models
+    /// The symbolic allele used in INPUT gVCF reference confidence records
     std::string ref_symbolic_allele = "<NON_REF>";
 
     /// FORMAT field to consult for reference depth in gVCF reference records
     std::string ref_dp_format = "MIN_DP";
+
+    /// Sometimes the input gVCF records contain specific allele calls that
+    /// GLnexus is unable to render accurately in the output VCF file, e.g.
+    /// rare alleles that are "pruned" during unification to ameliorate
+    /// combinatorial explosion of the possible genotypes.
+    /// By default, GLnexus emits no-calls (.) in such situations, which is
+    /// the same thing that'd appear if the sample had no overlapping gVCF data
+    /// at all. Sometimes it might be useful to distinguish these cases.
+    /// If unrepr_symbolic_allele is set to a symbolic allele such as "?" or
+    /// "NON_REF", then GLnexus will add this symbolic allele to the ALT of
+    /// all output records, and calls of it indicate an unrepresentable allele
+    /// call as described above.
+    /// The symbolic allele must not contain angle brackets or whitespace.
+    std::string unrepr_symbolic_allele;
 
     genotyper_config() = default;
 };

--- a/src/genotyper.cc
+++ b/src/genotyper.cc
@@ -11,7 +11,7 @@ using namespace std;
 
 namespace GLnexus {
 
-bool is_gvcf_ref_record(const genotyper_config& cfg, const bcf1_t* record) {
+static bool is_gvcf_ref_record(const genotyper_config& cfg, const bcf1_t* record) {
     return record->n_allele == 2 && string(record->d.allele[1]) == cfg.ref_symbolic_allele;
 }
 
@@ -196,7 +196,14 @@ Status LossTracker::get(loss_stats& ans) const noexcept {
 
 // Update the loss_stats data structure with call information for
 // original calls associated with a unified site
-Status update_orig_calls_for_loss(const genotyper_config& cfg, bcf1_t* record, int n_bcf_samples, int* gt, const map<int,int>& sample_mapping, LossTrackers& losses_for_site) {
+#define IS_CALLED(cfg,gt_i) (!bcf_gt_is_missing(gt_i) &&                 \
+                             (cfg.unrepr_symbolic_allele.empty() ||      \
+                              bcf_gt_allele(gt_i) < site.alleles.size()))
+static Status update_orig_calls_for_loss(const genotyper_config& cfg,
+                                         const unified_site& site,
+                                         bcf1_t* record, int n_bcf_samples, int* gt,
+                                         const map<int,int>& sample_mapping,
+                                         LossTrackers& losses_for_site) {
     range rng(record);
     Status s;
 
@@ -204,7 +211,7 @@ Status update_orig_calls_for_loss(const genotyper_config& cfg, bcf1_t* record, i
         int sample_ind = sample_mapping.at(i);
         auto& loss = losses_for_site[sample_ind];
 
-        int n_calls = !bcf_gt_is_missing(gt[i*2]) + !bcf_gt_is_missing(gt[i*2 + 1]);
+        int n_calls = IS_CALLED(cfg,gt[i*2]) + IS_CALLED(cfg,gt[i*2 + 1]);
         loss.add_call_for_site(rng, n_calls, is_gvcf_ref_record(cfg, record));
     }
 
@@ -213,7 +220,9 @@ Status update_orig_calls_for_loss(const genotyper_config& cfg, bcf1_t* record, i
 
 // Update the loss_stats data sturcture with the joint call for
 // the unified site and finalize the loss measures
-Status update_joint_call_loss(bcf1_t* record, int n_bcf_samples, vector<int>& gt, LossTrackers& losses_for_site) {
+static Status update_joint_call_loss(const genotyper_config& cfg, const unified_site& site,
+                                     bcf1_t* record, int n_bcf_samples, vector<int>& gt,
+                                     LossTrackers& losses_for_site) {
 
     if(n_bcf_samples != losses_for_site.size()) {
         return Status::Failure("update_joint_call_loss: number of samples and bcf does not match");
@@ -224,7 +233,7 @@ Status update_joint_call_loss(bcf1_t* record, int n_bcf_samples, vector<int>& gt
     for (int i = 0; i < n_bcf_samples; i++) {
         auto& loss = losses_for_site[i];
 
-        int n_gt_missing = (bcf_gt_is_missing(gt[i*2]) + bcf_gt_is_missing(gt[i*2 + 1]));
+        int n_gt_missing = (!IS_CALLED(cfg,gt[i*2]) + (!IS_CALLED(cfg,gt[i*2 + 1])));
 
         assert(n_gt_missing <= 2);
         // Lock down the loss associated with this unified_site
@@ -256,8 +265,19 @@ Status translate_genotypes(const genotyper_config& cfg, const unified_site& site
 
     // map the bcf1_t alt alleles according to unification
     for (int i = 1; i < record->n_allele; i++) {
+        int a = -1; // default sentinel value for no-call
         auto p = site.unification.find(make_pair(rng.beg, string(record->d.allele[i])));
-        allele_mapping.push_back(p != site.unification.end() ? p->second : -1);
+        if (p != site.unification.end()) {
+            // found a matching allele in the unified site
+            a = p->second;
+        } else if (!cfg.unrepr_symbolic_allele.empty()) {
+            // no matching allele in the unified site. if we actually observe
+            // a call of this allele, we will (if so configured) emit a
+            // symbolic ALT allele distinct from no-call. The symbolic allele
+            // will be added to the output BCF record in genotype_site below.
+            a = site.alleles.size();
+        }
+        allele_mapping.push_back(a);
     }
 
     // get the genotype calls
@@ -268,7 +288,7 @@ Status translate_genotypes(const genotyper_config& cfg, const unified_site& site
     assert(record->n_sample == bcf_hdr_nsamples(dataset_header));
 
     // update loss statistics for this bcf record
-    update_orig_calls_for_loss(cfg, record, n_bcf_samples, gt, sample_mapping, losses_for_site);
+    update_orig_calls_for_loss(cfg, site, record, n_bcf_samples, gt, sample_mapping, losses_for_site);
     // and the depth of coverage info
     unique_ptr<AlleleDepthHelper> depth;
     S(AlleleDepthHelper::Open(cfg, dataset, dataset_header, record, depth));
@@ -299,7 +319,9 @@ Status translate_genotypes(const genotyper_config& cfg, const unified_site& site
             // accurately render the situation.
             genotypes[2*ij.second]
                 = genotypes[2*ij.second+1]
-                = bcf_gt_missing;
+                = (cfg.unrepr_symbolic_allele.empty()
+                        ? bcf_gt_missing
+                        : bcf_gt_unphased(site.alleles.size()));
         }
     }
 
@@ -363,6 +385,12 @@ Status genotype_site(const genotyper_config& cfg, BCFData& data, const unified_s
     for (const auto& allele : site.alleles) {
         c_alleles.push_back(allele.c_str());
     }
+    string unrepr;
+    if (!cfg.unrepr_symbolic_allele.empty()) {
+        // add an extra ALT entry for the "unrepresentable" symbolic allele
+        unrepr = "<" + cfg.unrepr_symbolic_allele + ">";
+        c_alleles.push_back(unrepr.c_str());
+    }
 
     ans = shared_ptr<bcf1_t>(bcf_init(), &bcf_destroy);
 
@@ -378,7 +406,7 @@ Status genotype_site(const genotyper_config& cfg, BCFData& data, const unified_s
         return Status::Failure("bcf_update_genotypes");
     }
 
-    S(update_joint_call_loss(ans.get(), bcf_hdr_nsamples(hdr), genotypes, loss_trackers));
+    S(update_joint_call_loss(cfg, site, ans.get(), bcf_hdr_nsamples(hdr), genotypes, loss_trackers));
     // Package consolidated_loss for this site and merge into losses_for_site
     // to be returned to parent caller
     consolidated_loss losses;

--- a/src/genotyper.cc
+++ b/src/genotyper.cc
@@ -197,7 +197,7 @@ Status LossTracker::get(loss_stats& ans) const noexcept {
 // Update the loss_stats data structure with call information for
 // original calls associated with a unified site
 #define IS_CALLED(cfg,gt_i) (!bcf_gt_is_missing(gt_i) &&                 \
-                             (cfg.unrepr_symbolic_allele.empty() ||      \
+                             (cfg.loss_symbolic_allele.empty() ||      \
                               bcf_gt_allele(gt_i) < site.alleles.size()))
 static Status update_orig_calls_for_loss(const genotyper_config& cfg,
                                          const unified_site& site,
@@ -270,7 +270,7 @@ Status translate_genotypes(const genotyper_config& cfg, const unified_site& site
         if (p != site.unification.end()) {
             // found a matching allele in the unified site
             a = p->second;
-        } else if (!cfg.unrepr_symbolic_allele.empty()) {
+        } else if (!cfg.loss_symbolic_allele.empty()) {
             // no matching allele in the unified site. if we actually observe
             // a call of this allele, we will (if so configured) emit a
             // symbolic ALT allele distinct from no-call. The symbolic allele
@@ -319,7 +319,7 @@ Status translate_genotypes(const genotyper_config& cfg, const unified_site& site
             // accurately render the situation.
             genotypes[2*ij.second]
                 = genotypes[2*ij.second+1]
-                = (cfg.unrepr_symbolic_allele.empty()
+                = (cfg.loss_symbolic_allele.empty()
                         ? bcf_gt_missing
                         : bcf_gt_unphased(site.alleles.size()));
         }
@@ -386,9 +386,9 @@ Status genotype_site(const genotyper_config& cfg, BCFData& data, const unified_s
         c_alleles.push_back(allele.c_str());
     }
     string unrepr;
-    if (!cfg.unrepr_symbolic_allele.empty()) {
+    if (!cfg.loss_symbolic_allele.empty()) {
         // add an extra ALT entry for the "unrepresentable" symbolic allele
-        unrepr = "<" + cfg.unrepr_symbolic_allele + ">";
+        unrepr = "<" + cfg.loss_symbolic_allele + ">";
         c_alleles.push_back(unrepr.c_str());
     }
 

--- a/src/service.cc
+++ b/src/service.cc
@@ -221,10 +221,10 @@ Status Service::genotype_sites(const genotyper_config& cfg, const string& sample
     // TODO: memoize
     vector<string> hdr_lines;
     hdr_lines.push_back("##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
-    if (!cfg.unrepr_symbolic_allele.empty()) {
+    if (!cfg.loss_symbolic_allele.empty()) {
         // optional symbol to distinguish an "unrepresentable" allele from
         // other no-calls due to missing data
-        hdr_lines.push_back("##ALT=<ID=" + cfg.unrepr_symbolic_allele + ",Description=\"Unrepresentable allele from GLnexus\">");
+        hdr_lines.push_back("##ALT=<ID=" + cfg.loss_symbolic_allele + ",Description=\"Unrepresentable allele from GLnexus\">");
     }
     for (const auto& ctg : body_->metadata_->contigs()) {
         ostringstream stm;

--- a/src/service.cc
+++ b/src/service.cc
@@ -219,16 +219,23 @@ Status Service::genotype_sites(const genotyper_config& cfg, const string& sample
 
     // create a BCF header for this sample set
     // TODO: memoize
-    shared_ptr<bcf_hdr_t> hdr(bcf_hdr_init("w"), &bcf_hdr_destroy);
-    const char* hdrGT = "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">";
-    if (bcf_hdr_append(hdr.get(), hdrGT) != 0) {
-        return Status::Failure("bcf_hdr_append", hdrGT);
+    vector<string> hdr_lines;
+    hdr_lines.push_back("##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
+    if (!cfg.unrepr_symbolic_allele.empty()) {
+        // optional symbol to distinguish an "unrepresentable" allele from
+        // other no-calls due to missing data
+        hdr_lines.push_back("##ALT=<ID=" + cfg.unrepr_symbolic_allele + ",Description=\"Unrepresentable allele from GLnexus\">");
     }
     for (const auto& ctg : body_->metadata_->contigs()) {
         ostringstream stm;
         stm << "##contig=<ID=" << ctg.first << ",length=" << ctg.second << ">";
-        if (bcf_hdr_append(hdr.get(), stm.str().c_str()) != 0) {
-            return Status::Failure("bcf_hdr_append", stm.str());
+        hdr_lines.push_back(stm.str());
+    }
+
+    shared_ptr<bcf_hdr_t> hdr(bcf_hdr_init("w"), &bcf_hdr_destroy);
+    for (const auto& line : hdr_lines) {
+        if (bcf_hdr_append(hdr.get(), line.c_str()) != 0) {
+            return Status::Failure("bcf_hdr_append", line);
         }
     }
     for (const auto& sample : sample_names) {

--- a/test/data/discover_alleles_trio1.vcf
+++ b/test/data/discover_alleles_trio1.vcf
@@ -10,6 +10,7 @@ A	1002	.	C	G,T	.	PASS	.	GT	0/0	1/1	2/2
 A	1011	.	CC	AG	.	PASS	.	GT	0/1	0/1	0/1
 A	1101	.	C	A	.	PASS	.	GT	0/1	0/1	0/1
 A	1103	.	C	G	.	PASS	.	GT	0/1	0/1	0/1
+A	1201	.	C	A	.	PASS	.	GT	0/1	0/1	0/1
 B	1001	.	A	AA	.	PASS	.	GT	1/1	0/1	0/1
 B	1002	.	C	G	.	PASS	.	GT	1/1	1/1	1/1
 B	1011	.	CC	AG	.	PASS	.	GT	0/1	0/1	0/1

--- a/test/service.cc
+++ b/test/service.cc
@@ -979,9 +979,9 @@ TEST_CASE("genotyper placeholder") {
     }
 
     // This is the 2trios test but with
-    // genotyper_config::unrepr_symbolic_allele turned on -- changes the
+    // genotyper_config::loss_symbolic_allele turned on -- changes the
     // representation of the pruned alleles
-    SECTION("unrepr_symbolic_allele") {
+    SECTION("loss_symbolic_allele") {
         s = svc->discover_alleles("<ALL>", range(0, 0, 1000000), als);
         REQUIRE(s.ok());
 
@@ -990,7 +990,7 @@ TEST_CASE("genotyper placeholder") {
         REQUIRE(s.ok());
 
         genotyper_config cfg;
-        cfg.unrepr_symbolic_allele = "?";
+        cfg.loss_symbolic_allele = "?";
         consolidated_loss losses;
         s = svc->genotype_sites(cfg, string("<ALL>"), sites, tfn, losses);
         REQUIRE(s.ok());


### PR DESCRIPTION
@yifei-men this provides a configuration option, `genotyper_config::loss_symbolic_allele`, to distinguish unrepresentable gVCF calls (i.e. losses) from lack of gVCF coverage, instead of lumping them both as no-call (.). This is optional because it complicates the output VCF and users might not always care. I added a new site in the two-trios example to help with testing it. Please look this over because it touches the loss accounting in a few different places. 

This is the new output VCF for the two-trios example with this configuration option activated. The last site has no-calls for trio2 due to missing data, while the other sites have the new symbolic allele here and there.

```
##fileformat=VCFv4.2
##FILTER=<ID=PASS,Description="All filters passed">
##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
##ALT=<ID=?,Description="Unrepresentable allele from GLnexus">
##contig=<ID=A,length=1000000>
##contig=<ID=B,length=1000000>
##contig=<ID=C,length=1000000>
##bcftools_viewVersion=1.2+htslib-1.2.1
##bcftools_viewCommand=view /tmp/unrepr.bcf
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  trio1.ch        trio1.fa        trio1.mo        trio2.ch        trio2.fa        trio2.mo
A       1001    .       A       G,<?>   0       .       .       GT      1/1     0/1     0/1     0/0     0/1     0/1
A       1002    .       C       A,G,T,<?>       0       .       .       GT      3/3     0/0     2/2     1/1     1/1     1/1
A       1011    .       CC      AG,<?>  0       .       .       GT      0/1     0/1     0/1     0/0     0/2     0/2
A       1101    .       C       A,<?>   0       .       .       GT      0/1     0/1     0/1     0/0     0/2     0/2
A       1103    .       C       G,<?>   0       .       .       GT      0/1     0/1     0/1     0/0     0/2     0/2
A       1201    .       C       A,<?>   0       .       .       GT      0/1     0/1     0/1     ./.     ./.     ./.
```