### PR TITLE
genotyper: distinguish reason for no-call in output VCF

### DIFF
--- a/src/service.cc
+++ b/src/service.cc
@@ -219,16 +219,19 @@ Status Service::genotype_sites(const genotyper_config& cfg, const string& sample
 
     // create a BCF header for this sample set
     // TODO: memoize
-    shared_ptr<bcf_hdr_t> hdr(bcf_hdr_init("w"), &bcf_hdr_destroy);
-    const char* hdrGT = "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">";
-    if (bcf_hdr_append(hdr.get(), hdrGT) != 0) {
-        return Status::Failure("bcf_hdr_append", hdrGT);
-    }
+    vector<string> hdr_lines;
+    hdr_lines.push_back("##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
+    hdr_lines.push_back("##FORMAT=<ID=RNC,Number=G,Type=Character,Description=\"Reason for No Call in GT: . = N/A, M = Missing data, L = Lost/unrepresentable allele\">");
     for (const auto& ctg : body_->metadata_->contigs()) {
         ostringstream stm;
         stm << "##contig=<ID=" << ctg.first << ",length=" << ctg.second << ">";
-        if (bcf_hdr_append(hdr.get(), stm.str().c_str()) != 0) {
-            return Status::Failure("bcf_hdr_append", stm.str());
+        hdr_lines.push_back(stm.str());
+    }
+
+    shared_ptr<bcf_hdr_t> hdr(bcf_hdr_init("w"), &bcf_hdr_destroy);
+    for (const auto& line : hdr_lines) {
+        if (bcf_hdr_append(hdr.get(), line.c_str()) != 0) {
+            return Status::Failure("bcf_hdr_append", line);
         }
     }
     for (const auto& sample : sample_names) {

--- a/test/data/discover_alleles_trio1.vcf
+++ b/test/data/discover_alleles_trio1.vcf
@@ -10,6 +10,7 @@ A	1002	.	C	G,T	.	PASS	.	GT	0/0	1/1	2/2
 A	1011	.	CC	AG	.	PASS	.	GT	0/1	0/1	0/1
 A	1101	.	C	A	.	PASS	.	GT	0/1	0/1	0/1
 A	1103	.	C	G	.	PASS	.	GT	0/1	0/1	0/1
+A	1201	.	C	A	.	PASS	.	GT	0/1	0/1	0/1
 B	1001	.	A	AA	.	PASS	.	GT	1/1	0/1	0/1
 B	1002	.	C	G	.	PASS	.	GT	1/1	1/1	1/1
 B	1011	.	CC	AG	.	PASS	.	GT	0/1	0/1	0/1


### PR DESCRIPTION
@yifei-men simpler approach to the goal described in #23. Feedback welcome.

Each output genotype has an RNC FORMAT field explaining the reason for a no-call: . (N/A, allele was called), (M)issing data, (L)ost/unrepresentable allele.

Here's how the output now looks (always - doesn't need to be activated by configuration). We're paying a couple extra characters per genotype call, whether missing or not, which is unfortunate but perhaps worthwhile for the overall simpler approach. One thing I could use your help checking: does PyVCF parse this new field correctly, or does it want the characters to be comma-separated?

```
##fileformat=VCFv4.2
##FILTER=<ID=PASS,Description="All filters passed">
##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
##FORMAT=<ID=RNC,Number=G,Type=Character,Description="Reason for No Call in GT: . = N/A, M = Missing data, L = Lost/unrepresentable allele">
##contig=<ID=A,length=1000000>
##contig=<ID=B,length=1000000>
##contig=<ID=C,length=1000000>
##bcftools_viewVersion=1.2+htslib-1.2.1
##bcftools_viewCommand=view /tmp/aoeu.bcf
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  trio1.ch        trio1.fa
        trio1.mo        trio2.ch        trio2.fa        trio2.mo
A       1001    .       A       G       0       .       .       GT:RNC  1/1:..  0/1:..  0/1:..  0/0:..  0/1:..  0/1:..
A       1002    .       C       A,G,T   0       .       .       GT:RNC  3/3:..  0/0:..  2/2:..  1/1:..  1/1:..  1/1:..
A       1011    .       CC      AG      0       .       .       GT:RNC  0/1:..  0/1:..  0/1:..  0/0:..  0/.:.L  0/.:.L
A       1101    .       C       A       0       .       .       GT:RNC  0/1:..  0/1:..  0/1:..  0/0:..  0/.:.L  0/.:.L
A       1103    .       C       G       0       .       .       GT:RNC  0/1:..  0/1:..  0/1:..  0/0:..  0/.:.L  0/.:.L
A       1201    .       C       A       0       .       .       GT:RNC  0/1:..  0/1:..  0/1:..  ./.:MM  ./.:MM  ./.:MM
```