### PR TITLE
memoization for BCF headers and metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,19 @@ ExternalProject_Get_Property(CTPL source_dir)
 set(CTPL_INCLUDE_DIR ${source_dir})
 include_directories(${CTPL_INCLUDE_DIR})
 
+ExternalProject_Add(fcmm
+    URL https://github.com/giacomodrago/fcmm/archive/v1.0.1.zip
+    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external
+    CONFIGURE_COMMAND ""
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    LOG_DOWNLOAD ON
+  )
+ExternalProject_Get_Property(fcmm source_dir)
+set(FCMM_INCLUDE_DIR ${source_dir})
+include_directories(${FCMM_INCLUDE_DIR})
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++14 -Wall -Werror=return-type -Werror=unused-result -Wno-sign-compare -fdiagnostics-color=auto")
 
 ################################
@@ -123,6 +136,7 @@ add_dependencies(glnexus htslib)
 add_dependencies(glnexus rocksdb)
 add_dependencies(glnexus yaml-cpp)
 add_dependencies(glnexus CTPL)
+add_dependencies(glnexus fcmm)
 add_library(libglnexus ALIAS glnexus)
 
 add_executable(playground src/playground.cc)

--- a/src/data.cc
+++ b/src/data.cc
@@ -1,13 +1,30 @@
 #include <assert.h>
 #include "data.h"
+#include "fcmm.hpp"
+#include "khash.h"
 
 using namespace std;
 
 namespace GLnexus {
 
+// std::hash<string> using the string hash function from htslib
+class KStringHash {
+public:
+    std::size_t operator()(string const& s) const  {
+        return (size_t) kh_str_hash_func(s.c_str());
+    }
+};
+using StringCache = fcmm::Fcmm<string,string,hash<string>,KStringHash>;
+using StringSetCache = fcmm::Fcmm<string,shared_ptr<const set<string>>,hash<string>,KStringHash>;
+// this is not a hard limit but the FCMM performance degrades if it's too low
+const size_t CACHE_SIZE = 4096;
+
 struct MetadataCache::body {
     Metadata* inner;
     vector<pair<string,size_t> > contigs;
+    unique_ptr<StringSetCache> sampleset_samples_cache;
+    unique_ptr<StringCache> sample_dataset_cache;
+    unique_ptr<StringSetCache> sampleset_datasets_cache;
 };
 
 MetadataCache::MetadataCache() = default;
@@ -17,6 +34,9 @@ Status MetadataCache::Start(Metadata& inner, unique_ptr<MetadataCache>& ptr) {
     ptr.reset(new MetadataCache);
     ptr->body_.reset(new MetadataCache::body);
     ptr->body_->inner = &inner;
+    ptr->body_->sampleset_samples_cache = make_unique<StringSetCache>(CACHE_SIZE);
+    ptr->body_->sample_dataset_cache = make_unique<StringCache>(16 * CACHE_SIZE);
+    ptr->body_->sampleset_datasets_cache = make_unique<StringSetCache>(CACHE_SIZE);
     return ptr->body_->inner->contigs(ptr->body_->contigs);
 }
 
@@ -26,16 +46,36 @@ Status MetadataCache::contigs(vector<pair<string,size_t> >& ans) const {
 }
 
 Status MetadataCache::sampleset_samples(const string& sampleset, shared_ptr<const set<string> >& ans) const {
-    // TODO cache
-    return body_->inner->sampleset_samples(sampleset, ans);
+    auto cached = body_->sampleset_samples_cache->end();
+    if ((cached = body_->sampleset_samples_cache->find(sampleset))
+            != body_->sampleset_samples_cache->end()) {
+        ans = cached->second;
+        assert(ans);
+        return Status::OK();
+    }
+
+    Status s;
+    S(body_->inner->sampleset_samples(sampleset, ans));
+    body_->sampleset_samples_cache->insert(make_pair(sampleset,ans));
+    return Status::OK();
 }
 
 Status MetadataCache::sample_dataset(const string& sample, string& ans) const {
-    // TODO cache
-    return body_->inner->sample_dataset(sample, ans);
+    auto cached = body_->sample_dataset_cache->end();
+    if ((cached = body_->sample_dataset_cache->find(sample))
+            != body_->sample_dataset_cache->end()) {
+        ans = cached->second;
+        return Status::OK();
+    }
+
+    Status s;
+    S(body_->inner->sample_dataset(sample, ans));
+    body_->sample_dataset_cache->insert(make_pair(sample,ans));
+    return Status::OK();
 }
 
 Status MetadataCache::all_samples_sampleset(string& ans) {
+    // not safe to cache this as it's not immutable
     return body_->inner->all_samples_sampleset(ans);
 }
 
@@ -46,16 +86,25 @@ const vector<pair<string,size_t> >& MetadataCache::contigs() const {
 Status MetadataCache::sampleset_datasets(const string& sampleset,
                                          shared_ptr<const set<string>>& samples,
                                          shared_ptr<const set<string>>& datasets_out) const {
-    // TODO cache
     Status s;
-    auto datasets = make_shared<set<string>>();
     S(sampleset_samples(sampleset, samples));
+
+    auto cached = body_->sampleset_datasets_cache->end();
+    if ((cached = body_->sampleset_datasets_cache->find(sampleset))
+            != body_->sampleset_datasets_cache->end()) {
+        datasets_out = cached->second;
+        assert(datasets_out);
+        return Status::OK();
+    }
+
+    auto datasets = make_shared<set<string>>();
     for (const auto& it : *samples) {
         string dataset;
         S(sample_dataset(it, dataset));
         datasets->insert(dataset);
     }
     datasets_out = datasets;
+    body_->sampleset_datasets_cache->insert(make_pair(sampleset,datasets_out));
     return Status::OK();
 }
 


### PR DESCRIPTION
@orodeh I played around with memoizing/caching metadata, that is BCF headers and the immutable sample/sampleset/dataset relationships, using a concurrent hash map library [FCMM](https://github.com/giacomodrago/fcmm). The assumption is that this stuff is relatively small, such that there's no need for cache eviction, making the concurrent hash map (which doesn't support erase) a reasonable choice over the lock-based LRU cache. The benefit of memoizing the BCF headers might be significant, in that the header is typically much larger than a gVCF record, and currently we re-parse the header for every range query. Comments welcome.