### PR TITLE
In translate_genotypes, check for changes in REF allele.

### DIFF
--- a/src/genotyper.cc
+++ b/src/genotyper.cc
@@ -272,11 +272,20 @@ static Status translate_genotypes(const genotyper_config& cfg, const unified_sit
     // reference allele maps if it contains the unified site
     range rng(record);
     allele_mapping.push_back(rng.contains(site.pos) ? 0 : -1);
-
-    // map the bcf1_t alt alleles according to unification
-    for (int i = 1; i < record->n_allele; i++) {
-        auto p = site.unification.find(make_pair(rng.beg, string(record->d.allele[i])));
-        allele_mapping.push_back(p != site.unification.end() ? p->second : -1);
+    // if reference alleles are different, the same alt allele
+    // DNA sequence may have different meaning and cannot be translated
+    // directly as is.
+    bool isIdenticalRef = site.pos.size() == rng.size();
+    if (!isIdenticalRef) {
+        for (int i = 1; i < record->n_allele; i++) {
+            allele_mapping.push_back(-1);
+        }
+    } else {
+        // map the bcf1_t alt alleles according to unification
+        for (int i = 1; i < record->n_allele; i++) {
+            auto p = site.unification.find(make_pair(rng.beg, string(record->d.allele[i])));
+            allele_mapping.push_back(p != site.unification.end() ? p->second : -1);
+        }
     }
 
     // get the genotype calls

--- a/src/genotyper.cc
+++ b/src/genotyper.cc
@@ -275,8 +275,8 @@ static Status translate_genotypes(const genotyper_config& cfg, const unified_sit
     // if reference alleles are different, the same alt allele
     // DNA sequence may have different meaning and cannot be translated
     // directly as is.
-    bool isIdenticalRef = site.pos.size() == rng.size();
-    if (!isIdenticalRef) {
+    bool is_identical_ref = site.pos == rng;
+    if (!is_identical_ref) {
         for (int i = 1; i < record->n_allele; i++) {
             allele_mapping.push_back(-1);
         }

--- a/test/data/joint_A.gvcf
+++ b/test/data/joint_A.gvcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=A,length=1000000>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	JOINT_A
+A	1000	.	ATGTGTG	A,ATG,ATGTG,ATGTGTGTG	.	PASS	.	GT	1/3

--- a/test/data/joint_B.gvcf
+++ b/test/data/joint_B.gvcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=A,length=1000000>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	JOINT_B
+A	1000	.	ATG	ATGTG, A	.	PASS	.	GT	0/1

--- a/test/data/joint_C.gvcf
+++ b/test/data/joint_C.gvcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=A,length=1000000>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	JOINT_C
+A	1000	.	ATG	ATGTG, A	.	PASS	.	GT	0/1

--- a/test/data/joint_D.gvcf
+++ b/test/data/joint_D.gvcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=A,length=1000000>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	JOINT_D
+A	1000	.	ATG	ATGTG, A	.	PASS	.	GT	0/1

--- a/test/service.cc
+++ b/test/service.cc
@@ -618,12 +618,12 @@ TEST_CASE("genotyper placeholder") {
         int *gt = nullptr, gtsz = 0;
         int nGT = bcf_get_genotypes(hdr.get(), record.get(), &gt, &gtsz);
         REQUIRE(nGT == 6);
-        REQUIRE(bcf_gt_allele(gt[0] == 1));
-        REQUIRE(bcf_gt_allele(gt[1] == 1));
-        REQUIRE(bcf_gt_allele(gt[2] == 0));
-        REQUIRE(bcf_gt_allele(gt[3] == 1));
-        REQUIRE(bcf_gt_allele(gt[4] == 0));
-        REQUIRE(bcf_gt_allele(gt[5] == 1));
+        REQUIRE(bcf_gt_allele(gt[0]) == 1);
+        REQUIRE(bcf_gt_allele(gt[1]) == 1);
+        REQUIRE(bcf_gt_allele(gt[2]) == 0);
+        REQUIRE(bcf_gt_allele(gt[3]) == 1);
+        REQUIRE(bcf_gt_allele(gt[4]) == 0);
+        REQUIRE(bcf_gt_allele(gt[5]) == 1);
 
         REQUIRE(bcf_read(vcf.get(), hdr.get(), record.get()) == 0);
         REQUIRE(bcf_unpack(record.get(), BCF_UN_ALL) == 0);
@@ -635,12 +635,12 @@ TEST_CASE("genotyper placeholder") {
 
         nGT = bcf_get_genotypes(hdr.get(), record.get(), &gt, &gtsz);
         REQUIRE(nGT == 6);
-        REQUIRE(bcf_gt_allele(gt[0] == 2));
-        REQUIRE(bcf_gt_allele(gt[1] == 2));
-        REQUIRE(bcf_gt_allele(gt[2] == 0));
-        REQUIRE(bcf_gt_allele(gt[3] == 0));
-        REQUIRE(bcf_gt_allele(gt[4] == 1));
-        REQUIRE(bcf_gt_allele(gt[5] == 1));
+        REQUIRE(bcf_gt_allele(gt[0]) == 2);
+        REQUIRE(bcf_gt_allele(gt[1]) == 2);
+        REQUIRE(bcf_gt_allele(gt[2]) == 0);
+        REQUIRE(bcf_gt_allele(gt[3]) == 0);
+        REQUIRE(bcf_gt_allele(gt[4]) == 1);
+        REQUIRE(bcf_gt_allele(gt[5]) == 1);
 
         REQUIRE(bcf_read(vcf.get(), hdr.get(), record.get()) == 0);
         REQUIRE(bcf_unpack(record.get(), BCF_UN_ALL) == 0);
@@ -651,12 +651,12 @@ TEST_CASE("genotyper placeholder") {
 
         nGT = bcf_get_genotypes(hdr.get(), record.get(), &gt, &gtsz);
         REQUIRE(nGT == 6);
-        REQUIRE(bcf_gt_allele(gt[0] == 0));
-        REQUIRE(bcf_gt_allele(gt[1] == 1));
-        REQUIRE(bcf_gt_allele(gt[2] == 0));
-        REQUIRE(bcf_gt_allele(gt[3] == 1));
-        REQUIRE(bcf_gt_allele(gt[4] == 0));
-        REQUIRE(bcf_gt_allele(gt[5] == 1));
+        REQUIRE(bcf_gt_allele(gt[0]) == 0);
+        REQUIRE(bcf_gt_allele(gt[1]) == 1);
+        REQUIRE(bcf_gt_allele(gt[2]) == 0);
+        REQUIRE(bcf_gt_allele(gt[3]) == 1);
+        REQUIRE(bcf_gt_allele(gt[4]) == 0);
+        REQUIRE(bcf_gt_allele(gt[5]) == 1);
 
         REQUIRE(bcf_read(vcf.get(), hdr.get(), record.get()) == 0);
         REQUIRE(bcf_unpack(record.get(), BCF_UN_ALL) == 0);
@@ -667,12 +667,12 @@ TEST_CASE("genotyper placeholder") {
 
         nGT = bcf_get_genotypes(hdr.get(), record.get(), &gt, &gtsz);
         REQUIRE(nGT == 6);
-        REQUIRE(bcf_gt_allele(gt[0] == 0));
-        REQUIRE(bcf_gt_allele(gt[1] == 1));
-        REQUIRE(bcf_gt_allele(gt[2] == 0));
-        REQUIRE(bcf_gt_allele(gt[3] == 1));
-        REQUIRE(bcf_gt_allele(gt[4] == 0));
-        REQUIRE(bcf_gt_allele(gt[5] == 1));
+        REQUIRE(bcf_gt_allele(gt[0]) == 0);
+        REQUIRE(bcf_gt_allele(gt[1]) == 1);
+        REQUIRE(bcf_gt_allele(gt[2]) == 0);
+        REQUIRE(bcf_gt_allele(gt[3]) == 1);
+        REQUIRE(bcf_gt_allele(gt[4]) == 0);
+        REQUIRE(bcf_gt_allele(gt[5]) == 1);
 
         REQUIRE(bcf_read(vcf.get(), hdr.get(), record.get()) == 0);
         REQUIRE(bcf_unpack(record.get(), BCF_UN_ALL) == 0);
@@ -683,12 +683,12 @@ TEST_CASE("genotyper placeholder") {
 
         nGT = bcf_get_genotypes(hdr.get(), record.get(), &gt, &gtsz);
         REQUIRE(nGT == 6);
-        REQUIRE(bcf_gt_allele(gt[0] == 0));
-        REQUIRE(bcf_gt_allele(gt[1] == 1));
-        REQUIRE(bcf_gt_allele(gt[2] == 0));
-        REQUIRE(bcf_gt_allele(gt[3] == 1));
-        REQUIRE(bcf_gt_allele(gt[4] == 0));
-        REQUIRE(bcf_gt_allele(gt[5] == 1));
+        REQUIRE(bcf_gt_allele(gt[0]) == 0);
+        REQUIRE(bcf_gt_allele(gt[1]) == 1);
+        REQUIRE(bcf_gt_allele(gt[2]) == 0);
+        REQUIRE(bcf_gt_allele(gt[3]) == 1);
+        REQUIRE(bcf_gt_allele(gt[4]) == 0);
+        REQUIRE(bcf_gt_allele(gt[5]) == 1);
 
         // validate loss information
         auto loss1 = losses.find("trio1.ch");
@@ -750,18 +750,18 @@ TEST_CASE("genotyper placeholder") {
         int *gt = nullptr, gtsz = 0;
         int nGT = bcf_get_genotypes(hdr.get(), record.get(), &gt, &gtsz);
         REQUIRE(nGT == 12);
-        REQUIRE(bcf_gt_allele(gt[0] == 1));
-        REQUIRE(bcf_gt_allele(gt[1] == 1));
-        REQUIRE(bcf_gt_allele(gt[2] == 0));
-        REQUIRE(bcf_gt_allele(gt[3] == 1));
-        REQUIRE(bcf_gt_allele(gt[4] == 0));
-        REQUIRE(bcf_gt_allele(gt[5] == 1));
-        REQUIRE(bcf_gt_allele(gt[6] == 0));
-        REQUIRE(bcf_gt_allele(gt[7] == 0));
-        REQUIRE(bcf_gt_allele(gt[8] == 0));
-        REQUIRE(bcf_gt_allele(gt[9] == 1));
-        REQUIRE(bcf_gt_allele(gt[10] == 0));
-        REQUIRE(bcf_gt_allele(gt[11] == 1));
+        REQUIRE(bcf_gt_allele(gt[0]) == 1);
+        REQUIRE(bcf_gt_allele(gt[1]) == 1);
+        REQUIRE(bcf_gt_allele(gt[2]) == 0);
+        REQUIRE(bcf_gt_allele(gt[3]) == 1);
+        REQUIRE(bcf_gt_allele(gt[4]) == 0);
+        REQUIRE(bcf_gt_allele(gt[5]) == 1);
+        REQUIRE(bcf_gt_allele(gt[6]) == 0);
+        REQUIRE(bcf_gt_allele(gt[7]) == 0);
+        REQUIRE(bcf_gt_allele(gt[8]) == 0);
+        REQUIRE(bcf_gt_allele(gt[9]) == 1);
+        REQUIRE(bcf_gt_allele(gt[10]) == 0);
+        REQUIRE(bcf_gt_allele(gt[11]) == 1);
 
         REQUIRE(bcf_read(vcf.get(), hdr.get(), record.get()) == 0);
         REQUIRE(bcf_unpack(record.get(), BCF_UN_ALL) == 0);
@@ -774,18 +774,18 @@ TEST_CASE("genotyper placeholder") {
 
         nGT = bcf_get_genotypes(hdr.get(), record.get(), &gt, &gtsz);
         REQUIRE(nGT == 12);
-        REQUIRE(bcf_gt_allele(gt[0] == 3));
-        REQUIRE(bcf_gt_allele(gt[1] == 3));
-        REQUIRE(bcf_gt_allele(gt[2] == 0));
-        REQUIRE(bcf_gt_allele(gt[3] == 0));
-        REQUIRE(bcf_gt_allele(gt[4] == 2));
-        REQUIRE(bcf_gt_allele(gt[5] == 2));
-        REQUIRE(bcf_gt_allele(gt[6] == 1));
-        REQUIRE(bcf_gt_allele(gt[7] == 1));
-        REQUIRE(bcf_gt_allele(gt[8] == 1));
-        REQUIRE(bcf_gt_allele(gt[9] == 1));
-        REQUIRE(bcf_gt_allele(gt[10] == 1));
-        REQUIRE(bcf_gt_allele(gt[11] == 1));
+        REQUIRE(bcf_gt_allele(gt[0]) == 3);
+        REQUIRE(bcf_gt_allele(gt[1]) == 3);
+        REQUIRE(bcf_gt_allele(gt[2]) == 0);
+        REQUIRE(bcf_gt_allele(gt[3]) == 0);
+        REQUIRE(bcf_gt_allele(gt[4]) == 2);
+        REQUIRE(bcf_gt_allele(gt[5]) == 2);
+        REQUIRE(bcf_gt_allele(gt[6]) == 1);
+        REQUIRE(bcf_gt_allele(gt[7]) == 1);
+        REQUIRE(bcf_gt_allele(gt[8]) == 1);
+        REQUIRE(bcf_gt_allele(gt[9]) == 1);
+        REQUIRE(bcf_gt_allele(gt[10]) == 1);
+        REQUIRE(bcf_gt_allele(gt[11]) == 1);
 
         REQUIRE(bcf_read(vcf.get(), hdr.get(), record.get()) == 0);
         REQUIRE(bcf_unpack(record.get(), BCF_UN_ALL) == 0);
@@ -796,12 +796,12 @@ TEST_CASE("genotyper placeholder") {
 
         nGT = bcf_get_genotypes(hdr.get(), record.get(), &gt, &gtsz);
         REQUIRE(nGT == 12);
-        REQUIRE(bcf_gt_allele(gt[0] == 0));
-        REQUIRE(bcf_gt_allele(gt[1] == 1));
-        REQUIRE(bcf_gt_allele(gt[2] == 0));
-        REQUIRE(bcf_gt_allele(gt[3] == 1));
-        REQUIRE(bcf_gt_allele(gt[4] == 0));
-        REQUIRE(bcf_gt_allele(gt[5] == 1));
+        REQUIRE(bcf_gt_allele(gt[0]) == 0);
+        REQUIRE(bcf_gt_allele(gt[1]) == 1);
+        REQUIRE(bcf_gt_allele(gt[2]) == 0);
+        REQUIRE(bcf_gt_allele(gt[3]) == 1);
+        REQUIRE(bcf_gt_allele(gt[4]) == 0);
+        REQUIRE(bcf_gt_allele(gt[5]) == 1);
         REQUIRE(bcf_gt_allele(gt[6]) == 0);
         REQUIRE(bcf_gt_allele(gt[7]) == 0);
         REQUIRE(bcf_gt_allele(gt[8]) == 0);
@@ -818,12 +818,12 @@ TEST_CASE("genotyper placeholder") {
 
         nGT = bcf_get_genotypes(hdr.get(), record.get(), &gt, &gtsz);
         REQUIRE(nGT == 12);
-        REQUIRE(bcf_gt_allele(gt[0] == 0));
-        REQUIRE(bcf_gt_allele(gt[1] == 1));
-        REQUIRE(bcf_gt_allele(gt[2] == 0));
-        REQUIRE(bcf_gt_allele(gt[3] == 1));
-        REQUIRE(bcf_gt_allele(gt[4] == 0));
-        REQUIRE(bcf_gt_allele(gt[5] == 1));
+        REQUIRE(bcf_gt_allele(gt[0]) == 0);
+        REQUIRE(bcf_gt_allele(gt[1]) == 1);
+        REQUIRE(bcf_gt_allele(gt[2]) == 0);
+        REQUIRE(bcf_gt_allele(gt[3]) == 1);
+        REQUIRE(bcf_gt_allele(gt[4]) == 0);
+        REQUIRE(bcf_gt_allele(gt[5]) == 1);
         REQUIRE(bcf_gt_allele(gt[6]) == 0);
         REQUIRE(bcf_gt_allele(gt[7]) == 0);
         REQUIRE(bcf_gt_allele(gt[8]) == 0);
@@ -840,12 +840,12 @@ TEST_CASE("genotyper placeholder") {
 
         nGT = bcf_get_genotypes(hdr.get(), record.get(), &gt, &gtsz);
         REQUIRE(nGT == 12);
-        REQUIRE(bcf_gt_allele(gt[0] == 0));
-        REQUIRE(bcf_gt_allele(gt[1] == 1));
-        REQUIRE(bcf_gt_allele(gt[2] == 0));
-        REQUIRE(bcf_gt_allele(gt[3] == 1));
-        REQUIRE(bcf_gt_allele(gt[4] == 0));
-        REQUIRE(bcf_gt_allele(gt[5] == 1));
+        REQUIRE(bcf_gt_allele(gt[0]) == 0);
+        REQUIRE(bcf_gt_allele(gt[1]) == 1);
+        REQUIRE(bcf_gt_allele(gt[2]) == 0);
+        REQUIRE(bcf_gt_allele(gt[3]) == 1);
+        REQUIRE(bcf_gt_allele(gt[4]) == 0);
+        REQUIRE(bcf_gt_allele(gt[5]) == 1);
         REQUIRE(bcf_gt_allele(gt[6]) == 0);
         REQUIRE(bcf_gt_allele(gt[7]) == 0);
         REQUIRE(bcf_gt_allele(gt[8]) == 0);
@@ -869,12 +869,12 @@ TEST_CASE("genotyper placeholder") {
 
         nGT = bcf_get_genotypes(hdr.get(), record.get(), &gt, &gtsz);
         REQUIRE(nGT == 12);
-        REQUIRE(bcf_gt_allele(gt[0] == 0));
-        REQUIRE(bcf_gt_allele(gt[1] == 1));
-        REQUIRE(bcf_gt_allele(gt[2] == 0));
-        REQUIRE(bcf_gt_allele(gt[3] == 1));
-        REQUIRE(bcf_gt_allele(gt[4] == 0));
-        REQUIRE(bcf_gt_allele(gt[5] == 1));
+        REQUIRE(bcf_gt_allele(gt[0]) == 0);
+        REQUIRE(bcf_gt_allele(gt[1]) == 1);
+        REQUIRE(bcf_gt_allele(gt[2]) == 0);
+        REQUIRE(bcf_gt_allele(gt[3]) == 1);
+        REQUIRE(bcf_gt_allele(gt[4]) == 0);
+        REQUIRE(bcf_gt_allele(gt[5]) == 1);
         REQUIRE(bcf_gt_is_missing(gt[6]));
         REQUIRE(bcf_gt_is_missing(gt[7]));
         REQUIRE(bcf_gt_is_missing(gt[8]));
@@ -966,12 +966,12 @@ TEST_CASE("genotyper placeholder") {
         int *gt = nullptr, gtsz = 0;
         int nGT = bcf_get_genotypes(hdr.get(), record.get(), &gt, &gtsz);
         REQUIRE(nGT == 6);
-        REQUIRE(bcf_gt_allele(gt[0] == 0));
-        REQUIRE(bcf_gt_allele(gt[1] == 0));
-        REQUIRE(bcf_gt_allele(gt[2] == 0));
-        REQUIRE(bcf_gt_allele(gt[3] == 1));
-        REQUIRE(bcf_gt_allele(gt[4] == 0));
-        REQUIRE(bcf_gt_allele(gt[5] == 1));
+        REQUIRE(bcf_gt_allele(gt[0]) == 0);
+        REQUIRE(bcf_gt_allele(gt[1]) == 0);
+        REQUIRE(bcf_gt_allele(gt[2]) == 0);
+        REQUIRE(bcf_gt_allele(gt[3]) == 1);
+        REQUIRE(bcf_gt_allele(gt[4]) == 0);
+        REQUIRE(bcf_gt_allele(gt[5]) == 1);
 
         REQUIRE(bcf_read(vcf.get(), hdr.get(), record.get()) == 0);
         REQUIRE(bcf_unpack(record.get(), BCF_UN_ALL) == 0);
@@ -984,12 +984,12 @@ TEST_CASE("genotyper placeholder") {
 
         nGT = bcf_get_genotypes(hdr.get(), record.get(), &gt, &gtsz);
         REQUIRE(nGT == 6);
-        REQUIRE(bcf_gt_allele(gt[0] == 1));
-        REQUIRE(bcf_gt_allele(gt[1] == 1));
-        REQUIRE(bcf_gt_allele(gt[2] == 1));
-        REQUIRE(bcf_gt_allele(gt[3] == 1));
-        REQUIRE(bcf_gt_allele(gt[4] == 1));
-        REQUIRE(bcf_gt_allele(gt[5] == 1));
+        REQUIRE(bcf_gt_allele(gt[0]) == 1);
+        REQUIRE(bcf_gt_allele(gt[1]) == 1);
+        REQUIRE(bcf_gt_allele(gt[2]) == 1);
+        REQUIRE(bcf_gt_allele(gt[3]) == 1);
+        REQUIRE(bcf_gt_allele(gt[4]) == 1);
+        REQUIRE(bcf_gt_allele(gt[5]) == 1);
 
         REQUIRE(bcf_read(vcf.get(), hdr.get(), record.get()) == 0);
         REQUIRE(bcf_unpack(record.get(), BCF_UN_ALL) == 0);
@@ -1133,8 +1133,8 @@ TEST_CASE("gVCF genotyper") {
         int *gt = nullptr, gtsz = 0;
         int nGT = bcf_get_genotypes(hdr.get(), record.get(), &gt, &gtsz);
         REQUIRE(nGT == 2);
-        REQUIRE(bcf_gt_allele(gt[0] == 0));
-        REQUIRE(bcf_gt_allele(gt[1] == 0));
+        REQUIRE(bcf_gt_allele(gt[0]) == 0);
+        REQUIRE(bcf_gt_allele(gt[1]) == 0);
 
         REQUIRE(bcf_read(vcf.get(), hdr.get(), record.get()) == 0);
         REQUIRE(bcf_unpack(record.get(), BCF_UN_ALL) == 0);


### PR DESCRIPTION
## Problem that this PR addresses
In cases where the REF allele in the unified site differs from the original input (g)vcf, the ALT allele, when lifted over, may carry a different genomic meaning. This is especially problematic for indels.

This commit checks for changes in the REF allele and in the cases where the REF differs, all ALT calls in the original (g)vcf is deemed to be untranslatable and are genotyped as no-calls.

I'm also sneaking in a batch correction for typos relating to misplaced brackets around `bcf_gt_allele` in `REQUIRE` statements, which I discovered when adding in my own tests in similar formats. The misplaced bracket causes a subtle situation that doesn't execute the expected test conditions. Fortunately, this correction did not create any test failures, so the genotyping behavior has been performing as expected.

## Example
Test added, as inspired by real-life observation of inaccurate GLnexus genotype translation.

### Input
In the file Joint_A.gvcf, we note that the original input has 2 ALT calls at site *A:1000*, `A` and `ATGTG` associated with the REF `ATGTGTG`. We can interpret this as Joint_A has 1 TGTGTG deletion allele and 1 TG deletion allele at this site.
 
### Allele discovery and unification
Allele discovery and unification will return REF = `ATG` and ALT=`ATGTG`, which are the 2 most frequent alleles across the 4 gvcf joint-genotyped. 

### Output
Before this patch, we would expect GLnexus to output, for Joint_A, an ALT call of `ATGTG` and a loss of the original call of `A`. Note however, that the ALT call of `ATGTG`, when associated with the REF of `ATG`, indicates a `TG` insertion, which is different from the original input meaning of a `TG` deletion, and thus incorrect.

This patch will interpret both ALT calls in Joint_A to be untranslatable and thus we expect 2 no-calls at the unified site.

## Next steps
Create a more clever translate_genotype routine which can understand the context of the changing REF allele and translate input ALTs to unified alleles correctly, retaining the appropriate indel/point mutation semantic meaning.