### PR TITLE
Quick Patch: Accept N as a valid base for alleles

### DIFF
--- a/src/service.cc
+++ b/src/service.cc
@@ -36,7 +36,7 @@ Status Service::Start(Metadata& metadata, BCFData& data, unique_ptr<Service>& sv
 
 bool is_dna(const string& str) {
     return all_of(str.begin(), str.end(),
-                  [](char ch) { return ch == 'A' || ch == 'C' || ch == 'G' || ch == 'T'; });
+                  [](char ch) { return ch == 'A' || ch == 'C' || ch == 'G' || ch == 'T' || ch =='N'; });
 }
 
 // discover_alleles in one dataset -- used on the thread pool below


### PR DESCRIPTION
Noted N as REF alleles in real-world GVCF files, which causes GLnexus to throw an error and exit. Adding a quick patch to accept such entries.