### PR TITLE
KeyValue::Iterator: reduce buffer copying during iteration

### DIFF
--- a/test/BCFKeyValueData.cc
+++ b/test/BCFKeyValueData.cc
@@ -15,16 +15,16 @@ namespace KeyValueMem {
         friend class Reader;
 
     public:
-        bool valid() override {
+        bool valid() const override {
             return it_ != data_.end();
         }
 
-        const std::string& key() override {
-            return it_->first;
+        pair<const char*,size_t> key() const override {
+            return make_pair(it_->first.c_str(), it_->first.size());
         }
 
-        const std::string& value() override {
-            return it_->second;
+        pair<const char*,size_t> value() const override {
+            return make_pair(it_->second.c_str(), it_->second.size());
         }
 
         Status next() override {


### PR DESCRIPTION
@orodeh here's a premature optimization to to reduce the amount of buffer copying that occurs during use of a `KeyValue::Iterator`. This is complementary to the idea of scanning a BCF bucket *in situ*.