### PR TITLE
Cli command iter comp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ external/
 # cscope
 cscope*
 
+#emacs
+*~
+
 # htslib stuff
 mem:*
 src/1.*.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,7 @@ add_executable(playground src/playground.cc)
 add_dependencies(playground libglnexus)
 target_link_libraries(playground -pthread jemalloc glnexus libhts z librocksdb libyaml-cpp)
 
-add_executable(glnexus_cli cli/glnexus_cli.cc)
+add_executable(glnexus_cli cli/glnexus_cli.cc test/compare_iter.cc)
 add_dependencies(glnexus_cli libglnexus)
 add_dependencies(glnexus_cli spdlog)
 target_link_libraries(glnexus_cli -pthread jemalloc glnexus libhts z librocksdb libyaml-cpp snappy bz2 lz4 rt)
@@ -217,7 +217,8 @@ if (test)
                  test/genotyper.cc
                  test/service.cc
                  test/BCFKeyValueData.cc
-                 test/rocks_integration.cc)
+                 test/rocks_integration.cc
+                 test/compare_iter.cc)
   add_dependencies(unit_tests libglnexus)
   target_link_libraries(unit_tests glnexus librocksdb -pthread jemalloc libhts rt snappy z bz2 lz4 rt libyaml-cpp)
 

--- a/cli/dxapplet/dxapp.json
+++ b/cli/dxapplet/dxapp.json
@@ -48,6 +48,12 @@
       "class": "int",
       "default": 0,
       "optional": true
+    },
+    {
+      "name": "iter_compare",
+      "class": "int",
+      "default": 0,
+      "optional": true
     }
   ],
   "outputSpec": [

--- a/cli/dxapplet/src/code.sh
+++ b/cli/dxapplet/src/code.sh
@@ -53,6 +53,15 @@ main() {
     mkdir -p out/db_load_log
     cp GLnexus.db/LOG "out/db_load_log/${output_name}.LOG"
 
+
+    # Test that the iterators work correctly
+    if [ "$iter_compare" == "1" ]; then
+        echo "Comparing iterator implementations"
+        glnexus_cli iter_compare GLnexus.db
+        rc=$?
+        exit $rc
+    fi
+
     # assemble BED file of ranges to genotype
     mkdir -p in/bed_ranges_to_genotype
     touch in/bed_ranges_to_genotype/DUMMY
@@ -62,14 +71,6 @@ main() {
         echo "$range_sp" >> ranges.bed
     done
     wc -l ranges.bed
-
-    # Test that the iterators work correctly
-    if [ "$iter_compare" == "1" ]; then
-        echo "Comparing iterator implementations"
-        glnexus_cli iter_compare GLnexus.db
-        rc=$?
-        exit $rc
-    fi
 
     # genotype the ranges
     if [ "$(cat ranges.bed | wc -l)" -gt "0" ]; then

--- a/cli/dxapplet/src/code.sh
+++ b/cli/dxapplet/src/code.sh
@@ -58,8 +58,6 @@ main() {
     if [ "$iter_compare" == "1" ]; then
         echo "Comparing iterator implementations"
         glnexus_cli iter_compare GLnexus.db
-        rc=$?
-        exit $rc
     fi
 
     # assemble BED file of ranges to genotype

--- a/cli/dxapplet/src/code.sh
+++ b/cli/dxapplet/src/code.sh
@@ -63,6 +63,14 @@ main() {
     done
     wc -l ranges.bed
 
+    # Test that the iterators work correctly
+    if [ "$iter_compare" == "1" ]; then
+        echo "Comparing iterator implementations"
+        glnexus_cli iter_compare GLnexus.db
+        rc=$?
+        exit $rc
+    fi
+
     # genotype the ranges
     if [ "$(cat ranges.bed | wc -l)" -gt "0" ]; then
         if [ "$enable_perf" == "1" ]; then

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -572,38 +572,18 @@ int main_genotype(int argc, char *argv[]) {
     return 0;
 }
 
+void help_iter_compare(const char* prog) {
+    cerr << "usage: " << prog << " iter_compare /db/path" << endl
+         << "Run tests comparing the two BCF iterators" << endl
+         << endl;
+}
+
 int main_iter_compare(int argc, char *argv[]) {
-    if (argc == 2) {
-        help_init(argv[0]);
+    if (argc != 3) {
+        help_iter_compare(argv[0]);
         return 1;
     }
-
-    static struct option long_options[] = {
-        {"help", no_argument, 0, 'h'},
-        {0, 0, 0, 0}
-    };
-
-    int c;
-    optind = 2; // force optind past command positional argument
-    while (-1 != (c = getopt_long(argc, argv, "h",
-                                  long_options, nullptr))) {
-        switch (c) {
-            case 'h':
-            case '?':
-                help_init(argv[0]);
-                exit(1);
-                break;
-
-            default:
-                abort ();
-        }
-    }
-
-//    if (optind != argc-2) {
-//        help_init(argv[0]);
-//        return 1;
-//    }
-    string dbpath(argv[optind]);
+    string dbpath(argv[2]);
 
     // open the database in read-write mode, create an all-samples sample set,
     // and close it. This is not elegant. It'd be better for the bulk load
@@ -621,7 +601,6 @@ int main_iter_compare(int argc, char *argv[]) {
     H("all_samples_sampleset", data->all_samples_sampleset(sampleset));
     console->info() << "created sample set " << sampleset;
 
-    // resolve the user-supplied contig name to rid
     const auto& contigs = metadata->contigs();
 
     // get samples and datasets
@@ -629,7 +608,7 @@ int main_iter_compare(int argc, char *argv[]) {
     H("sampleset_datasets", metadata->sampleset_datasets(sampleset, samples, datasets));
 
     int nChroms = min((size_t)22, contigs.size());
-    int nIter = 20;
+    int nIter = 50;
     int maxRangeLen = 1000000;
     int minLen = 10; // ensure that the the range is of some minimal size
 
@@ -644,7 +623,7 @@ int main_iter_compare(int argc, char *argv[]) {
 
         int beg = genRandNumber(lenChrom - rangeLen);
         int rlen = genRandNumber(rangeLen - minLen);
-        GLnexus::range rng(0, beg, beg + minLen + rlen);
+        GLnexus::range rng(rid, beg, beg + minLen + rlen);
 
         int rc = compare_query(*data, *metadata, sampleset, rng);
         switch (rc) {

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -604,7 +604,6 @@ static void read_entire_iter(GLnexus::RangeBCFIterator *iter, vector<shared_ptr<
         vector<shared_ptr<bcf1_t>> v;
         v.clear();
         s = iter->next(dataset, hdr, v);
-        cout << "len(v)=" << v.size() << endl;
         for (auto rec : v)
             records.push_back(rec);
     } while (s.ok());
@@ -630,10 +629,11 @@ static int compare_query(GLnexus::BCFKeyValueData &data, GLnexus::MetadataCache 
     shared_ptr<const set<string>> samples, datasets;
 
     // simple iterator
-    assert(data.sampleset_range_base(cache, sampleset, rng,
-                                     samples, datasets, iterators).ok());
+    s = data.sampleset_range_base(cache, sampleset, rng,
+                                  samples, datasets, iterators);
+    if (!s.ok())
+        return 0;
 
-    cout << "--- regular iterator (" << iterators.size() << ")" << endl;
     for (int i=0; i < iterators.size(); i++) {
         read_entire_iter(iterators[i].get(), all_records_base);
 
@@ -646,10 +646,11 @@ static int compare_query(GLnexus::BCFKeyValueData &data, GLnexus::MetadataCache 
 
     // sophisticated iterator
     iterators.clear();
-    assert(data.sampleset_range(cache, sampleset, rng,
-                                 samples, datasets, iterators).ok());
+    s = data.sampleset_range(cache, sampleset, rng,
+                             samples, datasets, iterators);
+    if (!s.ok())
+        return 0;
 
-    cout << "--- sophisticated iterator (" << iterators.size() << ")" << endl;
     for (int i=0; i < iterators.size(); i++) {
         read_entire_iter(iterators[i].get(), all_records_soph);
     }
@@ -724,7 +725,7 @@ int main_iter_compare(int argc, char *argv[]) {
     shared_ptr<const set<string>> samples, datasets;
     H("sampleset_datasets", metadata->sampleset_datasets(sampleset, samples, datasets));
 
-    int nChroms = /*contigs.size()*/ 20;
+    int nChroms = min((size_t)22, contigs.size());
     int nIter = 50;
     for (int i = 0; i < nIter; i++) {
         int rid = genRandInt(nChroms);

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -595,29 +595,34 @@ static int bcf_shallow_compare(bcf1_t *x, bcf1_t *y) {
     return 1;
 }
 
-// read an entire iterator and add the bcf1 records to [records]
-static void read_entire_iter(GLnexus::RangeBCFIterator *iter, vector<shared_ptr<bcf1_t>> records) {
+static void read_entire_iter(GLnexus::RangeBCFIterator *iter, vector<shared_ptr<bcf1_t>> &records) {
     GLnexus::Status s;
 
     string dataset;
     shared_ptr<const bcf_hdr_t> hdr;
     do {
         vector<shared_ptr<bcf1_t>> v;
+        v.clear();
         s = iter->next(dataset, hdr, v);
-        records.insert(records.begin(), v.begin(), v.end());
+        cout << "len(v)=" << v.size() << endl;
+        for (auto rec : v)
+            records.push_back(rec);
     } while (s.ok());
 }
 
+static void sort_records(vector<shared_ptr<bcf1_t>> &records) {
+    sort(records.begin(), records.end(),
+         [] (const shared_ptr<bcf1_t>& p1, const shared_ptr<bcf1_t>& p2) {
+             if (p1->rid < p2->rid) return true;
+             if (p1->rid == p2->rid && p1->pos < p2->pos) return true;
+             return false;
+         });
+}
 
-// Read all the records in the range, and return as a vector of BCF records.
-// This is not a scalable function, because the return vector could be very
-// large. For debugging/testing use only.
-//
-// Return 1 upon success, 0 for failure.
 static int compare_query(GLnexus::BCFKeyValueData &data, GLnexus::MetadataCache &cache,
                           const std::string& sampleset, const GLnexus::range& rng) {
     int maxNumElemInQuery = 1000000;
-    cout << "compared range=" << rng.str() << " ";
+    cout << "compared range=" << rng.str() << " " << endl;
 
     GLnexus::Status s;
     vector<shared_ptr<bcf1_t>> all_records_base, all_records_soph;
@@ -627,8 +632,8 @@ static int compare_query(GLnexus::BCFKeyValueData &data, GLnexus::MetadataCache 
     // simple iterator
     assert(data.sampleset_range_base(cache, sampleset, rng,
                                      samples, datasets, iterators).ok());
-    cout << "num iterators=" << iterators.size() << endl;
 
+    cout << "--- regular iterator (" << iterators.size() << ")" << endl;
     for (int i=0; i < iterators.size(); i++) {
         read_entire_iter(iterators[i].get(), all_records_base);
 
@@ -644,20 +649,22 @@ static int compare_query(GLnexus::BCFKeyValueData &data, GLnexus::MetadataCache 
     assert(data.sampleset_range(cache, sampleset, rng,
                                  samples, datasets, iterators).ok());
 
+    cout << "--- sophisticated iterator (" << iterators.size() << ")" << endl;
     for (int i=0; i < iterators.size(); i++) {
         read_entire_iter(iterators[i].get(), all_records_soph);
     }
 
-    // compare all the elements between the two results
-    int len = all_records_soph.size();
-
-    if (len != all_records_base.size())
+    // verify that we get the same number of results. This is not a complete
+    // test, however, to compare the records more throughly, we need to sort them in
+    // memory, and that could be expensive with these large data sets.
+    int nElem = all_records_soph.size();
+    if (nElem != all_records_base.size())
         return 0;
-    for (int i=0; i < len; i++) {
-        if (bcf_shallow_compare(all_records_base[i].get(), all_records_soph[i].get()) != 1)
-            return 0;
-    }
-    cout << " num_elem=" << len << endl;
+//    for (int i=0; i < nElem; i++) {
+//        if (bcf_shallow_compare(all_records_base[i].get(), all_records_soph[i].get()) != 1)
+//            return 0;
+//    }
+    cout << " num_elem=" << nElem << endl;
     return 1;
 }
 
@@ -703,17 +710,12 @@ int main_iter_compare(int argc, char *argv[]) {
     string sampleset;
     H("open database R/W", GLnexus::RocksKeyValue::Open(dbpath, db));
     H("open database", GLnexus::BCFKeyValueData::Open(db.get(), data));
-    H("all_samples_sampleset", data->all_samples_sampleset(sampleset));
-    data.reset();
-    db.reset();
-    console->info() << "created sample set " << sampleset;
 
-
-    // open the database
-    H("open database", GLnexus::RocksKeyValue::Open(dbpath, db, GLnexus::RocksKeyValue::OpenMode::READ_ONLY));
-    H("open database", GLnexus::BCFKeyValueData::Open(db.get(), data));
     unique_ptr<GLnexus::MetadataCache> metadata;
     H("instantiate metadata cache", GLnexus::MetadataCache::Start(*data, metadata));
+
+    H("all_samples_sampleset", data->all_samples_sampleset(sampleset));
+    console->info() << "created sample set " << sampleset;
 
     // resolve the user-supplied contig name to rid
     const auto& contigs = metadata->contigs();
@@ -722,16 +724,16 @@ int main_iter_compare(int argc, char *argv[]) {
     shared_ptr<const set<string>> samples, datasets;
     H("sampleset_datasets", metadata->sampleset_datasets(sampleset, samples, datasets));
 
-    int nChroms = contigs.size();
+    int nChroms = /*contigs.size()*/ 20;
     int nIter = 50;
     for (int i = 0; i < nIter; i++) {
-        //int rid = genRandInt(nChroms);
-        int rid = 17;
+        int rid = genRandInt(nChroms);
+        //int rid = 17;
         size_t lenChrom = contigs[rid].second;
-
-        int beg = genRandInt(lenChrom/3);
-        int len = genRandInt(lenChrom - beg);
-        GLnexus::range rng(rid, beg, beg + len);
+        //int beg = genRandInt(lenChrom/3);
+        //int len = genRandInt(lenChrom - beg);
+        //GLnexus::range rng(rid, beg, beg + len);
+        GLnexus::range rng(rid, 0, lenChrom);
         if (compare_query(*data, *metadata, sampleset, rng) != 1)
             return 1; // ERROR
     }

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -571,6 +571,176 @@ int main_genotype(int argc, char *argv[]) {
     return 0;
 }
 
+// generate a random number in the range [0 .. n-1]
+static int genRandInt(int n){
+    static bool firstTime = true;
+
+    // initialization
+    if (firstTime) {
+        firstTime = false;
+        srand (time(NULL));
+    }
+
+    int i = rand() % n;
+    return i;
+}
+
+// A quick comparision of BCF records
+//
+// Return 1 upon success, 0 for failure.
+static int bcf_shallow_compare(bcf1_t *x, bcf1_t *y) {
+    if (x->rid != y->rid) return 0;
+    if (x->pos != y->pos) return 0;
+    if (x->rlen != y->rlen) return 0;
+    return 1;
+}
+
+// read an entire iterator and add the bcf1 records to [records]
+static void read_entire_iter(GLnexus::RangeBCFIterator *iter, vector<shared_ptr<bcf1_t>> records) {
+    GLnexus::Status s;
+
+    string dataset;
+    shared_ptr<const bcf_hdr_t> hdr;
+    do {
+        vector<shared_ptr<bcf1_t>> v;
+        s = iter->next(dataset, hdr, v);
+        records.insert(records.begin(), v.begin(), v.end());
+    } while (s.ok());
+}
+
+
+// Read all the records in the range, and return as a vector of BCF records.
+// This is not a scalable function, because the return vector could be very
+// large. For debugging/testing use only.
+//
+// Return 1 upon success, 0 for failure.
+static int compare_query(GLnexus::BCFKeyValueData &data, GLnexus::MetadataCache &cache,
+                          const std::string& sampleset, const GLnexus::range& rng) {
+    int maxNumElemInQuery = 1000000;
+    cout << "compared range=" << rng.str() << " ";
+
+    GLnexus::Status s;
+    vector<shared_ptr<bcf1_t>> all_records_base, all_records_soph;
+    vector<unique_ptr<GLnexus::RangeBCFIterator>> iterators;
+    shared_ptr<const set<string>> samples, datasets;
+
+    // simple iterator
+    assert(data.sampleset_range_base(cache, sampleset, rng,
+                                     samples, datasets, iterators).ok());
+    cout << "num iterators=" << iterators.size() << endl;
+
+    for (int i=0; i < iterators.size(); i++) {
+        read_entire_iter(iterators[i].get(), all_records_base);
+
+        int numElem = all_records_base.size();
+        if (numElem > maxNumElemInQuery) {
+            cout << " too many elements (" << numElem << "), stopping" << endl;
+            return 1;
+        }
+    }
+
+    // sophisticated iterator
+    iterators.clear();
+    assert(data.sampleset_range(cache, sampleset, rng,
+                                 samples, datasets, iterators).ok());
+
+    for (int i=0; i < iterators.size(); i++) {
+        read_entire_iter(iterators[i].get(), all_records_soph);
+    }
+
+    // compare all the elements between the two results
+    int len = all_records_soph.size();
+
+    if (len != all_records_base.size())
+        return 0;
+    for (int i=0; i < len; i++) {
+        if (bcf_shallow_compare(all_records_base[i].get(), all_records_soph[i].get()) != 1)
+            return 0;
+    }
+    cout << " num_elem=" << len << endl;
+    return 1;
+}
+
+int main_iter_compare(int argc, char *argv[]) {
+    if (argc == 2) {
+        help_init(argv[0]);
+        return 1;
+    }
+
+    static struct option long_options[] = {
+        {"help", no_argument, 0, 'h'},
+        {0, 0, 0, 0}
+    };
+
+    int c;
+    optind = 2; // force optind past command positional argument
+    while (-1 != (c = getopt_long(argc, argv, "h",
+                                  long_options, nullptr))) {
+        switch (c) {
+            case 'h':
+            case '?':
+                help_init(argv[0]);
+                exit(1);
+                break;
+
+            default:
+                abort ();
+        }
+    }
+
+//    if (optind != argc-2) {
+//        help_init(argv[0]);
+//        return 1;
+//    }
+    string dbpath(argv[optind]);
+
+    // open the database in read-write mode, create an all-samples sample set,
+    // and close it. This is not elegant. It'd be better for the bulk load
+    // process to create the sample set when it finishes. Need some way to
+    // recover the name of the most recently created all-samples sample set.
+    unique_ptr<GLnexus::KeyValue::DB> db;
+    unique_ptr<GLnexus::BCFKeyValueData> data;
+    string sampleset;
+    H("open database R/W", GLnexus::RocksKeyValue::Open(dbpath, db));
+    H("open database", GLnexus::BCFKeyValueData::Open(db.get(), data));
+    H("all_samples_sampleset", data->all_samples_sampleset(sampleset));
+    data.reset();
+    db.reset();
+    console->info() << "created sample set " << sampleset;
+
+
+    // open the database
+    H("open database", GLnexus::RocksKeyValue::Open(dbpath, db, GLnexus::RocksKeyValue::OpenMode::READ_ONLY));
+    H("open database", GLnexus::BCFKeyValueData::Open(db.get(), data));
+    unique_ptr<GLnexus::MetadataCache> metadata;
+    H("instantiate metadata cache", GLnexus::MetadataCache::Start(*data, metadata));
+
+    // resolve the user-supplied contig name to rid
+    const auto& contigs = metadata->contigs();
+
+    // get samples and datasets
+    shared_ptr<const set<string>> samples, datasets;
+    H("sampleset_datasets", metadata->sampleset_datasets(sampleset, samples, datasets));
+
+    int nChroms = contigs.size();
+    int nIter = 50;
+    for (int i = 0; i < nIter; i++) {
+        //int rid = genRandInt(nChroms);
+        int rid = 17;
+        size_t lenChrom = contigs[rid].second;
+
+        int beg = genRandInt(lenChrom/3);
+        int len = genRandInt(lenChrom - beg);
+        GLnexus::range rng(rid, beg, beg + len);
+        if (compare_query(*data, *metadata, sampleset, rng) != 1)
+            return 1; // ERROR
+    }
+
+    cout << "Passed " << nIter << " iterator comparison tests" << endl;
+    return 0; // GOOD STATUS
+}
+
+
 void help(const char* prog) {
     cerr << "usage: " << prog << " <command> [options]" << endl
              << endl
@@ -578,6 +748,7 @@ void help(const char* prog) {
              << "  init     initialize new database" << endl
              << "  load     load a gVCF file into an existing database" << endl
              << "  genotype genotype samples in the database" << endl
+             << "  iter_compare compare the two BCF iterator impelementations" << endl
              << endl;
 }
 
@@ -600,6 +771,8 @@ int main(int argc, char *argv[]) {
         return main_dump(argc, argv);
     } else if (command == "genotype") {
         return main_genotype(argc, argv);
+    } else if (command == "iter_compare") {
+        return main_iter_compare(argc, argv);
     } else {
         cerr << "unknown command " << command << endl;
         help(argv[0]);

--- a/include/BCFSerialize.h
+++ b/include/BCFSerialize.h
@@ -22,6 +22,10 @@ void bcf_raw_write_to_mem(bcf1_t *v, int reclen, char *addr);
 //  Read a BCF record from memory, return the length of the packed record in RAM.
 int bcf_raw_read_from_mem(const char *addr, bcf1_t *v);
 
+// Return 1 if the records are the same, 0 otherwise.
+// This compares most, but not all, fields.
+int bcf_shallow_compare(const bcf1_t *x, const bcf1_t *y);
+
 class BCFWriter {
  private:
     static int STACK_ALLOC_LIMIT;

--- a/include/compare_iter.h
+++ b/include/compare_iter.h
@@ -1,0 +1,22 @@
+#ifndef GLNEXUS_COMPARE_QUERY_H
+#define GLNEXUS_COMPARE_QUERY_H
+
+#include "BCFKeyValueData.h"
+
+// utilities for comparing two BCF iterators
+
+// generate a random number in the range [0 .. n-1]
+int genRandNumber(int n);
+
+// Generate a number that is one of [0, 1/n, 2/n, 3/n, ... (n-1)/n]
+double genRandDouble(int n);
+
+// Compares the two query iterators, and returns:
+//  1: success
+//  0: failure, the iterators returned different results
+// -1: abort, used too much memory
+int compare_query(GLnexus::BCFKeyValueData &data, GLnexus::MetadataCache &cache,
+                   const std::string& sampleset, const GLnexus::range& rng);
+
+
+#endif

--- a/src/BCFSerialize.cc
+++ b/src/BCFSerialize.cc
@@ -106,6 +106,25 @@ int bcf_raw_read_from_mem(const char *addr, bcf1_t *v) {
     return loc;
 }
 
+// Return 1 if the records are the same, 0 otherwise.
+// This compares most, but not all, fields.
+int bcf_shallow_compare(const bcf1_t *x, const bcf1_t *y) {
+    if (x->rid != y->rid) return 0;
+    if (x->pos != y->pos) return 0;
+    if (x->rlen != y->rlen) return 0;
+
+    // I think nan != nan, so we are skipping this comparison
+    //if (x->qual != y->qual) return 0;
+
+    if (x->n_info != y->n_info) return 0;
+    if (x->n_allele != y->n_allele) return 0;
+    if (x->n_sample != y->n_sample) return 0;
+    if (x->shared.l != y->shared.l) return 0;
+    if (x->indiv.l != y->indiv.l) return 0;
+
+    return 1;
+}
+
 int BCFWriter::STACK_ALLOC_LIMIT = 32 * 1024;
 
 BCFWriter::BCFWriter() {}

--- a/src/data.cc
+++ b/src/data.cc
@@ -174,6 +174,14 @@ public:
     }
 };
 
+/* A naive implementation that splits the range into fixed sized
+ * sub-ranges. Inside a sub-range, it iterates over the datasets, and
+ * reads their records with point lookups.
+ *
+ * This is an inefficient DB access pattern, because it ignores the fact
+ * that the data is ordered lexicographically by bucket, and then dataset. In other words,
+ * data for one bucket for all datasets lies adjacently on disk.
+ */
 Status BCFData::sampleset_range(const MetadataCache& metadata, const string& sampleset,
                                 const range& pos,
                                 shared_ptr<const set<string>>& samples,

--- a/test/BCFKeyValueData.cc
+++ b/test/BCFKeyValueData.cc
@@ -1,30 +1,11 @@
 #include <iostream>
 #include <map>
 #include "BCFKeyValueData.h"
+#include "BCFSerialize.h"
+#include "compare_iter.h"
 #include "catch.hpp"
 using namespace std;
 using namespace GLnexus;
-
-#define PSEUDO_RAND_SEED (1103)
-
-// generate a random number in the range [0 .. n-1]
-static int genRandNumber(int n){
-    static bool firstTime = true;
-
-    // initialization
-    if (firstTime) {
-        firstTime = false;
-        srand(PSEUDO_RAND_SEED);
-    }
-
-    int i = rand() % n;
-    return i;
-}
-
-static double genRandDouble(int n) {
-    return double(genRandNumber(n)) / double(n);
-}
-
 
 // Trivial in-memory KeyValue implementation used in unit tests.
 namespace KeyValueMem {
@@ -871,114 +852,6 @@ TEST_CASE("BCFKeyValueData::sampleset_range") {
     // TODO: need a test with only a subset of the samples
 }
 
-static void print_bcf_record(bcf1_t *x) {
-    cout << "rid=" << x->rid << endl;
-    cout << "pos=" << x->pos << endl;
-    cout << "rlen=" << x->rlen << endl;
-    cout << "qual=" << x->qual << endl;
-    cout << "n_info=" << x->n_info << endl;
-    cout << "n_allele=" << x->n_allele << endl;
-    cout << "n_sample=" << x->n_sample << endl;
-    cout << "shared.l=" << x->shared.l << endl;
-    cout << "indiv.l=" << x->indiv.l << endl;
-//    cout << std::string(x->indiv.s) << endl;
-}
-
-// return 1 if the records are the same, 0 otherwise
-static int bcf_shallow_compare(const bcf1_t *x, const bcf1_t *y) {
-    if (x->rid != y->rid) return 0;
-    if (x->pos != y->pos) return 0;
-    if (x->rlen != y->rlen) return 0;
-
-    // I think nan != nan, so we are skipping this comparison
-    //if (x->qual != y->qual) return 0;
-
-    if (x->n_info != y->n_info) return 0;
-    if (x->n_allele != y->n_allele) return 0;
-    if (x->n_sample != y->n_sample) return 0;
-    if (x->shared.l != y->shared.l) return 0;
-    if (x->indiv.l != y->indiv.l) return 0;
-
-    return 1;
-}
-
-using IterResults = map<string, shared_ptr<vector<shared_ptr<bcf1_t>>>>;
-
-static void read_entire_iter(RangeBCFIterator *iter, shared_ptr<IterResults> results) {
-    Status s;
-
-    string dataset;
-    shared_ptr<const bcf_hdr_t> hdr;
-    do {
-        vector<shared_ptr<bcf1_t>> v;
-        v.clear();
-        s = iter->next(dataset, hdr, v);
-        for (auto rec : v) {
-            if (results->find(dataset) == results->end()) {
-                auto w = make_shared<vector<shared_ptr<bcf1_t>>>();
-                (*results)[dataset] = w;
-            }
-            results->at(dataset)->push_back(rec);
-        }
-    } while (s.ok());
-}
-
-static void compare_results(shared_ptr<IterResults> resultsBase,
-                            shared_ptr<IterResults> resultsSoph) {
-    for(IterResults::iterator iter = resultsBase->begin();
-        iter != resultsBase->end();
-        ++iter) {
-        string dataset = iter->first;
-        shared_ptr<vector<shared_ptr<bcf1_t>>> v = iter->second;
-        shared_ptr<vector<shared_ptr<bcf1_t>>> w = resultsSoph->at(dataset);
-
-        REQUIRE(v->size() == w->size());
-        int len = v->size();
-        //cout << dataset << " len=" << len << endl;
-        for (int i=0; i < len; i++) {
-            if (bcf_shallow_compare((*v)[i].get(), (*w)[i].get()) == 0) {
-                cout << "Error comparing two records"  << endl;
-                print_bcf_record((*v)[i].get());
-                print_bcf_record((*w)[i].get());
-                REQUIRE(false);
-            }
-        }
-    }
-}
-
-// Read all the records in the range, and return as a vector of BCF records.
-// This is not a scalable function, because the return vector could be very
-// large. For debugging/testing use only.
-static void compare_query(T &data, MetadataCache &cache,
-                          const std::string& sampleset, const range& rng) {
-    //cout << "compare_query " << rng.str() << endl;
-
-    Status s;
-    vector<unique_ptr<RangeBCFIterator>> iterators;
-    shared_ptr<const set<string>> samples, datasets;
-
-    // simple iterator
-    REQUIRE(data.sampleset_range_base(cache, sampleset, rng,
-                                      samples, datasets, iterators).ok());
-
-    auto resultsBase = make_shared<IterResults>();
-    for (int i=0; i < iterators.size(); i++) {
-        read_entire_iter(iterators[i].get(), resultsBase);
-    }
-    iterators.clear();
-
-    // sophisticated iterator
-    auto resultsSoph = make_shared<IterResults>();
-    REQUIRE(data.sampleset_range(cache, sampleset, rng,
-                                 samples, datasets, iterators).ok());
-    for (int i=0; i < iterators.size(); i++) {
-        read_entire_iter(iterators[i].get(), resultsSoph);
-    }
-
-    // compare all the elements between the two results
-    compare_results(resultsBase, resultsSoph);
-}
-
 TEST_CASE("BCFKeyValueData compare iterator implementations") {
     // This tests the optimized bucket-based range slicing in BCFKeyValueData
     int nRegions = 13;
@@ -1015,7 +888,12 @@ TEST_CASE("BCFKeyValueData compare iterator implementations") {
         if (end < beg)
             std::swap(beg, end);
         range rng(0, beg, end);
-        compare_query(*data, *cache, sampleset, rng);
+        int rc = compare_query(*data, *cache, sampleset, rng);
+        switch (rc) {
+        case 1: break; // comparison succeeded
+        case 0: REQUIRE(false); // ERROR
+        case -1: break;  // Query used too much memory, continue
+        }
     }
 
     cout << "Compared " << nIter << " range queries between the two iterators" << endl;

--- a/test/compare_iter.cc
+++ b/test/compare_iter.cc
@@ -1,0 +1,152 @@
+#include <iostream>
+#include <fstream>
+#include <map>
+#include "BCFKeyValueData.h"
+#include "BCFSerialize.h"
+using namespace std;
+using namespace GLnexus;
+
+using IterResults = map<string, shared_ptr<vector<shared_ptr<bcf1_t>>>>;
+using T = BCFKeyValueData;
+
+// This module provides utility functions for comparing BCF iterators
+
+// Seed for pseudo random number generator
+#define PSEUDO_RAND_SEED (1103)
+
+// maximal number of entries that we keep in memory
+#define MAX_NUM_ENTRIES  (2000000)
+
+// generate a random number in the range [0 .. n-1]
+int genRandNumber(int n){
+    static bool firstTime = true;
+
+    // initialization
+    if (firstTime) {
+        firstTime = false;
+        srand(PSEUDO_RAND_SEED);
+    }
+
+    int i = rand() % n;
+    return i;
+}
+
+double genRandDouble(int n) {
+    return double(genRandNumber(n)) / double(n);
+}
+
+static void print_bcf_record(bcf1_t *x) {
+    cout << "rid=" << x->rid << endl;
+    cout << "pos=" << x->pos << endl;
+    cout << "rlen=" << x->rlen << endl;
+    cout << "qual=" << x->qual << endl;
+    cout << "n_info=" << x->n_info << endl;
+    cout << "n_allele=" << x->n_allele << endl;
+    cout << "n_sample=" << x->n_sample << endl;
+    cout << "shared.l=" << x->shared.l << endl;
+    cout << "indiv.l=" << x->indiv.l << endl;
+}
+
+static int calcTotNumEntries(shared_ptr<IterResults> results) {
+    int nEntries = 0;
+    for(IterResults::iterator iter = results->begin();
+        iter != results->end(); ++iter) {
+        shared_ptr<vector<shared_ptr<bcf1_t>>> v = iter->second;
+        nEntries += v->size();
+    }
+    return nEntries;
+}
+
+// Read an entire iterator, and put into memory.
+static void read_entire_iter(RangeBCFIterator *iter, shared_ptr<IterResults> results) {
+    Status s;
+
+    string dataset;
+    shared_ptr<const bcf_hdr_t> hdr;
+    do {
+        vector<shared_ptr<bcf1_t>> v;
+        v.clear();
+        s = iter->next(dataset, hdr, v);
+        for (auto rec : v) {
+            if (results->find(dataset) == results->end()) {
+                auto w = make_shared<vector<shared_ptr<bcf1_t>>>();
+                (*results)[dataset] = w;
+            }
+            results->at(dataset)->push_back(rec);
+        }
+    } while (s.ok());
+}
+
+// Return true if the results are equivalent, false otherwise
+static int compare_results(shared_ptr<IterResults> resultsBase,
+                            shared_ptr<IterResults> resultsSoph) {
+    for(IterResults::iterator iter = resultsBase->begin();
+        iter != resultsBase->end();
+        ++iter) {
+        string dataset = iter->first;
+        shared_ptr<vector<shared_ptr<bcf1_t>>> v = iter->second;
+        shared_ptr<vector<shared_ptr<bcf1_t>>> w = resultsSoph->at(dataset);
+
+        assert(v->size() == w->size());
+        int len = v->size();
+        //cout << dataset << " len=" << len << endl;
+        for (int i=0; i < len; i++) {
+            if (bcf_shallow_compare((*v)[i].get(), (*w)[i].get()) == 0) {
+                cout << "Error comparing two records"  << endl;
+                print_bcf_record((*v)[i].get());
+                print_bcf_record((*w)[i].get());
+                return 0;
+            }
+        }
+    }
+
+    return 1;
+}
+
+// Read all the records in the range, and return as a vector of BCF records.
+// This is not a scalable function, because the return vector could be very
+// large. For debugging/testing use only.
+int compare_query(T &data, MetadataCache &cache,
+                   const std::string& sampleset, const range& rng) {
+    Status s;
+    vector<unique_ptr<RangeBCFIterator>> iterators;
+    shared_ptr<const set<string>> samples, datasets;
+
+    // simple iterator
+    s = data.sampleset_range_base(cache, sampleset, rng,
+                                  samples, datasets, iterators);
+    assert(s.ok());
+
+    auto resultsBase = make_shared<IterResults>();
+    for (int i=0; i < iterators.size(); i++) {
+        read_entire_iter(iterators[i].get(), resultsBase);
+
+        if (calcTotNumEntries(resultsBase) > MAX_NUM_ENTRIES) {
+            // We are overrunning the memory limits, abort
+            cout << "compare_query " << rng.str() << " ran over memory limit, aborting" << endl;
+            return -1;
+        }
+    }
+    iterators.clear();
+
+    // sophisticated iterator
+    auto resultsSoph = make_shared<IterResults>();
+    s = data.sampleset_range(cache, sampleset, rng,
+                             samples, datasets, iterators);
+    assert(s.ok());
+    for (int i=0; i < iterators.size(); i++) {
+        read_entire_iter(iterators[i].get(), resultsSoph);
+
+        if (calcTotNumEntries(resultsBase) > MAX_NUM_ENTRIES) {
+            // We are overrunning the memory limits, abort
+            cout << "compare_query " << rng.str() << " ran over memory limit, aborting" << endl;
+            return -1;
+        }
+    }
+
+    cout << "compare_query " << rng.str()
+         << " num_entries=" << calcTotNumEntries(resultsSoph) << endl;
+
+    // compare all the elements between the two results
+    return compare_results(resultsBase, resultsSoph);
+}


### PR DESCRIPTION
@mlin, please take a look.

This code branch adds  random comparison functionality into the cli. In the applet, it is disabled by default. The user needs to specify a special flag to enable it. The common code for the CLI and test has been factored out into compare_iter.{cc,h}. 

    Ohad. 