### PR TITLE
RocksKeyValue: use prefix extractor with BCFKeyValueData to speed up lookups

### DIFF
--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -26,6 +26,14 @@ GLnexus::Status s;
         return 1; \
     }
 
+static GLnexus::RocksKeyValue::prefix_spec* GLnexus_prefix_spec() {
+    static unique_ptr<GLnexus::RocksKeyValue::prefix_spec> p;
+    if (!p) {
+        p = make_unique<GLnexus::RocksKeyValue::prefix_spec>("bcf", GLnexus::BCFKeyValueDataPrefixLength());
+    }
+    return p.get();
+}
+
 void help_init(const char* prog) {
     cerr << "usage: " << prog << " init [options] /desired/db/path exemplar.gvcf[.gz]" << endl
          << "Initializes a new GLnexus database in the specified directory; the parent directory" << endl
@@ -94,7 +102,7 @@ int main_init(int argc, char *argv[]) {
 
     // create and initialize the database
     unique_ptr<GLnexus::KeyValue::DB> db;
-    H("create database", GLnexus::RocksKeyValue::Initialize(dbpath, db));
+    H("create database", GLnexus::RocksKeyValue::Initialize(dbpath, db, GLnexus_prefix_spec()));
     H("initialize database", GLnexus::BCFKeyValueData::InitializeDB(db.get(), contigs));
 
     // report success
@@ -188,7 +196,8 @@ int main_load(int argc, char *argv[]) {
 
     // open the database
     unique_ptr<GLnexus::KeyValue::DB> db;
-    H("open database", GLnexus::RocksKeyValue::Open(dbpath, db, GLnexus::RocksKeyValue::OpenMode::BULK_LOAD));
+    H("open database", GLnexus::RocksKeyValue::Open(dbpath, db, GLnexus_prefix_spec(),
+                                                    GLnexus::RocksKeyValue::OpenMode::BULK_LOAD));
 
     {
         unique_ptr<GLnexus::BCFKeyValueData> data;
@@ -323,7 +332,8 @@ int main_dump(int argc, char *argv[]) {
 
     // open the database
     unique_ptr<GLnexus::KeyValue::DB> db;
-    H("open database", GLnexus::RocksKeyValue::Open(dbpath, db, GLnexus::RocksKeyValue::OpenMode::READ_ONLY));
+    H("open database", GLnexus::RocksKeyValue::Open(dbpath, db, GLnexus_prefix_spec(),
+                                                    GLnexus::RocksKeyValue::OpenMode::READ_ONLY));
 
     {
         unique_ptr<GLnexus::BCFKeyValueData> data;
@@ -463,7 +473,8 @@ int main_genotype(int argc, char *argv[]) {
     unique_ptr<GLnexus::BCFKeyValueData> data;
 
     // open the database in read-only mode
-    H("open database", GLnexus::RocksKeyValue::Open(dbpath, db, GLnexus::RocksKeyValue::OpenMode::READ_ONLY));
+    H("open database", GLnexus::RocksKeyValue::Open(dbpath, db, GLnexus_prefix_spec(),
+                                                    GLnexus::RocksKeyValue::OpenMode::READ_ONLY));
     {
         unique_ptr<GLnexus::BCFKeyValueData> data;
         H("open database", GLnexus::BCFKeyValueData::Open(db.get(), data));
@@ -581,7 +592,8 @@ int main_iter_compare(int argc, char *argv[]) {
     unique_ptr<GLnexus::KeyValue::DB> db;
     unique_ptr<GLnexus::BCFKeyValueData> data;
     string sampleset;
-    H("open database", GLnexus::RocksKeyValue::Open(dbpath, db, GLnexus::RocksKeyValue::OpenMode::READ_ONLY));
+    H("open database", GLnexus::RocksKeyValue::Open(dbpath, db, GLnexus_prefix_spec(),
+                                                    GLnexus::RocksKeyValue::OpenMode::READ_ONLY));
     H("open database", GLnexus::BCFKeyValueData::Open(db.get(), data));
 
     unique_ptr<GLnexus::MetadataCache> metadata;

--- a/include/BCFKeyValueData.h
+++ b/include/BCFKeyValueData.h
@@ -69,6 +69,10 @@ public:
                        std::set<std::string>& samples);
 };
 
+/// Get the bucket key prefix length for the bcf collection. This is used with
+/// e.g. the RocksDB prefix mode, or DynamoDB hash-range key.
+size_t BCFKeyValueDataPrefixLength();
+
 }
 
 #endif

--- a/include/RocksKeyValue.h
+++ b/include/RocksKeyValue.h
@@ -4,13 +4,23 @@
 // Implement a KeyValue interface to a RocksDB on-disk database.
 //
 #include "KeyValue.h"
-
 namespace GLnexus {
 namespace RocksKeyValue {
 
+/// Specification for collection key prefix. RocksDB can maintain a special
+/// hash index to speed up lookups in collections in which the key space can
+/// be partitioned into a number of buckets according to a key prefix of fixed
+/// size, with the tradeoff that in-order iterators are restricted to one key
+/// prefix. Activate this mode by providing a [prefix_spec] containing the
+/// collection (only one is supported right now) and prefix size. Importantly,
+/// the database must be initialized and always used with the same
+/// [prefix_spec].
+using prefix_spec = std::pair<std::string, size_t>;
+
 /// Initialize a new database. The parent directory must exist. Fails if the
 /// path already exists.
-Status Initialize(const std::string& dbpath, std::unique_ptr<KeyValue::DB>& db);
+Status Initialize(const std::string& dbpath, std::unique_ptr<KeyValue::DB>& db,
+                  prefix_spec* pfx = nullptr);
 
 /// Database open mode
 enum class OpenMode {
@@ -29,7 +39,8 @@ enum class OpenMode {
 };
 
 /// Open an existing database.
-Status Open(const std::string& dbPath, std::unique_ptr<KeyValue::DB>& db, OpenMode mode=OpenMode::NORMAL);
+Status Open(const std::string& dbPath, std::unique_ptr<KeyValue::DB>& db,
+            prefix_spec* pfx = nullptr, OpenMode mode=OpenMode::NORMAL);
 
 // Delete an existing database.
 Status destroy(const std::string dbPath);

--- a/src/BCFKeyValueData.cc
+++ b/src/BCFKeyValueData.cc
@@ -76,6 +76,7 @@ private:
     BCFBucketRange& operator=(const BCFBucketRange&);
 
 public:
+    static const size_t PREFIX_LENGTH = 23;
     int interval_len;
 
     // constructor
@@ -92,7 +93,9 @@ public:
         ss << setw(3) << setfill('0') << rng.rid
            << setw(10) << setfill('0') << rng.beg
            << setw(10) << setfill('0') << rng.end;
-        return ss.str();
+        std::string ans = ss.str();
+        assert(ans.size() == PREFIX_LENGTH);
+        return ans;
     }
 
     // Produce the complete key for a bucket (given the prefix) in a dataset
@@ -111,11 +114,11 @@ public:
 
     // Decompose the key into bucket prefix and dataset
     Status parse_key(const string& key, string& bucket, string& dataset) {
-        if (key.size() < 23) {
+        if (key.size() < PREFIX_LENGTH) {
             return Status::Invalid("BCFBucketRange::parse_key: key too small", key);
         }
-        bucket = key.substr(0, 23);
-        dataset = key.substr(23);
+        bucket = key.substr(0, PREFIX_LENGTH);
+        dataset = key.substr(PREFIX_LENGTH);
         return Status::OK();
     }
 
@@ -133,6 +136,8 @@ public:
         return range(rec->rid, bgn, bgn + interval_len);
     }
 };
+
+size_t BCFKeyValueDataPrefixLength() { return BCFBucketRange::PREFIX_LENGTH; }
 
 
 // Metadata that is being added to the DB


### PR DESCRIPTION
@orodeh this enables the prefix hash index for BCF buckets