### PR TITLE
Zero copy bucket scan

### DIFF
--- a/include/BCFSerialize.h
+++ b/include/BCFSerialize.h
@@ -14,7 +14,7 @@ Status range_check(int x, size_t y);
 // and modified from the htslib sources. They are used to read/write
 // uncompressed BCF records from/to memory. They are declared for
 // testing purposes, they are not to be used without the proper wrappers
-// provided by the BCFWriter and BCFReader classes.
+// provided by the BCFWriter and BCFScanner classes.
 
 // Ccalculate the amount of bytes it would take to pack this bcf1 record.
 int bcf_raw_calc_packed_len(bcf1_t *v);
@@ -62,24 +62,6 @@ class BCFWriter {
     Status write(bcf1_t* x);
     Status contents(std::string& ans);
     int get_num_entries() const;
-};
-
-class BCFReader {
- private:
-    const char* buf_ = nullptr;
-    size_t bufsz_;
-    int current_ = 0;
-
-    BCFReader(const char* buf, size_t bufsz);
- public:
-    /// Reads BCF records from a memory buffer (without the header)
-    static Status Open(const char* buf, size_t bufsz, std::unique_ptr<BCFReader>& ans);
-
-    ~BCFReader();
-    Status read(std::shared_ptr<bcf1_t>& ans);
-
-    /// Reads a BCF header from a memory buffer
-    static Status read_header(const char* buf, int len, int& consumed, std::shared_ptr<bcf_hdr_t>& ans);
 };
 
 class BCFScanner {

--- a/src/BCFKeyValueData.cc
+++ b/src/BCFKeyValueData.cc
@@ -458,7 +458,7 @@ Status BCFKeyValueData::dataset_header(const string& dataset,
     // Parse the header
     shared_ptr<bcf_hdr_t> ans;
     int consumed;
-    S(BCFReader::read_header(data.c_str(), data.size(), consumed, ans));
+    S(BCFScanner::read_header(data.c_str(), data.size(), consumed, ans));
     hdr = ans;
 
     // Memoize it

--- a/src/BCFSerialize.cc
+++ b/src/BCFSerialize.cc
@@ -287,43 +287,6 @@ std::string BCFWriter::write_header(const bcf_hdr_t *hdr) {
 
 
 
-// constructor
-BCFReader::BCFReader(const char* buf, size_t bufsz) :
-    buf_(buf), bufsz_(bufsz)
-{}
-
-Status BCFReader::Open(const char* buf,
-                       size_t bufsz,
-                       unique_ptr<BCFReader>& ans) {
-    ans.reset(new BCFReader(buf, bufsz));
-    return Status::OK();
-}
-
-BCFReader::~BCFReader() {
-    buf_ = nullptr;
-    bufsz_ = 0;
-    current_ = 0;
-}
-
-Status BCFReader::read(shared_ptr<bcf1_t>& ans) {
-    if (!ans) {
-        ans = shared_ptr<bcf1_t>(bcf_init(), &bcf_destroy);
-    }
-    if ((size_t)current_ >= bufsz_)
-        return Status::NotFound();
-    int reclen = 0;
-    Status s = bcf_raw_read_from_mem(buf_, current_, bufsz_, ans.get(), reclen);
-    if (!s.ok())
-        return s;
-    current_ += reclen;
-    return Status::OK();
-}
-
-Status BCFReader::read_header(const char* buf, int hdrlen, int& consumed,
-                              shared_ptr<bcf_hdr_t>& ans) {
-    return bcf_raw_read_header(buf, hdrlen, consumed, ans);
-}
-
 // BCFScanner
 // constructor
 BCFScanner::BCFScanner(const char* buf, size_t bufsz) :

--- a/src/BCFSerialize.cc
+++ b/src/BCFSerialize.cc
@@ -310,10 +310,9 @@ BCFScanner::~BCFScanner() {
 Status BCFScanner::next() {
     if ((size_t)current_ >= bufsz_)
         return Status::NotFound();
+    Status s;
     uint32_t reclen = 0;
-    Status s = bcf_raw_calc_rec_len(buf_, current_, bufsz_, reclen);
-    if (!s.ok())
-        return s;
+    S(bcf_raw_calc_rec_len(buf_, current_, bufsz_, reclen));
     current_ += reclen;
     if ((size_t)current_ >= bufsz_)
         return Status::NotFound();

--- a/src/BCFSerialize.cc
+++ b/src/BCFSerialize.cc
@@ -41,7 +41,7 @@ namespace GLnexus {
 
 Status range_check(int x, size_t y) {
     if (x <= y) return Status::OK();
-    return Status::Invalid();
+    return Status::Invalid("Memory range check failed");
 }
 
 // Ccalculate the amount of bytes it would take to pack this bcf1 record.
@@ -142,9 +142,9 @@ Status bcf_raw_overlap(const char *buf, int start, size_t len, const range &rng,
     S(range_check(start + 32, len));
 
     uint32_t *x = (uint32_t*) &buf[start];
-    int32_t rid = x[2];
-    int32_t beg = x[3];
-    int32_t rlen = x[4];
+    uint32_t rid = x[2];
+    uint32_t beg = x[3];
+    uint32_t rlen = x[4];
     ans = range(rid, beg, beg + rlen).overlaps(rng);
     return Status::OK();
 }

--- a/test/htslib_behaviors.cc
+++ b/test/htslib_behaviors.cc
@@ -1,4 +1,4 @@
-// Test certain non-obvious behaviors of htslib 
+// Test certain non-obvious behaviors of htslib
 
 #include <iostream>
 #include <fstream>
@@ -121,7 +121,7 @@ TEST_CASE("htslib VCF header chrom injection") {
 
 TEST_CASE("htslib VCF header synthesis") {
     shared_ptr<bcf_hdr_t> hdr(bcf_hdr_init("w"), &bcf_hdr_destroy);
-    
+
     REQUIRE(bcf_hdr_append(hdr.get(),"##contig=<ID=A,length=1000000>") == 0);
     REQUIRE(bcf_hdr_append(hdr.get(),"##contig=<ID=B,length=100000>") == 0);
     REQUIRE(bcf_hdr_append(hdr.get(),"##contig=<ID=C,length=10000>") == 0);
@@ -196,7 +196,7 @@ TEST_CASE("DNAnexus VCF/BCF serialization") {
     // now read the records back from memory & ensure they match the originals
     loc = 0;
     for (const auto& rec : records) {
-        loc += GLnexus::bcf_raw_read_from_mem(&buf[loc], vt.get());
+        loc += GLnexus::bcf_raw_read_from_mem(buf, loc, memlen, vt.get());
         REQUIRE(vt->rid == rec->rid);
         REQUIRE(vt->pos == rec->pos);
         REQUIRE(vt->n_sample == rec->n_sample);

--- a/test/htslib_behaviors.cc
+++ b/test/htslib_behaviors.cc
@@ -17,6 +17,16 @@ using namespace std;
 // sugar for declaring a unique_ptr with a custom deleter function
 #define UPD(T,name,ini,del) std::unique_ptr<T, void(*)(T*)> up_##name((ini), (del)); auto name = up_##name.get();
 
+TEST_CASE("Memory range checks") {
+    for (int i = 0; i < 2; i++) {
+        REQUIRE(GLnexus::range_check(i * 10, 20).ok());
+    }
+    for (int i = 2; i < 5; i++) {
+        GLnexus::Status s = GLnexus::range_check((i * 10) + 1, 20);
+        REQUIRE(s == GLnexus::StatusCode::INVALID);
+    }
+}
+
 TEST_CASE("htslib VCF missing data representation") {
     // Verify how htslib data structures represent missing data such as ./.
     // genotypes, . genotype likelihoods, etc.

--- a/test/htslib_behaviors.cc
+++ b/test/htslib_behaviors.cc
@@ -196,7 +196,9 @@ TEST_CASE("DNAnexus VCF/BCF serialization") {
     // now read the records back from memory & ensure they match the originals
     loc = 0;
     for (const auto& rec : records) {
-        loc += GLnexus::bcf_raw_read_from_mem(buf, loc, memlen, vt.get());
+        int reclen = 0;
+        REQUIRE(GLnexus::bcf_raw_read_from_mem(buf, loc, memlen, vt.get(), reclen).ok());
+        loc += reclen;
         REQUIRE(vt->rid == rec->rid);
         REQUIRE(vt->pos == rec->pos);
         REQUIRE(vt->n_sample == rec->n_sample);


### PR DESCRIPTION
This achieves two goals:
1) More efficient range scanning of BCF buckets
2) Performing range-checks to make reading from memory safe. This is important for raw BCF record reading from memory.