### PR TITLE
BCFKeyValueData metadata features: creating new sample sets, maintaining sample count

### DIFF
--- a/include/BCFKeyValueData.h
+++ b/include/BCFKeyValueData.h
@@ -39,6 +39,9 @@ public:
     Status sample_dataset(const std::string& sample, std::string& ans) const override;
     Status all_samples_sampleset(std::string& ans) override;
 
+    Status new_sampleset(MetadataCache& metadata, const std::string& sampleset,
+                         const std::set<std::string>& samples);
+
     // statistics
     std::shared_ptr<StatsRangeQuery> getRangeStats();
 

--- a/include/BCFKeyValueData.h
+++ b/include/BCFKeyValueData.h
@@ -38,6 +38,7 @@ public:
                              std::shared_ptr<const std::set<std::string> >& ans) const override;
     Status sample_dataset(const std::string& sample, std::string& ans) const override;
     Status all_samples_sampleset(std::string& ans) override;
+    Status sample_count(size_t& ans) const override;
 
     Status new_sampleset(MetadataCache& metadata, const std::string& sampleset,
                          const std::set<std::string>& samples);

--- a/include/data.h
+++ b/include/data.h
@@ -50,6 +50,9 @@ public:
     /// (but one could call all_samples_sampleset again to get a different
     /// sample set including them).
     virtual Status all_samples_sampleset(std::string& ans) = 0;
+
+    /// Return the count of all samples in the database.
+    virtual Status sample_count(size_t& ans) const = 0;
 };
 
 
@@ -71,6 +74,7 @@ public:
                              std::shared_ptr<const std::set<std::string> >& ans) const override;
     Status sample_dataset(const std::string& sample, std::string& ans) const override;
     Status all_samples_sampleset(std::string& ans) override;
+    Status sample_count(size_t& ans) const override;
 
     const std::vector<std::pair<std::string,size_t> >& contigs() const;
     Status sampleset_datasets(const std::string& sampleset,

--- a/src/BCFKeyValueData.cc
+++ b/src/BCFKeyValueData.cc
@@ -179,6 +179,10 @@ struct BCFKeyValueData_body {
     ActiveMetadata amd;
     std::mutex statsMutex;
     StatsRangeQuery statsRq; // statistics for range queries
+    atomic<size_t> sample_count; // number of samples in the database. could be
+                                 // obtained from the size of the current
+                                 // all-samples sampleset, but maintained here
+                                 // for convenience.
 };
 
 auto collections = { "config", "sampleset", "sample_dataset", "header", "bcf" };
@@ -289,6 +293,14 @@ Status BCFKeyValueData::Open(KeyValue::DB* db, unique_ptr<BCFKeyValueData>& ans)
 
     ans->body_->rangeHelper = make_unique<BCFBucketRange>(interval_len);
     ans->body_->header_cache = make_unique<BCFHeaderCache>(BCF_HEADER_CACHE_SIZE);
+
+    // initialize sample_count
+    string sampleset;
+    S(ans->all_samples_sampleset(sampleset));
+    shared_ptr<const set<string>> all_samples;
+    S(ans->sampleset_samples(sampleset, all_samples));
+    ans->body_->sample_count = all_samples->size();
+
     return Status::OK();
 }
 
@@ -477,6 +489,11 @@ Status BCFKeyValueData::new_sampleset(MetadataCache& metadata,
     return wb->commit();
 }
 
+Status BCFKeyValueData::sample_count(size_t& ans) const {
+    ans = body_->sample_count;
+    return Status::OK();
+}
+
 shared_ptr<StatsRangeQuery> BCFKeyValueData::getRangeStats() {
     // return a copy of the current statistics
     std::lock_guard<std::mutex> lock(body_->statsMutex);
@@ -621,7 +638,7 @@ Status BCFKeyValueData::dataset_range(const string& dataset,
 }
 
 // BCFKeyValueData::sampleset_range optimized implementation: if the sample
-// set covers >=25% of the samples in the database, produces RangeBCFIterators
+// set covers >=10% of the samples in the database, produces RangeBCFIterators
 // that use underlying KeyValue::Iterators instead of repeated point lookups
 // (as in the base implementation). One iterator per underlying storage bucket
 // is produced.
@@ -753,8 +770,15 @@ Status BCFKeyValueData::sampleset_range(const MetadataCache& metadata, const str
     // resolve samples and datasets
     S(metadata.sampleset_datasets(sampleset, samples, datasets));
 
-    // TODO: dispatch to sampleset_range_base if the sample set is "too
-    // small". need a way to know N of the whole database
+    // Heuristic: if the desired sample set has fewer than 10% of the samples
+    // in the database, then dispatch to the repeated-lookup strategy of
+    // sampleset_range_base. This heuristic is wrong if the desired samples
+    // are actually contiguous in the database, though.
+    size_t total_sample_count;
+    S(metadata.sample_count(total_sample_count));
+    if (samples->size() == 1 || samples->size() * 10 < total_sample_count) {
+        return sampleset_range_base(metadata, sampleset, pos, samples, datasets, iterators);
+    }
 
     // get a KeyValue::Reader so that all iterators read from the same
     // snapshot (this isn't strictly necessary since datasets are immutable,
@@ -1055,6 +1079,9 @@ static Status import_gvcf_inner(BCFKeyValueData_body *body_,
         body_->amd.erase(dataset, samples_out);
 
         retval = wb->commit();
+        if (retval.ok()) {
+            body_->sample_count++;
+        }
     }
 
     // good path

--- a/src/BCFKeyValueData.cc
+++ b/src/BCFKeyValueData.cc
@@ -431,6 +431,52 @@ Status BCFKeyValueData::all_samples_sampleset(string& ans) {
     }
 }
 
+Status BCFKeyValueData::new_sampleset(MetadataCache& metadata,
+                                      const string& sampleset,
+                                      const set<string>& samples) {
+    // TODO: validation regexp for sampleset
+    if (samples.empty()) {
+        return Status::Invalid("BCFKeyValueData::new_sampleset: no samples provided");
+    }
+
+    // Prepare a write batch for the new sample set. While doing so, verify
+    // that all the samples actually exist. We do this before we take the
+    // mutex, thus assuming that samples cannot be deleted.
+    Status s;
+    string all_samples_id;
+    S(metadata.all_samples_sampleset(all_samples_id));
+    shared_ptr<const set<string>> all_samples;
+    S(metadata.sampleset_samples(all_samples_id, all_samples));
+
+    KeyValue::CollectionHandle coll;
+    S(body_->db->collection("sampleset",coll));
+    unique_ptr<KeyValue::WriteBatch> wb;
+    S(body_->db->begin_writes(wb));
+    S(wb->put(coll, sampleset, string()));
+
+    for (const string& sample : samples) {
+        if (all_samples->find(sample) == all_samples->end()) {
+            return Status::NotFound("BCFKeyValueData::new_sampleset: sample does not exist", sample);
+        }
+        S(wb->put(coll, sampleset + string(1,'\0') + sample, string()));
+    }
+
+    // Now take the mutex
+    lock_guard<mutex> lock(body_->mutex);
+
+    // verify the sample set doesn't already exist
+    shared_ptr<const set<string>> dummy;
+    s = metadata.sampleset_samples(sampleset, dummy);
+    if (s.ok()) {
+        return Status::Exists("BCFKeyValueData::new_sampleset: sample set already exists", sampleset);
+    } else if (s != StatusCode::NOT_FOUND) {
+        return s;
+    }
+
+    // commit the new sample set
+    return wb->commit();
+}
+
 shared_ptr<StatsRangeQuery> BCFKeyValueData::getRangeStats() {
     // return a copy of the current statistics
     std::lock_guard<std::mutex> lock(body_->statsMutex);

--- a/src/data.cc
+++ b/src/data.cc
@@ -79,6 +79,10 @@ Status MetadataCache::all_samples_sampleset(string& ans) {
     return body_->inner->all_samples_sampleset(ans);
 }
 
+Status MetadataCache::sample_count(size_t& ans) const {
+    return body_->inner->sample_count(ans);
+}
+
 const vector<pair<string,size_t> >& MetadataCache::contigs() const {
     return body_->contigs;
 }

--- a/test/BCFKeyValueData.cc
+++ b/test/BCFKeyValueData.cc
@@ -243,8 +243,12 @@ TEST_CASE("BCFKeyValueData::import_gvcf") {
     unique_ptr<MetadataCache> cache;
     REQUIRE(MetadataCache::Start(*data, cache).ok());
     set<string> samples_imported;
+    size_t ct;
 
     SECTION("empty all_samples_sampleset") {
+        REQUIRE(cache->sample_count(ct).ok());
+        REQUIRE(ct == 0);
+
         shared_ptr<const set<string>> all;
         Status s = cache->sampleset_samples("*", all);
         REQUIRE(s == StatusCode::NOT_FOUND);
@@ -267,6 +271,9 @@ TEST_CASE("BCFKeyValueData::import_gvcf") {
     SECTION("NA12878D_HiSeqX.21.10009462-10009469.gvcf") {
         Status s = data->import_gvcf(*cache, "NA12878D", "test/data/NA12878D_HiSeqX.21.10009462-10009469.gvcf", samples_imported);
         REQUIRE(s.ok());
+
+        REQUIRE(cache->sample_count(ct).ok());
+        REQUIRE(ct == 1);
 
         // check that internal version number of all-samples sampleset was
         // incremented
@@ -299,6 +306,9 @@ TEST_CASE("BCFKeyValueData::import_gvcf") {
         Status s = data->import_gvcf(*cache, "1", "test/data/sampleset_range1.gvcf", samples_imported);
         REQUIRE(s.ok());
 
+        REQUIRE(cache->sample_count(ct).ok());
+        REQUIRE(ct == 1);
+
         KeyValue::CollectionHandle coll;
         REQUIRE(db.collection("sampleset", coll).ok());
         string version;
@@ -322,6 +332,9 @@ TEST_CASE("BCFKeyValueData::import_gvcf") {
 
         s = data->import_gvcf(*cache, "2", "test/data/sampleset_range2.gvcf", samples_imported);
         REQUIRE(s.ok());
+
+        REQUIRE(cache->sample_count(ct).ok());
+        REQUIRE(ct == 2);
 
         REQUIRE(db.get(coll, "*", version).ok());
         REQUIRE(version == "2");
@@ -648,6 +661,10 @@ TEST_CASE("BCFData::sampleset_range") {
     s = data->import_gvcf(*cache, "2", "test/data/sampleset_range2.gvcf", samples_imported);
     REQUIRE(s.ok());
 
+    size_t ct;
+    REQUIRE(cache->sample_count(ct).ok());
+    REQUIRE(ct == 2);
+
     // check * version number
     KeyValue::CollectionHandle coll;
     REQUIRE(db.collection("sampleset", coll).ok());
@@ -809,6 +826,10 @@ TEST_CASE("BCFKeyValueData::sampleset_range") {
     REQUIRE(s.ok());
     s = data->import_gvcf(*cache, "3", "test/data/sampleset_range3.gvcf", samples_imported);
     REQUIRE(s.ok());
+
+    size_t ct;
+    REQUIRE(cache->sample_count(ct).ok());
+    REQUIRE(ct == 3);
 
     string sampleset;
     s = cache->all_samples_sampleset(sampleset);

--- a/test/service.cc
+++ b/test/service.cc
@@ -145,6 +145,11 @@ public:
         return Status::NotImplemented();
     }
 
+    Status sample_count(size_t& ans) const override {
+        ans = sample_datasets_.size();
+        return Status::OK();
+    }
+
     Status sample_dataset(const string& sample, string& ans) const override {
         auto p = sample_datasets_.find(sample);
         if (p == sample_datasets_.end()) {


### PR DESCRIPTION
1. Provides a way to create a new sample set with a subset of the available samples.
1. Provides a fast method to count all the samples in the database. Counts the size of the * sample set at startup, then updates this integer counter as samples are added -- no need to write the counter into the database.
1. Implements the idea of `BCFKeyValueData::sampleset_range` falling back to the point-lookup method for small sample sets.