### PR TITLE
Adding sanity tests to check the validity of the gVCF data

### DIFF
--- a/test/BCFKeyValueData.cc
+++ b/test/BCFKeyValueData.cc
@@ -236,7 +236,7 @@ TEST_CASE("BCFKeyValueData initialization") {
 
 TEST_CASE("BCFKeyValueData::import_gvcf") {
     KeyValueMem::DB db({});
-    vector<pair<string,uint64_t>> contigs = {make_pair<string,uint64_t>("21", 1000000)};
+    vector<pair<string,uint64_t>> contigs = {make_pair<string,uint64_t>("21", 48129895)};
     REQUIRE(T::InitializeDB(&db, contigs).ok());
     unique_ptr<T> data;
     REQUIRE(T::Open(&db, data).ok());
@@ -457,7 +457,7 @@ TEST_CASE("BCFKeyValueData::import_gvcf") {
 
 TEST_CASE("BCFKeyValueData BCF retrieval") {
     KeyValueMem::DB db({});
-    auto contigs = {make_pair<string,uint64_t>("21", 1000000)};
+    auto contigs = {make_pair<string,uint64_t>("21", 48129895)};
     REQUIRE(T::InitializeDB(&db, contigs).ok());
     unique_ptr<T> data;
     REQUIRE(T::Open(&db, data).ok());
@@ -466,6 +466,7 @@ TEST_CASE("BCFKeyValueData BCF retrieval") {
     set<string> samples_imported;
 
     Status s = data->import_gvcf(*cache, "NA12878D", "test/data/NA12878D_HiSeqX.21.10009462-10009469.gvcf", samples_imported);
+    cout << s.str() << endl;
     REQUIRE(s.ok());
 
     SECTION("dataset_header") {
@@ -557,7 +558,7 @@ TEST_CASE("BCFKeyValueData range overlap with a single dataset") {
     for (int ilen : intervals) {
         //cout << "interval_len=" << ilen << endl;
         KeyValueMem::DB db({});
-        auto contigs = {make_pair<string,uint64_t>("21", 1000000)};
+        auto contigs = {make_pair<string,uint64_t>("21", 48129895)};
 
         // Buckets of size 9 break the ranges [1005 -- 1010] and [3004 -- 3006]
         // in two.
@@ -648,7 +649,7 @@ TEST_CASE("BCFData::sampleset_range") {
     // returns iterators over 100kbp slices.
 
     KeyValueMem::DB db({});
-    auto contigs = {make_pair<string,uint64_t>("21", 1000000)};
+    auto contigs = {make_pair<string,uint64_t>("21", 48129895)};
     REQUIRE(T::InitializeDB(&db, contigs).ok());
     unique_ptr<T> data;
     REQUIRE(T::Open(&db, data).ok());
@@ -812,7 +813,7 @@ TEST_CASE("BCFKeyValueData::sampleset_range") {
     // This tests the optimized bucket-based range slicing in BCFKeyValueData
 
     KeyValueMem::DB db({});
-    auto contigs = {make_pair<string,uint64_t>("21", 1000000)};
+    auto contigs = {make_pair<string,uint64_t>("21", 48129895)};
     REQUIRE(T::InitializeDB(&db, contigs, 25000).ok());
     unique_ptr<T> data;
     REQUIRE(T::Open(&db, data).ok());
@@ -1062,7 +1063,7 @@ TEST_CASE("BCFKeyValueData compare iterator implementations") {
     // This tests the optimized bucket-based range slicing in BCFKeyValueData
     int nRegions = 13;
     int nIter = 10;
-    int lenChrom = 1000000;
+    int lenChrom = 48129895;
 
     KeyValueMem::DB db({});
     auto contigs = {make_pair<string,uint64_t>("21", lenChrom)};

--- a/test/data/bad_dna.gvcf
+++ b/test/data/bad_dna.gvcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=A,length=1000000>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	JOINT_D
+A	1000	.	KTG	ATGTG, A	.	PASS	.	GT	0/1

--- a/test/data/bad_dna2.gvcf
+++ b/test/data/bad_dna2.gvcf
@@ -1,0 +1,108 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##ALT=<ID=NON_REF,Description="Represents any possible alternative allele at this location">
+##FILTER=<ID=LowQual,Description="Low quality">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=MIN_DP,Number=1,Type=Integer,Description="Minimum DP observed within the GVCF block">
+##FORMAT=<ID=PGT,Number=1,Type=String,Description="Physical phasing haplotype information, describing how the alternate alleles are phased in relation to one another">
+##FORMAT=<ID=PID,Number=1,Type=String,Description="Physical phasing ID information, where each unique ID within a given sample (but not across samples) connects records within a phasing group">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##FORMAT=<ID=SB,Number=4,Type=Integer,Description="Per-sample component statistics which comprise the Fisher's Exact Test to detect strand bias.">
+##GATKCommandLine=<ID=HaplotypeCaller,Version=3.3-0-g37228af,Date="Thu Mar 26 22:56:46 UTC 2015",Epoch=1427410606380,CommandLineOptions="analysis_type=HaplotypeCaller input_file=[/home/dnanexus/in/sorted_bam/NA12878D_HiSeqX.realigned.recalibrated.bam] showFullBamList=false read_buffer_size=null phone_home=AWS gatk_key=null tag=NA read_filter=[] intervals=[1] excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=genome.fa nonDeterministicRandomSeed=false disableDithering=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=250 baq=OFF baqGapOpenPenalty=40.0 refactor_NDN_cigar_string=false fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false useOriginalQualities=false defaultBaseQualities=-1 performanceLog=null BQSR=null quantize_quals=0 disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 globalQScorePrior=-1.0 validation_strictness=SILENT remove_program_records=false keep_program_records=false sample_rename_mapping_file=null unsafe=null disable_auto_index_creation_and_locking_when_reading_rods=false no_cmdline_in_header=false sites_only=false never_trim_vcf_format_field=false bcf=false bam_compression=null simplifyBAM=false disable_bam_indexing=false generate_md5=false num_threads=1 num_cpu_threads_per_data_thread=2 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false variant_index_type=LINEAR variant_index_parameter=128000 logging_level=INFO log_to_file=null help=false version=false likelihoodCalculationEngine=PairHMM heterogeneousKmerSizeResolution=COMBO_MIN graphOutput=null bamOutput=null bamWriterType=CALLED_HAPLOTYPES disableOptimizations=false dbsnp=(RodBinding name=dbsnp source=dbsnp_138.b37.vcf.gz) dontTrimActiveRegions=false maxDiscARExtension=25 maxGGAARExtension=300 paddingAroundIndels=150 paddingAroundSNPs=20 comp=[] annotation=[ClippingRankSumTest, DepthPerSampleHC, StrandBiasBySample] excludeAnnotation=[SpanningDeletions, TandemRepeatAnnotator, ChromosomeCounts, FisherStrand, StrandOddsRatio, QualByDepth] debug=false useFilteredReadsForAnnotations=false emitRefConfidence=GVCF annotateNDA=false heterozygosity=0.001 indel_heterozygosity=1.25E-4 standard_min_confidence_threshold_for_calling=-0.0 standard_min_confidence_threshold_for_emitting=-0.0 max_alternate_alleles=6 input_prior=[] sample_ploidy=2 genotyping_mode=DISCOVERY alleles=(RodBinding name= source=UNBOUND) contamination_fraction_to_filter=0.0 contamination_fraction_per_sample_file=null p_nonref_model=null exactcallslog=null output_mode=EMIT_VARIANTS_ONLY allSitePLs=true sample_name=null kmerSize=[10, 25] dontIncreaseKmerSizesForCycles=false allowNonUniqueKmersInRef=false numPruningSamples=1 recoverDanglingHeads=false doNotRecoverDanglingBranches=false minDanglingBranchLength=4 consensus=false GVCFGQBands=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 70, 80, 90, 99] indelSizeToEliminateInRefModel=10 min_base_quality_score=10 minPruning=2 gcpHMM=10 includeUmappedReads=false useAllelesTrigger=false phredScaledGlobalReadMismappingRate=45 maxNumHaplotypesInPopulation=128 mergeVariantsViaLD=false doNotRunPhysicalPhasing=false pair_hmm_implementation=VECTOR_LOGLESS_CACHING keepRG=null justDetermineActiveRegions=false dontGenotype=false errorCorrectKmers=false debugGraphTransformations=false dontUseSoftClippedBases=false captureAssemblyFailureBAM=false allowCyclesInKmerGraphToGeneratePaths=false noFpga=false errorCorrectReads=false kmerLengthForReadErrorCorrection=25 minObservationsForKmerToBeSolid=20 pcr_indel_model=CONSERVATIVE maxReadsInRegionPerSample=1000 minReadsPerAlignmentStart=5 activityProfileOut=null activeRegionOut=null activeRegionIn=null activeRegionExtension=null forceActive=false activeRegionMaxSize=null bandPassSigma=null maxProbPropagationDistance=50 activeProbabilityThreshold=0.002 min_mapping_quality_score=20 filter_reads_with_N_cigar=false filter_mismatching_base_and_quals=false filter_bases_not_stored=false">
+##GVCFBlock=minGQ=0(inclusive),maxGQ=1(exclusive)
+##GVCFBlock=minGQ=1(inclusive),maxGQ=2(exclusive)
+##GVCFBlock=minGQ=10(inclusive),maxGQ=11(exclusive)
+##GVCFBlock=minGQ=11(inclusive),maxGQ=12(exclusive)
+##GVCFBlock=minGQ=12(inclusive),maxGQ=13(exclusive)
+##GVCFBlock=minGQ=13(inclusive),maxGQ=14(exclusive)
+##GVCFBlock=minGQ=14(inclusive),maxGQ=15(exclusive)
+##GVCFBlock=minGQ=15(inclusive),maxGQ=16(exclusive)
+##GVCFBlock=minGQ=16(inclusive),maxGQ=17(exclusive)
+##GVCFBlock=minGQ=17(inclusive),maxGQ=18(exclusive)
+##GVCFBlock=minGQ=18(inclusive),maxGQ=19(exclusive)
+##GVCFBlock=minGQ=19(inclusive),maxGQ=20(exclusive)
+##GVCFBlock=minGQ=2(inclusive),maxGQ=3(exclusive)
+##GVCFBlock=minGQ=20(inclusive),maxGQ=21(exclusive)
+##GVCFBlock=minGQ=21(inclusive),maxGQ=22(exclusive)
+##GVCFBlock=minGQ=22(inclusive),maxGQ=23(exclusive)
+##GVCFBlock=minGQ=23(inclusive),maxGQ=24(exclusive)
+##GVCFBlock=minGQ=24(inclusive),maxGQ=25(exclusive)
+##GVCFBlock=minGQ=25(inclusive),maxGQ=26(exclusive)
+##GVCFBlock=minGQ=26(inclusive),maxGQ=27(exclusive)
+##GVCFBlock=minGQ=27(inclusive),maxGQ=28(exclusive)
+##GVCFBlock=minGQ=28(inclusive),maxGQ=29(exclusive)
+##GVCFBlock=minGQ=29(inclusive),maxGQ=30(exclusive)
+##GVCFBlock=minGQ=3(inclusive),maxGQ=4(exclusive)
+##GVCFBlock=minGQ=30(inclusive),maxGQ=31(exclusive)
+##GVCFBlock=minGQ=31(inclusive),maxGQ=32(exclusive)
+##GVCFBlock=minGQ=32(inclusive),maxGQ=33(exclusive)
+##GVCFBlock=minGQ=33(inclusive),maxGQ=34(exclusive)
+##GVCFBlock=minGQ=34(inclusive),maxGQ=35(exclusive)
+##GVCFBlock=minGQ=35(inclusive),maxGQ=36(exclusive)
+##GVCFBlock=minGQ=36(inclusive),maxGQ=37(exclusive)
+##GVCFBlock=minGQ=37(inclusive),maxGQ=38(exclusive)
+##GVCFBlock=minGQ=38(inclusive),maxGQ=39(exclusive)
+##GVCFBlock=minGQ=39(inclusive),maxGQ=40(exclusive)
+##GVCFBlock=minGQ=4(inclusive),maxGQ=5(exclusive)
+##GVCFBlock=minGQ=40(inclusive),maxGQ=41(exclusive)
+##GVCFBlock=minGQ=41(inclusive),maxGQ=42(exclusive)
+##GVCFBlock=minGQ=42(inclusive),maxGQ=43(exclusive)
+##GVCFBlock=minGQ=43(inclusive),maxGQ=44(exclusive)
+##GVCFBlock=minGQ=44(inclusive),maxGQ=45(exclusive)
+##GVCFBlock=minGQ=45(inclusive),maxGQ=46(exclusive)
+##GVCFBlock=minGQ=46(inclusive),maxGQ=47(exclusive)
+##GVCFBlock=minGQ=47(inclusive),maxGQ=48(exclusive)
+##GVCFBlock=minGQ=48(inclusive),maxGQ=49(exclusive)
+##GVCFBlock=minGQ=49(inclusive),maxGQ=50(exclusive)
+##GVCFBlock=minGQ=5(inclusive),maxGQ=6(exclusive)
+##GVCFBlock=minGQ=50(inclusive),maxGQ=51(exclusive)
+##GVCFBlock=minGQ=51(inclusive),maxGQ=52(exclusive)
+##GVCFBlock=minGQ=52(inclusive),maxGQ=53(exclusive)
+##GVCFBlock=minGQ=53(inclusive),maxGQ=54(exclusive)
+##GVCFBlock=minGQ=54(inclusive),maxGQ=55(exclusive)
+##GVCFBlock=minGQ=55(inclusive),maxGQ=56(exclusive)
+##GVCFBlock=minGQ=56(inclusive),maxGQ=57(exclusive)
+##GVCFBlock=minGQ=57(inclusive),maxGQ=58(exclusive)
+##GVCFBlock=minGQ=58(inclusive),maxGQ=59(exclusive)
+##GVCFBlock=minGQ=59(inclusive),maxGQ=60(exclusive)
+##GVCFBlock=minGQ=6(inclusive),maxGQ=7(exclusive)
+##GVCFBlock=minGQ=60(inclusive),maxGQ=70(exclusive)
+##GVCFBlock=minGQ=7(inclusive),maxGQ=8(exclusive)
+##GVCFBlock=minGQ=70(inclusive),maxGQ=80(exclusive)
+##GVCFBlock=minGQ=8(inclusive),maxGQ=9(exclusive)
+##GVCFBlock=minGQ=80(inclusive),maxGQ=90(exclusive)
+##GVCFBlock=minGQ=9(inclusive),maxGQ=10(exclusive)
+##GVCFBlock=minGQ=90(inclusive),maxGQ=99(exclusive)
+##GVCFBlock=minGQ=99(inclusive),maxGQ=2147483647(exclusive)
+##INFO=<ID=BaseQRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt Vs. Ref base qualities">
+##INFO=<ID=ClippingRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref number of hard clipped bases">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP Membership">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DS,Number=0,Type=Flag,Description="Were any of the samples downsampled?">
+##INFO=<ID=END,Number=1,Type=Integer,Description="Stop position of the interval">
+##INFO=<ID=HaplotypeScore,Number=1,Type=Float,Description="Consistency of the site with at most two segregating haplotypes">
+##INFO=<ID=InbreedingCoeff,Number=1,Type=Float,Description="Inbreeding coefficient as estimated from the genotype likelihoods per-sample when compared against the Hardy-Weinberg expectation">
+##INFO=<ID=MLEAC,Number=A,Type=Integer,Description="Maximum likelihood expectation (MLE) for the allele counts (not necessarily the same as the AC), for each ALT allele, in the same order as listed">
+##INFO=<ID=MLEAF,Number=A,Type=Float,Description="Maximum likelihood expectation (MLE) for the allele frequency (not necessarily the same as the AF), for each ALT allele, in the same order as listed">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=MQRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref read mapping qualities">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read position bias">
+##contig=<ID=A,length=1000000>
+##reference=file:///home/dnanexus/genome.fa
+##bcftools_concatVersion=1.1+htslib-1.1
+##bcftools_concatCommand=concat -f results.per-chrom.txt -o output.vcf.gz -O z
+#CHROM	POS	ID	REF	ALT	  QUAL	FILTER	INFO	FORMAT	HX0001
+A	1001	.	K	<NON_REF>	.	.	END=1005	GT:DP:GQ:MIN_DP:PL	0/0:14:36:13:0,36,540
+A	1011	.	KCCAT	<NON_REF>	.	.	END=1016	GT:DP:GQ:MIN_DP:PL	0/0:14:36:13:0,36,540
+A	2001	.	NNNN	<NON_REF>	.	.	END=2005	GT:DP:GQ:MIN_DP:PL	0/0:14:36:13:0,36,540
+A	2003	.	CCATT	<NON_REF>	.	.	END=2008	GT:DP:GQ:MIN_DP:PL	0/0:14:36:13:0,36,540
+A	2004	.	GGA	<NON_REF>	.	.	END=2007	GT:DP:GQ:MIN_DP:PL	0/0:14:36:13:0,36,540
+A	2007	.	GG	<NON_REF>	.	.	END=2009	GT:DP:GQ:MIN_DP:PL	0/0:14:36:13:0,36,540
+A	3001	.	ACACGGTTAA	<NON_REF>	.	.	END=3009	GT:DP:GQ:MIN_DP:PL	0/0:14:36:13:0,36,540
+A	3004	.	ATAT	<NON_REF>	.	.	END=3006	GT:DP:GQ:MIN_DP:PL	0/0:14:36:13:0,36,540
+A	3005	.	GCA	<NON_REF>	.	.	END=3008	GT:DP:GQ:MIN_DP:PL	0/0:14:36:13:0,36,540
+A	3008	.	GCAGCCA	<NON_REF>	.	.	END=3015	GT:DP:GQ:MIN_DP:PL	0/0:14:36:13:0,36,540

--- a/test/data/bad_dna3.gvcf
+++ b/test/data/bad_dna3.gvcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=A,length=1000004>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	JOINT_D
+A	1000	.	ATG	ATGTG, A	.	PASS	.	GT	0/1

--- a/test/data/bad_dna4.gvcf
+++ b/test/data/bad_dna4.gvcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=A,length=1000000>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	JOINT_D
+A	1000	.	ATG	ATGTG, 	.	PASS	.	GT	0/1

--- a/test/rocks_integration.cc
+++ b/test/rocks_integration.cc
@@ -188,7 +188,7 @@ TEST_CASE("RocksDB::import_gvcf") {
     Status s = RocksKeyValue::Initialize(dbPath, db);
     REQUIRE(s.ok());
 
-    auto contigs = {make_pair<string,uint64_t>("21", 1000000)};
+    auto contigs = {make_pair<string,uint64_t>("21", 48129895)};
     REQUIRE(T::InitializeDB(db.get(), contigs).ok());
     unique_ptr<T> data;
     REQUIRE(T::Open(db.get(), data).ok());
@@ -238,7 +238,7 @@ TEST_CASE("RocksDB BCF retrieval") {
     Status s = RocksKeyValue::Initialize(dbPath, db);
     REQUIRE(s.ok());
 
-    auto contigs = {make_pair<string,uint64_t>("21", 1000000)};
+    auto contigs = {make_pair<string,uint64_t>("21", 48129895)};
     REQUIRE(T::InitializeDB(db.get(), contigs).ok());
     unique_ptr<T> data;
     REQUIRE(T::Open(db.get(), data).ok());
@@ -341,7 +341,7 @@ TEST_CASE("RocksKeyValue prefix mode") {
     Status s = RocksKeyValue::Initialize(dbPath, db, &prefix_spec);
     REQUIRE(s.ok());
 
-    auto contigs = {make_pair<string,uint64_t>("21", 1000000)};
+    auto contigs = {make_pair<string,uint64_t>("21", 48129895)};
     REQUIRE(T::InitializeDB(db.get(), contigs).ok());
     unique_ptr<T> data;
     REQUIRE(T::Open(db.get(), data).ok());

--- a/test/rocks_integration.cc
+++ b/test/rocks_integration.cc
@@ -500,7 +500,7 @@ TEST_CASE("Multi-threading") {
     Status s = RocksKeyValue::Initialize(dbPath, db);
     REQUIRE(s.ok());
 
-    auto contigs = {make_pair<string,uint64_t>("21", 1000000)};
+    auto contigs = {make_pair<string,uint64_t>("21", 48129895)};
     REQUIRE(T::InitializeDB(db.get(), contigs).ok());
     unique_ptr<T> data;
     REQUIRE(T::Open(db.get(), data).ok());
@@ -586,7 +586,7 @@ TEST_CASE("Concurrent import/query") {
     Status s = RocksKeyValue::Initialize(dbPath, db);
     REQUIRE(s.ok());
 
-    auto contigs = {make_pair<string,uint64_t>("21", 1000000)};
+    auto contigs = {make_pair<string,uint64_t>("21", 48129895)};
     REQUIRE(T::InitializeDB(db.get(), contigs).ok());
     unique_ptr<T> data;
     REQUIRE(T::Open(db.get(), data).ok());


### PR DESCRIPTION
This implements the following additional checks on gVCFs as we load them: 
1) <= 1,000 contigs (due to bucket key schema)
2) contig length <= 1e10 (ditto)
3) on ingestion, check gVCF records don't pass end of contig
4) DNA regexp for gVCF REF and ALT alleles
