### PR TITLE
Making the applet able to create residual files

### DIFF
--- a/cli/dxapplet/dxapp.json
+++ b/cli/dxapplet/dxapp.json
@@ -54,6 +54,12 @@
       "class": "boolean",
       "default": false,
       "optional": true
+    },
+    {
+      "name": "residuals",
+      "class": "boolean",
+      "default": false,
+      "optional": true
     }
   ],
   "outputSpec": [
@@ -76,6 +82,11 @@
     {
       "name": "perf",
       "class": "array:file",
+      "optional": true
+    },
+    {
+      "name": "residuals",
+      "class": "file",
       "optional": true
     }
   ],

--- a/cli/dxapplet/src/code.sh
+++ b/cli/dxapplet/src/code.sh
@@ -90,7 +90,7 @@ main() {
         fi
 
         residuals_flag=""
-        if [ -n $residuals ]; then
+        if [[ $residuals == "true" ]]; then
             residuals_flag="--residuals"
         fi
 

--- a/cli/dxapplet/src/code.sh
+++ b/cli/dxapplet/src/code.sh
@@ -89,9 +89,21 @@ main() {
             sudo perf record -F $recordFreq -a -g &
         fi
 
+        residuals_flag=""
+        if [ -n $residuals ]; then
+            residuals_flag="--residuals"
+        fi
+
         mkdir -p out/vcf
-        time glnexus_cli genotype GLnexus.db --bed ranges.bed \
+        time glnexus_cli genotype GLnexus.db $residuals_flag --bed ranges.bed \
             | bcftools view - | bgzip -c > "out/vcf/${output_name}.vcf.gz"
+
+        # we are writing the generated VCF to stdout, so the residuals will
+        # be placed in a default location.
+        if [ -f /tmp/residuals.yml ]; then
+            mkdir -p out/residuals/
+            mv /tmp/residuals.yml out/residuals/
+        fi
 
         if [ "$enable_perf" == "1" ]; then
             sudo killall perf

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -410,7 +410,8 @@ void help_genotype(const char* prog) {
     cerr << "usage: " << prog << " genotype [options] /db/path chrom 1234 2345" << endl
          << "Genotype all samples in the database in the given interval. The positions are" << endl
          << "one-based, inclusive. As an alternative to providing one interval on the" << endl
-         << "command line, you can pass a three-column BED file using --bed FILENAME."
+         << "command line, you can pass a three-column BED file using --bed FILENAME." << endl
+         << "In order to create a detailed report of missed called, use the --residuals option."
          << endl;
 }
 
@@ -422,11 +423,13 @@ int main_genotype(int argc, char *argv[]) {
 
     static struct option long_options[] = {
         {"help", no_argument, 0, 'h'},
+        {"residuals", no_argument, 0, 'r'},
         {"bed", required_argument, 0, 'b'},
         {0, 0, 0, 0}
     };
 
     string bedfilename;
+    bool residuals = false;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -439,6 +442,9 @@ int main_genotype(int argc, char *argv[]) {
                     cerr <<  "invalid BED filename" << endl;
                     return 1;
                 }
+                break;
+            case 'r':
+                residuals = true;
                 break;
             case 'h':
             case '?':
@@ -559,8 +565,11 @@ int main_genotype(int argc, char *argv[]) {
             console->info() << "unified to " << sites.size() << " sites";
 
             GLnexus::consolidated_loss losses;
+            GLnexus::genotyper_config genoCfg = GLnexus::genotyper_config();
+            genoCfg.output_residuals = residuals;
+
             H("genotype sites",
-              svc->genotype_sites(GLnexus::genotyper_config(), sampleset, sites, string("-"), losses));
+              svc->genotype_sites(genoCfg, sampleset, sites, string("-"), losses));
             console->info("genotyping complete!");
 
             if (losses.size() < 100) {

--- a/src/service.cc
+++ b/src/service.cc
@@ -403,7 +403,14 @@ Status Service::genotype_sites(const genotyper_config& cfg, const string& sample
     // set up the residuals file
     unique_ptr<Residuals> residuals = nullptr;
     unique_ptr<ResidualsFile> residualsFile = nullptr;
-    string res_filename = filename + ".residuals.yml";
+    string res_filename;
+    if (filename != "-" && filename.find(".") > 0) {
+        int lastindex = filename.find_last_of(".");
+        string rawname = filename.substr(0, lastindex);
+        res_filename = rawname + ".residuals.yml";
+    } else {
+        res_filename = "/tmp/residuals.yml";
+    }
     if (cfg.output_residuals) {
         S(Residuals::Open(*(body_->metadata_), body_->data_, sampleset, sample_names, residuals));
         S(ResidualsFile::Open(res_filename, residualsFile));

--- a/test/service.cc
+++ b/test/service.cc
@@ -665,7 +665,7 @@ TEST_CASE("genotype residuals") {
     REQUIRE(s.ok());
 
     // verify that the residuals file is in correct yaml format
-    YAML::Node resFile = YAML::LoadFile(tfn + ".residuals.yml");
+    YAML::Node resFile = YAML::LoadFile("/tmp/GLnexus_unit_tests.residuals.yml");
     REQUIRE(resFile.size() == 3);
 
     // It seems that a list of documents split by --- symbols


### PR DESCRIPTION
Allow the applet to create residual file reports. The one difficultly I had to work around, was that the file name given for the output VCF was "-" (stdout). 