### PR TITLE
unifier: add a configuration setting to prefer small alleles

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -398,10 +398,21 @@ struct StatsRangeQuery {
     }
 };
 
+enum class UnifierPreference { Common, Small };
+
 struct unifier_config {
-    /// Maximum number of alleles per unified site; excess rare alleles will
-    /// be pruned. If zero, then no specific limit is enforced.
+    /// Maximum number of alleles per unified site; excess alleles will be
+    /// pruned. If zero, then no specific limit is enforced.
     size_t max_alleles_per_site = 0;
+
+    /// The unifier may need to prune alleles if they're too numerous and/or
+    /// overlap in conflicting ways. The preference controls which alleles the
+    /// unifier will try hardest to keep: common alleles (default), or alleles
+    /// editing the smallest portion of the reference (least likely to
+    /// conflict with other alleles).
+    UnifierPreference preference = UnifierPreference::Common;
+
+    static Status of_yaml(const YAML::Node& yaml, unifier_config& ans);
 };
 
 enum class GLnexusOutputFormat {

--- a/src/types.cc
+++ b/src/types.cc
@@ -286,4 +286,37 @@ Status unified_site::of_yaml(const YAML::Node& yaml, const vector<pair<string,si
     return Status::OK();
 }
 
+Status unifier_config::of_yaml(const YAML::Node& yaml, unifier_config& ans) {
+    Status s;
+
+    ans = unifier_config();
+
+    #define V(pred,msg) if (!(pred)) return Status::Invalid("unifier_config::of_yaml: " msg)
+    V(yaml.IsMap(), "not a map at top level");
+
+    const auto n_max_alleles_per_site = yaml["max_alleles_per_site"];
+    if (n_max_alleles_per_site) {
+        V(n_max_alleles_per_site.IsScalar(), "invalid max_alleles_per_site");
+        int max_alleles_per_site = n_max_alleles_per_site.as<int>();
+        V(max_alleles_per_site > 0, "invalid max_alleles_per_site");
+        ans.max_alleles_per_site = (size_t) max_alleles_per_site;
+    }
+
+    const auto n_preference = yaml["preference"];
+    if (n_preference) {
+        V(n_preference.IsScalar(), "invalid preference");
+        const string& preference = n_preference.Scalar();
+        if (preference == "common") {
+            ans.preference = UnifierPreference::Common;
+        } else if (preference == "small") {
+            ans.preference = UnifierPreference::Small;
+        } else {
+            V(false, "invalid preference");
+        }
+    }
+
+    #undef V
+    return Status::OK();
+}
+
 }

--- a/test/data/gvcf_test_cases/join_records_prefer_small.yml
+++ b/test/data/gvcf_test_cases/join_records_prefer_small.yml
@@ -1,9 +1,5 @@
 readme: |
-  This is a synthetic test case targeted at testing logic for "joining" records in genotyper. In particular, this case asserts that for a given site, a sample which have multiple (>1) variant records within the site will be considered a no call due to lossAllele.
-  This no-call is necessary because we cannot assert phase when joining variant records (TODO: phase can be naively asserted for homozygous genotypes, and can be potentially supported by GLnexus in future iterations.)
-  ## Explanation of included sample:
-  D.gvcf has 2 vcf heterozygous variant records within site, and we should consider sample D as a no call within the given site, with RNC = LostAllele
-  A.gvcf, B.gvcf and C.gvcf are used to suggest a 3-bp long site
+  This test case is based on join_records_unjoinable.yml, but changes the unifier configuration to prefer small variants even if they're rare.
 input:
   header : |-
       ##fileformat=VCFv4.2
@@ -35,28 +31,35 @@ input:
         A	1002	.	C	G,<NON_REF>	315.53	.	.	GT:AD:DP:GQ:PL:SB	0/1:103,15,0:118:99:232,0,3603,542,3649,4191:64,39,11,4
   unifier_config:
     max_alleles_per_site: 16
-    preference: common
+    preference: small
 
 truth_unified_sites:
-    - range: {ref: "A", beg: 1000, end: 1002}
-      alleles: [TTC, T, ATC]
-      observation_count: [0, 2, 1]
+    - range: {ref: A, beg: 1000, end: 1000}
+      alleles: [T, A]
+      observation_count: [0, 1]
       unification:
+        - range: {beg: 1000, end: 1000}
+          alt: T
+          to: 0
         - range: {beg: 1000, end: 1002}
           alt: TTC
           to: 0
         - range: {beg: 1000, end: 1000}
-          alt: T
+          alt: A
+          to: 1
+    - range: {ref: A, beg: 1002, end: 1002}
+      alleles: [C, G]
+      observation_count: [0, 1]
+      unification:
+        - range: {beg: 1000, end: 1002}
+          alt: TTC
           to: 0
         - range: {beg: 1002, end: 1002}
           alt: C
           to: 0
-        - range: {beg: 1000, end: 1002}
-          alt: T
+        - range: {beg: 1002, end: 1002}
+          alt: G
           to: 1
-        - range: {beg: 1000, end: 1000}
-          alt: A
-          to: 2
 
 truth_output_vcf:
   - truth.vcf: |
@@ -66,4 +69,5 @@ truth_output_vcf:
       ##FORMAT=<ID=RNC,Number=G,Type=Character,Description="Reason for No Call in GT: . = n/a, M = Missing data, P = Partial data, D = insufficient Depth of coverage, - = unrepresentable overlapping deletion, L = Lost/unrepresentable allele (other than deletion), U = multiple Unphased variants present, O = multiple Overlapping variants present">
       ##contig=<ID=A,length=1000000>
       #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	A	B	C	D
-      A	1000	.	TTC	T,ATC	0	.	.	GT:RNC	0/0:..	0/1:..	0/1:..	./.:UU
+      A	1000	.	T	A	0	.	.	GT:RNC	0/0:..	0/.:.-	0/.:.-	0/1:..
+      A	1002	.	C	G	0	.	.	GT:RNC	0/0:..	0/.:.-	0/.:.-	0/1:..

--- a/test/gvcf_test_cases.cc
+++ b/test/gvcf_test_cases.cc
@@ -36,6 +36,9 @@ class GVCFTestCase {
     // Name of curated case
     string name;
 
+    // unifier configuration
+    unifier_config unifier_cfg;
+
     // Filenames of input gvcfs
     set<string> input_gvcfs;
 
@@ -170,6 +173,11 @@ public:
         V(n_header.IsScalar(), "header string invalid");
         header = n_header.Scalar();
 
+        const auto n_unifier_config = n_input["unifier_config"];
+        if (n_unifier_config) {
+            S(unifier_config::of_yaml(n_unifier_config, unifier_cfg));
+        }
+
         // Stage temp folders for output
         S(create_folder(TEMP_DIR));
         temp_dir_path = TEMP_DIR + name + "/";
@@ -244,7 +252,7 @@ public:
         Status s = svc->discover_alleles("<ALL>", range(0, 0, 1000000000), als);
         REQUIRE(s.ok());
 
-        s =unified_sites(unifier_config(), als, sites);
+        s = unified_sites(unifier_cfg, als, sites);
         REQUIRE(s.ok());
 
         REQUIRE(is_sorted(sites.begin(), sites.end()));
@@ -550,4 +558,8 @@ TEST_CASE("join record logic test: overlapping records") {
 
 TEST_CASE("lost deletion") {
     GVCFTestCase("lost_deletion").perform_gvcf_test();
+}
+
+TEST_CASE("join records with unifier preference for small alleles") {
+    GVCFTestCase("join_records_prefer_small").perform_gvcf_test();
 }


### PR DESCRIPTION
"small" alleles, by which we mean editing the smallest stretch of the reference genome, are (heuristically) the least likely to conflict with other overlapping alleles and cause UnphasedVariants genotype losses. Common remains the default preference for now because it seems the right heuristic to minimize total loss, however.