### PR TITLE
Residuals include the target range (exon) containing each unified site

### DIFF
--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -640,14 +640,18 @@ int main_genotype(int argc, char *argv[]) {
             console->info() << "discovering alleles in " << ranges.size() << " range(s)";
             vector<GLnexus::discovered_alleles> valleles;
             H("discover alleles", svc->discover_alleles(sampleset, ranges, valleles));
-            GLnexus::discovered_alleles alleles;
-            for (const auto& als : valleles) {
-                H("merging discovered alleles", GLnexus::merge_discovered_alleles(als, alleles));
+            unsigned discovered_allele_count=0;
+            for (const auto& dsals : valleles) {
+                discovered_allele_count += dsals.size();
             }
-            console->info() << "discovered " << alleles.size() << " alleles";
+            console->info() << "discovered " << discovered_allele_count << " alleles";
 
             vector<GLnexus::unified_site> sites;
-            H("unify sites", GLnexus::unified_sites(GLnexus::unifier_config(), alleles, sites));
+            for (int i = 0; i < valleles.size(); i++) {
+                vector<GLnexus::unified_site> sites_i;
+                H("unify sites", GLnexus::unified_sites(GLnexus::unifier_config(), valleles[i], sites_i, ranges[i]));
+                sites.insert(sites.end(), sites_i.begin(), sites_i.end());
+            }
             console->info() << "unified to " << sites.size() << " sites";
 
             GLnexus::consolidated_loss losses;

--- a/include/types.h
+++ b/include/types.h
@@ -253,6 +253,9 @@ Status discovered_alleles_of_yaml(const YAML::Node&,
 struct unified_site {
     range pos;
 
+    /// Optional: the sequencing target range (e.g. exon) containing this site
+    range containing_target;
+
 
     /// Alleles at the position.
 
@@ -279,7 +282,7 @@ struct unified_site {
         return observation_count < rhs.observation_count;
     }
 
-    unified_site(const range& pos_) noexcept : pos(pos_) {}
+    unified_site(const range& pos_) noexcept : pos(pos_), containing_target(-1,-1,-1) {}
 
     Status yaml(const std::vector<std::pair<std::string,size_t> >& contigs,
                 YAML::Emitter& out) const;

--- a/include/unifier.h
+++ b/include/unifier.h
@@ -10,7 +10,8 @@ namespace GLnexus {
 /// Compute unified sites from all discovered alleles in some genomic region
 Status unified_sites(const unifier_config& cfg,
 	                 const discovered_alleles& alleles,
-	                 std::vector<unified_site>& ans);
+	                 std::vector<unified_site>& ans,
+	                 range containing_target = range(-1,-1,-1));
 
 }
 

--- a/src/types.cc
+++ b/src/types.cc
@@ -96,7 +96,7 @@ Status range_of_yaml(const YAML::Node& yaml, const vector<pair<string,size_t> >&
     V(n_end && n_end.IsScalar(), "missing/invalid 'end' field");
     int end = n_end.as<int>();
 
-    V(beg >= 1 && end >= beg, "invalid beg/end coordinates");
+    V(beg >= 0 && end >= beg, "invalid beg/end coordinates");
 
     ans = range(rid, beg, end);
     return Status::OK();
@@ -181,6 +181,11 @@ Status unified_site::yaml(const std::vector<std::pair<std::string,size_t> >& con
     ans << YAML::Key << "range" << YAML::Value;
     S(range_yaml(contigs, pos, ans));
 
+    if (containing_target.rid >= 0) {
+        ans << YAML::Key << "containing_target" << YAML::Value;
+        S(range_yaml(contigs, containing_target, ans));
+    }
+
     ans << YAML::Key << "alleles";
     ans << YAML::Value << YAML::Flow << YAML::BeginSeq;
     for (const auto& allele : alleles) {
@@ -232,6 +237,11 @@ Status unified_site::of_yaml(const YAML::Node& yaml, const vector<pair<string,si
     V(n_range, "missing 'range' field");
     S(range_of_yaml(n_range, contigs, ans.pos));
     #define VR(pred,msg) if (!(pred)) return Status::Invalid("unified_site_of_yaml: " msg, ans.pos.str(contigs))
+
+    const auto n_containing_target = yaml["containing_target"];
+    if (n_containing_target) {
+        S(range_of_yaml(n_containing_target, contigs, ans.containing_target));
+    }
 
     ans.alleles.clear();
     const auto n_alleles = yaml["alleles"];

--- a/src/unifier.cc
+++ b/src/unifier.cc
@@ -384,7 +384,8 @@ Status unify_alleles(const unifier_config& cfg, const range& pos,
 
 Status unified_sites(const unifier_config& cfg,
                      const discovered_alleles& alleles,
-                     vector<unified_site>& ans) {
+                     vector<unified_site>& ans,
+                     range containing_target) {
     Status s;
 
     map<range,pair<discovered_alleles,minimized_alleles>> sites;
@@ -396,6 +397,8 @@ Status unified_sites(const unifier_config& cfg,
         UNPAIR(site_alleles, ref_alleles, alt_alleles);
         unified_site us(pos);
         S(unify_alleles(cfg, pos, ref_alleles, alt_alleles, us));
+        assert(containing_target.rid < 0 || containing_target.contains(pos));
+        us.containing_target = containing_target;
         ans.push_back(us);
     }
     return Status::OK();

--- a/test/types.cc
+++ b/test/types.cc
@@ -425,6 +425,7 @@ TEST_CASE("unified_site::yaml") {
     SECTION("roundtrip") {
         const char* del = 1 + R"(
 range: {ref: '17', beg: 1000, end: 1001}
+containing_target: {ref: '17', beg: 1, end: 10000}
 alleles: [AG, AC, C]
 observation_count: [100, 50, 1]
 unification:


### PR DESCRIPTION
This is to reduce time spent debugging why we lose alleles crossing the boundary of a target range. Now we can at least see, in the residuals file, that the site is very close to the boundary.