### PR TITLE
One DB pass

### DIFF
--- a/include/genotyper.h
+++ b/include/genotyper.h
@@ -5,13 +5,20 @@
 #include "types.h"
 #include <fstream>
 #include <memory>
+#include "residuals.h"
 
 namespace GLnexus {
 
+// Genotype a site.
+//
+// residual_rec: in case there are call losses, generate a YAML formatted record giving
+// the context. This is used offline to improve the algorithms.
 Status genotype_site(const genotyper_config& cfg, MetadataCache& cache, BCFData& data,
                      const unified_site& site,
                      const std::string& sampleset, const std::vector<std::string>& samples,
                      const bcf_hdr_t* hdr, std::shared_ptr<bcf1_t>& ans, consolidated_loss& losses_for_site,
+                     std::shared_ptr<Residuals>& residuals,
+                     std::shared_ptr<std::string> &residual_rec,
                      std::atomic<bool>* abort = nullptr);
 
 // LossTracker handles the low-level housekeeping of loss accounting for a

--- a/include/genotyper.h
+++ b/include/genotyper.h
@@ -17,7 +17,7 @@ Status genotype_site(const genotyper_config& cfg, MetadataCache& cache, BCFData&
                      const unified_site& site,
                      const std::string& sampleset, const std::vector<std::string>& samples,
                      const bcf_hdr_t* hdr, std::shared_ptr<bcf1_t>& ans, consolidated_loss& losses_for_site,
-                     Residuals *residuals,
+                     bool residualsFlag,
                      std::shared_ptr<std::string> &residual_rec,
                      std::atomic<bool>* abort = nullptr);
 

--- a/include/genotyper.h
+++ b/include/genotyper.h
@@ -17,7 +17,7 @@ Status genotype_site(const genotyper_config& cfg, MetadataCache& cache, BCFData&
                      const unified_site& site,
                      const std::string& sampleset, const std::vector<std::string>& samples,
                      const bcf_hdr_t* hdr, std::shared_ptr<bcf1_t>& ans, consolidated_loss& losses_for_site,
-                     std::shared_ptr<Residuals>& residuals,
+                     Residuals *residuals,
                      std::shared_ptr<std::string> &residual_rec,
                      std::atomic<bool>* abort = nullptr);
 

--- a/include/residuals.h
+++ b/include/residuals.h
@@ -15,37 +15,17 @@ struct DatasetSiteInfo {
     std::vector<std::shared_ptr<bcf1_t>> records;
 };
 
-class Residuals {
-private:
-    const MetadataCache& cache_;
-    BCFData& data_;
-    const std::string& sampleset_;
-    const std::vector<std::string>& samples_;
+// Create a YAML node describing a loss. The node is formatted as
+// a string for simplicity. The [sites] variable is a list of
+// sites, and records in them, to print out.
+Status residuals_gen_record(const unified_site& site,
+                            const bcf_hdr_t *gl_hdr,
+                            const bcf1_t *gl_call,
+                            const std::vector<DatasetSiteInfo> &sites,
+                            const MetadataCache& cache,
+                            const std::vector<std::string>& samples,
+                            std::string &ynode);
 
-public:
-    // constructor
-    Residuals(const MetadataCache& cache, BCFData& data,
-              const std::string& sampleset, const std::vector<std::string>& samples) :
-        cache_(cache), data_(data), sampleset_(sampleset), samples_(samples)
-        {}
-
-    // destructor
-    ~Residuals();
-
-    // Create a Residuals object
-    static Status Open(const MetadataCache& cache, BCFData& data,
-                       const std::string& sampleset, const std::vector<std::string>& samples,
-                       std::unique_ptr<Residuals> &ans);
-
-    // Create a YAML node describing a loss. The node is formatted as
-    // a string for simplicity. The [sites] variable is a list of
-    // sites, and records in them, to print out.
-    Status gen_record(const unified_site& site,
-                      const bcf_hdr_t *gl_hdr,
-                      const bcf1_t *gl_call,
-                      const std::vector<DatasetSiteInfo> &sites,
-                      std::string &ynode);
-};
 
 class ResidualsFile {
 private:

--- a/include/residuals.h
+++ b/include/residuals.h
@@ -8,6 +8,13 @@
 
 namespace GLnexus {
 
+// Dataset and the records it has for a particular site
+struct DatasetSiteInfo {
+    std::string name;
+    std::shared_ptr<const bcf_hdr_t> header;
+    std::vector<std::shared_ptr<bcf1_t>> records;
+};
+
 class Residuals {
 private:
     const MetadataCache& cache_;
@@ -28,13 +35,15 @@ public:
     // Create a Residuals object
     static Status Open(const MetadataCache& cache, BCFData& data,
                        const std::string& sampleset, const std::vector<std::string>& samples,
-                       std::unique_ptr<Residuals> &ans);
+                       std::shared_ptr<Residuals> &ans);
 
-    // Create a YAML node describing a loss. The node
-    // is formatted as a string for simplicity.
+    // Create a YAML node describing a loss. The node is formatted as
+    // a string for simplicity. The [sites] variable is a list of
+    // sites, and records in them, to print out.
     Status gen_record(const unified_site& site,
                       const bcf_hdr_t *gl_hdr,
                       const bcf1_t *gl_call,
+                      const std::vector<DatasetSiteInfo> &sites,
                       std::string &ynode);
 };
 
@@ -50,7 +59,7 @@ public:
     // destructor
     ~ResidualsFile();
 
-    static Status Open(std::string filename, std::unique_ptr<ResidualsFile> &ans);
+    static Status Open(std::string filename, std::shared_ptr<ResidualsFile> &ans);
 
     // write a YAML record to the end of the file, as an element in a top-level sequence.
     Status write_record(std::string &rec);

--- a/include/residuals.h
+++ b/include/residuals.h
@@ -35,7 +35,7 @@ public:
     // Create a Residuals object
     static Status Open(const MetadataCache& cache, BCFData& data,
                        const std::string& sampleset, const std::vector<std::string>& samples,
-                       std::shared_ptr<Residuals> &ans);
+                       std::unique_ptr<Residuals> &ans);
 
     // Create a YAML node describing a loss. The node is formatted as
     // a string for simplicity. The [sites] variable is a list of
@@ -59,7 +59,7 @@ public:
     // destructor
     ~ResidualsFile();
 
-    static Status Open(std::string filename, std::shared_ptr<ResidualsFile> &ans);
+    static Status Open(std::string filename, std::unique_ptr<ResidualsFile> &ans);
 
     // write a YAML record to the end of the file, as an element in a top-level sequence.
     Status write_record(std::string &rec);

--- a/src/genotyper.cc
+++ b/src/genotyper.cc
@@ -771,6 +771,7 @@ Status genotype_site(const genotyper_config& cfg, MetadataCache& cache, BCFData&
     merge_loss_stats(losses, losses_for_site);
 
     if (residuals != nullptr && any_losses(losses)) {
+        // Write loss record to the residuals file, useful for offline debugging.
         residual_rec = make_shared<string>();
         Status ls = residuals->gen_record(site, hdr, ans.get(), lost_calls_info, *residual_rec);
     }

--- a/src/genotyper.cc
+++ b/src/genotyper.cc
@@ -575,15 +575,6 @@ static Status translate_genotypes(const genotyper_config& cfg, const unified_sit
     return Status::OK();
 }
 
-// Figure out if there were any losses reported for this site
-static bool any_losses(consolidated_loss &losses_for_site) {
-    for (auto ls_pair : losses_for_site) {
-        loss_stats &ls = ls_pair.second;
-        if (ls.n_calls_lost > 0) return true;
-    }
-    return false;
-}
-
 
 Status genotype_site(const genotyper_config& cfg, MetadataCache& cache, BCFData& data, const unified_site& site,
                      const std::string& sampleset, const vector<string>& samples,
@@ -769,7 +760,8 @@ Status genotype_site(const genotyper_config& cfg, MetadataCache& cache, BCFData&
     }
     merge_loss_stats(losses, losses_for_site);
 
-    if (residuals != nullptr && any_losses(losses)) {
+    if (residuals != nullptr &&
+        !lost_calls_info.empty()) {
         // Write loss record to the residuals file, useful for offline debugging.
         residual_rec = make_shared<string>();
         S(residuals->gen_record(site, hdr, ans.get(), lost_calls_info, *residual_rec));

--- a/src/residuals.cc
+++ b/src/residuals.cc
@@ -17,22 +17,13 @@ static string concat(const std::vector<std::string>& samples) {
 }
 
 
-// destructor
-Residuals::~Residuals() {}
-
-Status Residuals::Open(const MetadataCache& cache, BCFData& data,
-                       const std::string& sampleset, const std::vector<std::string>& samples,
-                       unique_ptr<Residuals> &ans) {
-    ans = make_unique<Residuals>(cache, data, sampleset, samples);
-    return Status::OK();
-}
-
-
-Status Residuals::gen_record(const unified_site& site,
-                             const bcf_hdr_t *gl_hdr,
-                             const bcf1_t *gl_call,
-                             const std::vector<DatasetSiteInfo> &sites,
-                             std::string &ynode) {
+Status residuals_gen_record(const unified_site& site,
+                            const bcf_hdr_t *gl_hdr,
+                            const bcf1_t *gl_call,
+                            const std::vector<DatasetSiteInfo> &sites,
+                            const MetadataCache& cache,
+                            const std::vector<std::string>& samples,
+                            std::string &ynode) {
     Status s;
     YAML::Emitter out;
     out << YAML::BeginMap;
@@ -61,13 +52,13 @@ Status Residuals::gen_record(const unified_site& site,
 
     // write the unified site
     out << YAML::Key << "unified_site";
-    const auto& contigs = cache_.contigs();
+    const auto& contigs = cache.contigs();
     S(site.yaml(contigs, out));
 
 
     // write the output bcf, the calls that GLnexus made. Also, add the samples matching the calls.
     out << YAML::Key << "output_vcf";
-    out << YAML::Literal << concat(samples_) + "\n" + *(bcf1_to_string(gl_hdr, gl_call));
+    out << YAML::Literal << concat(samples) + "\n" + *(bcf1_to_string(gl_hdr, gl_call));
 
     out << YAML::EndMap;
 

--- a/src/residuals.cc
+++ b/src/residuals.cc
@@ -41,11 +41,6 @@ Status Residuals::gen_record(const unified_site& site,
     out << YAML::Key << "body";
     out << YAML::BeginSeq;
 
-    // We can't increase the range here, because we just have the original records.
-//    range pos = site.pos;
-//    if (pos.beg > 0) pos.beg--;
-//    pos.end++; // pad the query +/- 1bp to show context
-
     // for each pertinent dataset
     for (const auto& ds_info : sites) {
         if (ds_info.records.size() == 0)

--- a/src/residuals.cc
+++ b/src/residuals.cc
@@ -22,8 +22,8 @@ Residuals::~Residuals() {}
 
 Status Residuals::Open(const MetadataCache& cache, BCFData& data,
                        const std::string& sampleset, const std::vector<std::string>& samples,
-                       shared_ptr<Residuals> &ans) {
-    ans = make_shared<Residuals>(cache, data, sampleset, samples);
+                       unique_ptr<Residuals> &ans) {
+    ans = make_unique<Residuals>(cache, data, sampleset, samples);
     return Status::OK();
 }
 
@@ -86,8 +86,8 @@ ResidualsFile::~ResidualsFile() {
 
 
 Status ResidualsFile::Open(std::string filename,
-                           std::shared_ptr<ResidualsFile> &ans) {
-    ans = make_shared<ResidualsFile>(filename);
+                           std::unique_ptr<ResidualsFile> &ans) {
+    ans = make_unique<ResidualsFile>(filename);
 
     // Note: we open in truncate mode, to erase the existing file, if any.
     // This avoids confusing results of old runs, with the current run, in case of failure.

--- a/src/service.cc
+++ b/src/service.cc
@@ -410,8 +410,8 @@ Status Service::genotype_sites(const genotyper_config& cfg, const string& sample
     S(BCFFileSink::Open(cfg, filename, hdr.get(), bcf_out));
 
     // set up the residuals file
-    shared_ptr<Residuals> residuals = nullptr;
-    shared_ptr<ResidualsFile> residualsFile = nullptr;
+    unique_ptr<Residuals> residuals = nullptr;
+    unique_ptr<ResidualsFile> residualsFile = nullptr;
     string res_filename;
     if (filename != "-" && filename.find(".") > 0) {
         int lastindex = filename.find_last_of(".");
@@ -444,7 +444,7 @@ Status Service::genotype_sites(const genotyper_config& cfg, const string& sample
             consolidated_loss losses_for_site;
             Status ls = genotype_site(cfg, *(body_->metadata_), body_->data_, sites[i],
                                       sampleset, sample_names, hdr.get(), bcf, losses_for_site,
-                                      residuals, residual_rec,
+                                      residuals.get(), residual_rec,
                                       &abort);
             if (ls.bad()) {
                 return ls;

--- a/src/service.cc
+++ b/src/service.cc
@@ -410,7 +410,6 @@ Status Service::genotype_sites(const genotyper_config& cfg, const string& sample
     S(BCFFileSink::Open(cfg, filename, hdr.get(), bcf_out));
 
     // set up the residuals file
-    unique_ptr<Residuals> residuals = nullptr;
     unique_ptr<ResidualsFile> residualsFile = nullptr;
     string res_filename;
     if (filename != "-" && filename.find(".") > 0) {
@@ -421,7 +420,6 @@ Status Service::genotype_sites(const genotyper_config& cfg, const string& sample
         res_filename = "/tmp/residuals.yml";
     }
     if (cfg.output_residuals) {
-        S(Residuals::Open(*(body_->metadata_), body_->data_, sampleset, sample_names, residuals));
         S(ResidualsFile::Open(res_filename, residualsFile));
     }
 
@@ -444,7 +442,7 @@ Status Service::genotype_sites(const genotyper_config& cfg, const string& sample
             consolidated_loss losses_for_site;
             Status ls = genotype_site(cfg, *(body_->metadata_), body_->data_, sites[i],
                                       sampleset, sample_names, hdr.get(), bcf, losses_for_site,
-                                      residuals.get(), residual_rec,
+                                      residualsFile != nullptr, residual_rec,
                                       &abort);
             if (ls.bad()) {
                 return ls;

--- a/src/service.cc
+++ b/src/service.cc
@@ -391,15 +391,6 @@ public:
     }
 };
 
-// Figure out if there were any losses reported for this site
-static bool any_losses(consolidated_loss &losses_for_site) {
-    for (auto ls_pair : losses_for_site) {
-        loss_stats &ls = ls_pair.second;
-        if (ls.n_calls_lost > 0) return true;
-    }
-    return false;
-}
-
 Status Service::genotype_sites(const genotyper_config& cfg, const string& sampleset,
                                const vector<unified_site>& sites,
                                const string& filename, consolidated_loss& dlosses,
@@ -419,8 +410,8 @@ Status Service::genotype_sites(const genotyper_config& cfg, const string& sample
     S(BCFFileSink::Open(cfg, filename, hdr.get(), bcf_out));
 
     // set up the residuals file
-    unique_ptr<Residuals> residuals = nullptr;
-    unique_ptr<ResidualsFile> residualsFile = nullptr;
+    shared_ptr<Residuals> residuals = nullptr;
+    shared_ptr<ResidualsFile> residualsFile = nullptr;
     string res_filename;
     if (filename != "-" && filename.find(".") > 0) {
         int lastindex = filename.find_last_of(".");
@@ -448,24 +439,15 @@ Status Service::genotype_sites(const genotyper_config& cfg, const string& sample
                 abort = true;
                 return Status::Aborted();
             }
+            shared_ptr<string> residual_rec = nullptr;
             shared_ptr<bcf1_t> bcf;
             consolidated_loss losses_for_site;
             Status ls = genotype_site(cfg, *(body_->metadata_), body_->data_, sites[i],
                                       sampleset, sample_names, hdr.get(), bcf, losses_for_site,
+                                      residuals, residual_rec,
                                       &abort);
             if (ls.bad()) {
                 return ls;
-            }
-
-            shared_ptr<string> residual_rec = nullptr;
-            if (residuals != nullptr &&
-                any_losses(losses_for_site)) {
-                // create a residuals loss record
-                residual_rec = make_shared<string>();
-                ls = residuals->gen_record(sites[i], hdr.get(), bcf.get(), *residual_rec);
-                if (ls.bad()) {
-                    return ls;
-                }
             }
 
             results[i] = make_tuple(move(bcf), losses_for_site, residual_rec);


### PR DESCRIPTION
Using a single pass to generate genotype calls, as well as residual records. This implements:
1. The default residuals mode, where only lost calls are reported
2. Does not report on a larger range than the loss records