### PR TITLE
relax unifier so that alleles at a site needn't all overlap all others

### DIFF
--- a/test/data/gvcf_test_cases/join_records_incomplete_span.yml
+++ b/test/data/gvcf_test_cases/join_records_incomplete_span.yml
@@ -36,8 +36,8 @@ input:
 
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1002}
-      alleles: [TTC, T, ATC]
-      copy_number: [0, 2, 1]
+      alleles: [TTC, T, ATC, TTG]
+      copy_number: [0, 2, 1, 1]
       unification:
         - range: {beg: 1000, end: 1002}
           alt: TTC
@@ -54,6 +54,9 @@ truth_unified_sites:
         - range: {beg: 1000, end: 1000}
           alt: A
           to: 2
+        - range: {beg: 1002, end: 1002}
+          alt: G
+          to: 3
 
 truth_output_vcf:
   - truth.vcf: |
@@ -63,4 +66,4 @@ truth_output_vcf:
       ##FORMAT=<ID=RNC,Number=G,Type=Character,Description="Reason for No Call in GT: . = n/a, M = Missing data, P = Partial data, D = insufficient Depth of coverage, - = unrepresentable overlapping deletion, L = Lost/unrepresentable allele (other than deletion), U = multiple Unphased variants present, O = multiple Overlapping variants present">
       ##contig=<ID=A,length=1000000>
       #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	A	B	C	D
-      A	1000	.	TTC	T,ATC	0	.	.	GT:RNC	./.:PP	0/1:..	0/1:..	./.:PP
+      A	1000	.	TTC	T,ATC,TTG	0	.	.	GT:RNC	./.:PP	0/1:..	0/1:..	./.:PP

--- a/test/data/gvcf_test_cases/join_records_unjoinable.yml
+++ b/test/data/gvcf_test_cases/join_records_unjoinable.yml
@@ -39,8 +39,8 @@ input:
 
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1002}
-      alleles: [TTC, T, ATC]
-      copy_number: [0, 2, 1]
+      alleles: [TTC, T, ATC, TTG]
+      copy_number: [0, 2, 1, 1]
       unification:
         - range: {beg: 1000, end: 1002}
           alt: TTC
@@ -57,6 +57,9 @@ truth_unified_sites:
         - range: {beg: 1000, end: 1000}
           alt: A
           to: 2
+        - range: {beg: 1002, end: 1002}
+          alt: G
+          to: 3
 
 truth_output_vcf:
   - truth.vcf: |
@@ -66,4 +69,4 @@ truth_output_vcf:
       ##FORMAT=<ID=RNC,Number=G,Type=Character,Description="Reason for No Call in GT: . = n/a, M = Missing data, P = Partial data, D = insufficient Depth of coverage, - = unrepresentable overlapping deletion, L = Lost/unrepresentable allele (other than deletion), U = multiple Unphased variants present, O = multiple Overlapping variants present">
       ##contig=<ID=A,length=1000000>
       #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	A	B	C	D
-      A	1000	.	TTC	T,ATC	0	.	.	GT:RNC	0/0:..	0/1:..	0/1:..	./.:UU
+      A	1000	.	TTC	T,ATC,TTG	0	.	.	GT:RNC	0/0:..	0/1:..	0/1:..	./.:UU

--- a/test/data/gvcf_test_cases/rs11429009.yml
+++ b/test/data/gvcf_test_cases/rs11429009.yml
@@ -1,0 +1,70 @@
+readme: |
+
+  A tricky case for the allele unifier where the minimized alleles don't all
+  overlap; at one point we would prune rs11429009 unnecessarily, but this has
+  been relaxed.
+
+input:
+  header: |-
+      ##fileformat=VCFv4.2
+      ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+      ##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+      ##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+      ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+      ##FORMAT=<ID=SB,Number=4,Type=Integer,Description="Per-sample component statistics which comprise the Fisher's Exact Test to detect strand bias.">
+      ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
+      ##FORMAT=<ID=MIN_DP,Number=1,Type=Integer,Description="Minimum DP observed within the GVCF block">
+      ##FILTER=<ID=PASS,Description="All filters passed">
+      ##INFO=<ID=END,Number=1,Type=Integer,Description="Stop position of the interval">
+      ##contig=<ID=17,length=20000000>
+      #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT
+  body:
+    - A.gvcf: |
+        A
+        17	15643313	.	T	<NON_REF>	.	.	END=15643380	GT:DP:GQ:MIN_DP:PL	0/0:48:99:28:0,78,1170
+        17	15643381	rs58354673	CA	C,CAA,<NON_REF>	1047.73	.	.	GT:AD:DP:GQ:PL:SB	0/1:32,47,3,0:82:99:1085,0,781,1220,723,2322,1182,805,2018,1979:21,11,35,12
+        17	15643383	.	A	<NON_REF>	.	.	END=15643383	GT:DP:GQ:MIN_DP:PL	0/0:100:0:100:0,0,170
+    - B.gvcf: |
+        B
+        17	15643315	.	A	<NON_REF>	.	.	END=15643380	GT:DP:GQ:MIN_DP:PL	0/0:42:99:22:0,63,945
+        17	15643381	rs58354673	CA	C,CAA,<NON_REF>	871.73	.	.	GT:AD:DP:GQ:PL:SB	0/1:33,40,2,0:75:99:909,0,756,1046,774,2146,996,828,1865,1813:21,12,32,8
+        17	15643383	.	A	<NON_REF>	.	.	END=15643383	GT:DP:GQ:MIN_DP:PL	0/0:87:0:87:0,0,209
+    - C.gvcf: |
+        C
+        17	15643314	.	G	<NON_REF>	.	.	END=15643380	GT:DP:GQ:MIN_DP:PL	0/0:41:99:21:0,60,900
+        17	15643381	rs58354673	CA	C,CAA,<NON_REF>	25.74	.	.	GT:AD:DP:GQ:PL:SB	0/2:66,3,11,0:80:63:63,212,1978,0,1577,1628,259,1865,1639,1897:54,12,9,2
+        17	15643383	.	A	<NON_REF>	.	.	END=15643563	GT:DP:GQ:MIN_DP:PL	0/0:96:99:39:0,93,1395
+    - D.gvcf: |
+        D
+        17	15643313	.	T	<NON_REF>	.	.	END=15643381	GT:DP:GQ:MIN_DP:PL	0/0:44:99:23:0,66,889
+        17	15643382	rs11429009	A	AC,<NON_REF>	354.73	.	.	GT:AD:DP:GQ:PL:SB	0/1:48,22,0:70:99:392,0,1494,537,1560,2096:42,6,17,5
+        17	15643383	.	A	<NON_REF>	.	.	END=15643383	GT:DP:GQ:MIN_DP:PL	0/0:82:0:82:0,0,784
+truth_unified_sites:
+    - range: {ref: 17, beg: 15643381, end: 15643382}
+      alleles: [CA, C, CAA, CAC]
+      copy_number: [0, 2, 1, 1]
+      unification:
+      - range: {beg: 15643381, end: 15643382}
+        alt: CA
+        to: 0
+      - range: {beg: 15643382, end: 15643382}
+        alt: A
+        to: 0
+      - range: {beg: 15643381, end: 15643382}
+        alt: C
+        to: 1
+      - range: {beg: 15643381, end: 15643382}
+        alt: CAA
+        to: 2
+      - range: {beg: 15643382, end: 15643382}
+        alt: AC
+        to: 3
+truth_output_vcf:
+  - truth.vcf: |
+      ##fileformat=VCFv4.2
+      ##FILTER=<ID=PASS,Description="All filters passed">
+      ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+      ##FORMAT=<ID=RNC,Number=G,Type=Character,Description="Reason for No Call in GT: . = n/a, M = Missing data, P = Partial data, D = insufficient Depth of coverage, - = unrepresentable overlapping deletion, L = Lost/unrepresentable allele (other than deletion), U = multiple Unphased variants present, O = multiple Overlapping variants present">
+      ##contig=<ID=17,length=20000000>
+      #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	A	B	C	D
+      17	15643381	.	CA	C,CAA,CAC	0	.	.	GT:RNC	0/1:..	0/1:..	0/2:..	0/3:..

--- a/test/gvcf_test_cases.cc
+++ b/test/gvcf_test_cases.cc
@@ -623,3 +623,7 @@ TEST_CASE("min_allele_copy_number") {
 TEST_CASE("rs141305015") {
     GVCFTestCase("rs141305015").perform_gvcf_test();
 }
+
+TEST_CASE("rs11429009 allele unifier test") {
+    GVCFTestCase("rs11429009").perform_gvcf_test();
+}


### PR DESCRIPTION
This should be safe as long as the genotyper will not create phase assertions spanning multiple variant records in one sample

There is however a weird side effect, that it's possible in rare cases that a reference-padded ALT allele will be listed in the unified site that's not clearly observed in the cohort. Specifically, consider one sample with two A>G heterozygous SNPs adjacent to each other, which the variant caller doesn't phase for whatever reason. Suppose also there's some other sample with a TT dinucleotide substitution there. We'll compute ALT alleles of TT,GA,AG but we can't actually be sure GA and AG are extant haplotypes (it could instead be GG). In the end we will not emit an perilous genotype for the sample with the two SNPs, though (we'll no calls with RNC Unphased), so these are relatively harmless appendages.