### PR TITLE
Orodeh malloc static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,11 @@ MARK_AS_ADVANCED(
 
 # Compilation for performance profiling
 SET(CMAKE_CXX_FLAGS_PROFILE
-    "-g3 -ggdb -O2 -DNDEBUG -fno-omit-frame-pointer -funwind-tables -fasynchronous-unwind-tables"
+    "-gdwarf -O2 -DNDEBUG -funwind-tables -fasynchronous-unwind-tables"
     CACHE STRING "Flags used by the C++ compiler during performance profiling builds."
     FORCE )
 SET(CMAKE_C_FLAGS_PROFILE
-    "-g3 -ggdb -O2 -DNDEBUG -fno-omit-frame-pointer -funwind-tables -fasynchronous-unwind-tables"
+    "-gdwarf -O2 -DNDEBUG -funwind-tables -fasynchronous-unwind-tables"
     CACHE STRING "Flags used by the C compiler during performance profiling builds."
     FORCE )
 SET(CMAKE_EXE_LINKER_FLAGS_PROFILE
@@ -205,7 +205,8 @@ add_dependencies(glnexus CTPL)
 add_dependencies(glnexus fcmm)
 add_library(libglnexus ALIAS glnexus)
 
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++ -march=ivybridge")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -march=ivybridge")
+#set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++ -march=ivybridge")
 
 add_executable(playground src/playground.cc)
 add_dependencies(playground libglnexus)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,16 +205,16 @@ add_dependencies(glnexus CTPL)
 add_dependencies(glnexus fcmm)
 add_library(libglnexus ALIAS glnexus)
 
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++ -march=ivybridge")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -march=ivybridge -static-libstdc++ -pthread")
 
 add_executable(playground src/playground.cc)
 add_dependencies(playground libglnexus)
-target_link_libraries(playground -pthread jemalloc glnexus libhts z librocksdb libyaml-cpp)
+target_link_libraries(playground glnexus libhts librocksdb libyaml-cpp libz.a libsnappy.a libbz2.a liblz4.a librt.a)
 
 add_executable(glnexus_cli cli/glnexus_cli.cc test/compare_iter.cc)
 add_dependencies(glnexus_cli libglnexus)
 add_dependencies(glnexus_cli spdlog)
-target_link_libraries(glnexus_cli -pthread jemalloc glnexus libhts z librocksdb libyaml-cpp snappy bz2 lz4 rt)
+target_link_libraries(glnexus_cli glnexus libhts librocksdb libyaml-cpp libz.a libsnappy.a libbz2.a liblz4.a librt.a)
 
 install(TARGETS playground DESTINATION bin)
 
@@ -252,7 +252,7 @@ if (test)
                  test/compare_iter.cc
                  test/unifier.cc)
   add_dependencies(unit_tests libglnexus)
-  target_link_libraries(unit_tests glnexus librocksdb -pthread jemalloc libhts rt snappy z bz2 lz4 rt libyaml-cpp)
+  target_link_libraries(unit_tests glnexus libhts librocksdb libyaml-cpp libz.a libsnappy.a libbz2.a liblz4.a librt.a)
 
   add_test(unit_tests unit_tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,11 @@ MARK_AS_ADVANCED(
 
 # Compilation for performance profiling
 SET(CMAKE_CXX_FLAGS_PROFILE
-    "-gdwarf -O2 -DNDEBUG -funwind-tables -fasynchronous-unwind-tables"
+    "-gdwarf -O3 -DNDEBUG"
     CACHE STRING "Flags used by the C++ compiler during performance profiling builds."
     FORCE )
 SET(CMAKE_C_FLAGS_PROFILE
-    "-gdwarf -O2 -DNDEBUG -funwind-tables -fasynchronous-unwind-tables"
+    "-gdwarf -O3 -DNDEBUG"
     CACHE STRING "Flags used by the C compiler during performance profiling builds."
     FORCE )
 SET(CMAKE_EXE_LINKER_FLAGS_PROFILE
@@ -64,7 +64,7 @@ ExternalProject_Add(htslib
     URL https://github.com/samtools/htslib/archive/1.2.1.zip
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external
     CONFIGURE_COMMAND ""
-    PATCH_COMMAND sed -i "s/^CFLAGS .*$/CFLAGS = -g3 -ggdb -O2 -DNDEBUG -fno-omit-frame-pointer -funwind-tables -fasynchronous-unwind-tables -march=ivybridge/" Makefile
+    PATCH_COMMAND sed -i "s/^CFLAGS .*$/CFLAGS = -gdwarf -O3 -DNDEBUG -march=ivybridge/" Makefile
     BUILD_IN_SOURCE 1
     BUILD_COMMAND bash -c "make -n && make -j8"
     INSTALL_COMMAND ""
@@ -205,8 +205,7 @@ add_dependencies(glnexus CTPL)
 add_dependencies(glnexus fcmm)
 add_library(libglnexus ALIAS glnexus)
 
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -march=ivybridge")
-#set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++ -march=ivybridge")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++ -march=ivybridge")
 
 add_executable(playground src/playground.cc)
 add_dependencies(playground libglnexus)

--- a/cli/dxapplet/Makefile
+++ b/cli/dxapplet/Makefile
@@ -1,5 +1,5 @@
 all:
-	cd ../.. && cmake -DCMAKE_BUILD_TYPE=Release -Dtest=ON && make -j4 && ./unit_tests
+	cd ../.. && cmake -DCMAKE_BUILD_TYPE=Profile -Dtest=ON && make -j4 && ./unit_tests
 	cp ../../glnexus_cli resources/usr/local/bin/
 
 .PHONY: all

--- a/cli/dxapplet/Makefile
+++ b/cli/dxapplet/Makefile
@@ -1,5 +1,5 @@
 all:
-	cd ../.. && cmake -DCMAKE_BUILD_TYPE=Profile -Dtest=ON && make -j4 && ./unit_tests
+	cd ../.. && cmake -DCMAKE_BUILD_TYPE=Release -Dtest=ON && make -j4 && ./unit_tests
 	cp ../../glnexus_cli resources/usr/local/bin/
 
 .PHONY: all

--- a/cli/dxapplet/dxapp.json
+++ b/cli/dxapplet/dxapp.json
@@ -116,8 +116,6 @@
     "interpreter": "bash",
     "file": "src/code.sh",
     "execDepends": [
-      {"name": "liblz4-dev"},
-      {"name": "libsnappy-dev"},
       {"name": "sysstat"},
       {"name": "numactl"},
       {"name": "libjemalloc1"}

--- a/cli/dxapplet/dxapp.json
+++ b/cli/dxapplet/dxapp.json
@@ -119,7 +119,8 @@
       {"name": "liblz4-dev"},
       {"name": "libsnappy-dev"},
       {"name": "sysstat"},
-      {"name": "numactl"}
+      {"name": "numactl"},
+      {"name": "libjemalloc1"}
     ],
     "systemRequirements": {
       "main": {

--- a/cli/dxapplet/src/code.sh
+++ b/cli/dxapplet/src/code.sh
@@ -44,6 +44,8 @@ main() {
         rm -f perf.data
     fi
 
+    # Make sure jemalloc replaced the default malloc implementation, for
+    # all C/C++ libraries
     export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
 
     # download inputs.

--- a/cli/dxapplet/src/code.sh
+++ b/cli/dxapplet/src/code.sh
@@ -18,15 +18,12 @@ main() {
         enable_perf=true
     fi
 
-    if [ "$enable_perf" == "true" ]; then
-        apt_get_add_debug_repos
-    fi
-
     # We want to have visibility into kernel symbols. This is under a
     # special flag, because normally, we do not have the right
     # permissions in a platform container. We do this first, so, if there
     # are any permission problems, we will fail early.
     if [ "$enable_kernel_perf" == "true" ]; then
+        apt_get_add_debug_repos
         install_kernel_debug_symbols
     fi
 

--- a/cli/dxapplet/src/code.sh
+++ b/cli/dxapplet/src/code.sh
@@ -13,16 +13,6 @@ main() {
     dstat -cmdn 60 &
     iostat -x 600 &
 
-    # update standard C/C++ libraries, to match gcc-5
-    # the standard C++ library has to be version
-    # 3.4.20 or above
-    #
-    sudo apt-get -y -qq install libstdc++6
-    sudo add-apt-repository --yes -s ppa:ubuntu-toolchain-r/test
-    sudo apt-get -y -qq update || true
-    #sudo apt-get upgrade
-    sudo apt-get -y -qq upgrade libstdc++6
-
     # Kernel tracing implies user-space space tracing
     if [ "$enable_kernel_perf" == "true" ]; then
         enable_perf=true
@@ -52,15 +42,9 @@ main() {
         # test that perf is working correctly
         perf record -F $recordFreq -g /bin/ls
         rm -f perf.data
-
-        # Use libraries with debugging symbols, if they exist.
-        # This allows tracing the C++ standard library.
-        sudo apt-get -y -qq install libjemalloc1-dbg
-        sudo apt-get -y -qq install libstdc++6-dbgsym
-        sudo apt-get -y -qq install libc6-dbg
-        sudo apt-get -y -qq install libgcc1-dbg
-        export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/debug
     fi
+
+    export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
 
     # download inputs.
     # TODO: it would be nice to overlap the staging of the input gVCFs with
@@ -123,7 +107,7 @@ main() {
             # Run a perf command that will record everything the
             # machine is doing, this allows tracking down all activity,
             mkdir -p out/perf
-            sudo perf record -F $recordFreq -a -g &
+            sudo perf record -F $recordFreq -a --call-graph dwarf &
             perf_pid=$!
         fi
 

--- a/cli/dxapplet/src/code.sh
+++ b/cli/dxapplet/src/code.sh
@@ -13,6 +13,16 @@ main() {
     dstat -cmdn 60 &
     iostat -x 600 &
 
+    # update standard C/C++ libraries, to match gcc-5
+    # the standard C++ library has to be version
+    # 3.4.20 or above
+    #
+    sudo apt-get -y -qq install libstdc++6
+    sudo add-apt-repository --yes -s ppa:ubuntu-toolchain-r/test
+    sudo apt-get -y -qq update || true
+    #sudo apt-get upgrade
+    sudo apt-get -y -qq upgrade libstdc++6
+
     # Kernel tracing implies user-space space tracing
     if [ "$enable_kernel_perf" == "true" ]; then
         enable_perf=true

--- a/perf/run_standalone_glnexus.sh
+++ b/perf/run_standalone_glnexus.sh
@@ -40,6 +40,7 @@ sudo perf record -F $recordFreq -a -g &
 perf_pid=$!
 
 # Use debugging symbols
+#export LD_PRELOAD_PATH=
 export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/debug
 time numactl --interleave=all glnexus_cli genotype GLnexus.db --config test -t $(nproc) --bed ranges.bed | bcftools view - | bgzip -c > out/matches.vcf.gz
 

--- a/perf/run_standalone_glnexus.sh
+++ b/perf/run_standalone_glnexus.sh
@@ -35,13 +35,15 @@ dstat_pid=$!
 iostat -x 60 &
 iostat_pid=$!
 
+
+
 mkdir -p out/perf
-sudo perf record -F $recordFreq -a -g &
+sudo perf record -F $recordFreq -a --call-graph dwarf &
 perf_pid=$!
 
-# Use debugging symbols
-#export LD_PRELOAD_PATH=
-export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/debug
+# Make sure jemalloc replaced the default malloc implementation, for
+# all C/C++ libraries
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
 time numactl --interleave=all glnexus_cli genotype GLnexus.db --config test -t $(nproc) --bed ranges.bed | bcftools view - | bgzip -c > out/matches.vcf.gz
 
 


### PR DESCRIPTION
Mike, please take a look. This branch includes:
1.A cleanup of the profiling flags and packages
2. Using jemalloc for all allocations, includes those from stdlibc++

We could try the malloc-hooks approach instead, if you think that's better. 

Thanks,
      Ohad. 
