### PR TITLE
adjust assumptions about gVCF symbolic alleles

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -434,9 +434,6 @@ struct genotyper_config {
     /// FORMAT field to consult for per-allele depth in VCF records
     std::string allele_dp_format = "AD";
 
-    /// The symbolic allele used in gVCF reference confidence models
-    std::string ref_symbolic_allele = "<NON_REF>";
-
     /// FORMAT field to consult for reference depth in gVCF reference records
     std::string ref_dp_format = "MIN_DP";
 

--- a/include/types.h
+++ b/include/types.h
@@ -476,6 +476,13 @@ template<class T> struct htsvecbox {
     }
 };
 
+// test string against <.*>
+bool is_symbolic_allele(const char*);
+
+/// Determine whether the given record is a gVCF reference confidence record
+/// (or else a "normal" record with at least one specific ALT allele)
+bool is_gvcf_ref_record(const bcf1_t* record);
+
 // Predicate function used for filtering BCF records, as they are read from the database.
 // [retval] is set to true, for any record that passes the test.
 //

--- a/src/genotyper.cc
+++ b/src/genotyper.cc
@@ -14,12 +14,6 @@ using namespace std;
 // GT (and RNC for accountability). Also it assumes diploid.
 namespace GLnexus {
 
-/// Determine whether the given record is a gVCF reference confidence record
-/// (or else a "normal" record with at least one specific ALT allele)
-static bool is_gvcf_ref_record(const genotyper_config& cfg, const bcf1_t* record) {
-    return record->n_allele == 2 && strcmp(record->d.allele[1], cfg.ref_symbolic_allele.c_str()) == 0;
-}
-
 /// Detect an idiosyncratic class of records from certain HaplotypeCaller
 /// versions which have QUAL == 0.0 and 0/0 genotype calls...we treat these as
 /// "pseudo" reference confidence records.
@@ -390,7 +384,7 @@ public:
         n_sample_ = record->n_sample;
         n_allele_ = record->n_allele;
         // is this a gVCF reference confidence record?
-        is_g_ = is_gvcf_ref_record(cfg_, record);
+        is_g_ = is_gvcf_ref_record(record);
 
         if (is_g_) {
             // if so, look for the MIN_DP FORMAT field (or equivalent)
@@ -577,7 +571,7 @@ Status find_variant_records(const genotyper_config& cfg, const unified_site& sit
     vector<shared_ptr<bcf1_t>> ref_records;
     ref_records.reserve(records.size());
     for (auto& record : records) {
-        (is_gvcf_ref_record(cfg, record.get()) || is_pseudo_ref_record(hdr, record.get())
+        (is_gvcf_ref_record(record.get()) || is_pseudo_ref_record(hdr, record.get())
             ? ref_records : variant_records).push_back(record);
     }
 

--- a/src/genotyper.cc
+++ b/src/genotyper.cc
@@ -746,7 +746,7 @@ Status genotype_site(const genotyper_config& cfg, MetadataCache& cache, BCFData&
 
     shared_ptr<const set<string>> samples2, datasets;
     vector<unique_ptr<RangeBCFIterator>> iterators;
-    S(data.sampleset_range(cache, sampleset, site.pos, 0,
+    S(data.sampleset_range(cache, sampleset, site.pos, nullptr,
                            samples2, datasets, iterators));
     assert(samples.size() == samples2->size());
 

--- a/src/service.cc
+++ b/src/service.cc
@@ -190,9 +190,11 @@ Status Service::discover_alleles(const string& sampleset, const range& pos,
     Status s;
 
     // Query for (iterators to) records overlapping pos in all the data sets.
-    // We query with min_alleles=3 to get variant records only (excluding
-    // reference confidence records which have 2 alleles)
+    // We query for variant records only (excluding reference confidence records
+    // which have only a symbolic ALT allele)
     bcf_predicate predicate = [](const bcf_hdr_t* hdr, bcf1_t* bcf, bool &retval) {
+        // bcf_unpack alleles
+        // call some function that determines if the only ALT allele is symbolic
         retval = (bcf->n_allele >= 3);
         return Status::OK();
     };

--- a/src/types.cc
+++ b/src/types.cc
@@ -578,4 +578,15 @@ Status genotyper_config::of_yaml(const YAML::Node& yaml, genotyper_config& ans) 
     return Status::OK();
 }
 
+// regex for a VCF symbolic allele
+static std::regex regex_symbolic_allele("<.*>");
+bool is_symbolic_allele(const char* allele) {
+    return regex_match(allele, regex_symbolic_allele);
+}
+
+// gVCF reference confidence records recognized as having exactly one, symbolic ALT allele
+bool is_gvcf_ref_record(const bcf1_t* record) {
+    return record->n_allele == 2 && is_symbolic_allele(record->d.allele[1]);
+}
+
 } // namespace GLnexus

--- a/src/types.cc
+++ b/src/types.cc
@@ -490,7 +490,6 @@ Status genotyper_config::yaml(YAML::Emitter& ans) const {
 
     ans << YAML::Key << "required_dp" << YAML::Value << required_dp;
     ans << YAML::Key << "allele_dp_format" << YAML::Value << allele_dp_format;
-    ans << YAML::Key << "ref_symbolic_allele" << YAML::Value << ref_symbolic_allele;
     ans << YAML::Key << "ref_dp_format" << YAML::Value << ref_dp_format;
     ans << YAML::Key << "output_residuals" << YAML::Value << output_residuals;
 
@@ -531,12 +530,6 @@ Status genotyper_config::of_yaml(const YAML::Node& yaml, genotyper_config& ans) 
     if (n_allele_dp_format) {
         V(n_allele_dp_format.IsScalar(), "invalid allele_dp_format");
         ans.allele_dp_format = n_allele_dp_format.Scalar();
-    }
-
-    const auto n_ref_symbolic_allele = yaml["ref_symbolic_allele"];
-    if (n_ref_symbolic_allele) {
-        V(n_ref_symbolic_allele.IsScalar(), "invalid ref_symbolic_allele");
-        ans.ref_symbolic_allele = n_ref_symbolic_allele.Scalar();
     }
 
     const auto n_ref_dp_format = yaml["ref_dp_format"];


### PR DESCRIPTION
Accommodate variant callers that only include the catch-all symbolic allele (`<*>`/`<NON_REF>`) in reference confidence records and not variant records.