### PR TITLE
Revised methods for quality thresholding during allele discovery and unification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ add_library(glnexus
             include/data.h src/data.cc
             include/diploid.h src/diploid.cc
             include/service.h src/service.cc
+            include/discovery.h src/discovery.cc
             include/unifier.h src/unifier.cc
             include/genotyper.h src/genotyper.cc
             include/residuals.h src/residuals.cc

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -494,7 +494,7 @@ int main_dump(int argc, char *argv[]) {
 // should reside in some user-modifiable yml file
 const char* config_presets_yml = R"eof(
 unifier_config:
-  minGQ: 60
+  minAQ: 50
 genotyper_config:
   required_dp: 1
   liftover_fields:

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -494,7 +494,7 @@ int main_dump(int argc, char *argv[]) {
 // should reside in some user-modifiable yml file
 const char* config_presets_yml = R"eof(
 unifier_config:
-  min_allele_copy_number: 0.999
+  minGQ: 60
 genotyper_config:
   required_dp: 1
   liftover_fields:

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -494,7 +494,7 @@ int main_dump(int argc, char *argv[]) {
 // should reside in some user-modifiable yml file
 const char* config_presets_yml = R"eof(
 unifier_config:
-  minAQ: 50
+  min_quality: 50
 genotyper_config:
   required_dp: 1
   liftover_fields:

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -494,7 +494,7 @@ int main_dump(int argc, char *argv[]) {
 // should reside in some user-modifiable yml file
 const char* config_presets_yml = R"eof(
 unifier_config:
-  min_allele_copy_number: 0.99
+  min_allele_copy_number: 0.999
 genotyper_config:
   required_dp: 1
   liftover_fields:

--- a/include/diploid.h
+++ b/include/diploid.h
@@ -16,10 +16,12 @@ unsigned alleles_gt(unsigned a1, unsigned a2);
 // Produces a record->n_sample*record->n_allele matrix with an estimate, for
 // each sample, of the copy number of each allele.
 // If PL or GL genotype likelihoods are available, these are used to derive
-// soft estimates of the allele copy numbers, assuming a uniform prior over
-// genotypes.
+// soft estimates of the allele copy numbers. A prior distribution on the genotypes
+// is applied in deriving these estimates, flat across all genotypes except
+// homozygous ref (0/0), which is multiplied by bias00. That is, the prior over
+// genotypes [0/0, 0/1, 1/1, ...] is proportional to [bias00, 1, 1, ..].
 // Otherwise, copy numbers are filled in based on the hard genotype calls.
-Status estimate_allele_copy_number(const bcf_hdr_t* header, bcf1_t *record, std::vector<std::vector<float>>& ans);
+Status estimate_allele_copy_number(const bcf_hdr_t* header, bcf1_t *record, double bias00, std::vector<std::vector<double>>& ans);
 
 namespace trio {
 int mendelian_inconsistencies(int gt_p1, int gt_p2, int gt_ch);

--- a/include/diploid.h
+++ b/include/diploid.h
@@ -22,6 +22,7 @@ unsigned alleles_gt(unsigned a1, unsigned a2);
 // genotypes [0/0, 0/1, 1/1, ...] is proportional to [bias00, 1, 1, ..].
 // Otherwise, copy numbers are filled in based on the hard genotype calls.
 Status estimate_allele_copy_number(const bcf_hdr_t* header, bcf1_t *record, double bias00, std::vector<std::vector<double>>& ans);
+Status bcf_alleles_maxAQ(const bcf_hdr_t* hdr, bcf1_t* record, const std::vector<unsigned>& samples, std::vector<int>& ans);
 
 namespace trio {
 int mendelian_inconsistencies(int gt_p1, int gt_p2, int gt_ch);

--- a/include/diploid.h
+++ b/include/diploid.h
@@ -12,16 +12,10 @@ unsigned genotypes(unsigned n_allele);
 std::pair<unsigned,unsigned> gt_alleles(unsigned gt);
 unsigned alleles_gt(unsigned a1, unsigned a2);
 
-// Estimate allele copy number for each sample from a BCF record.
-// Produces a record->n_sample*record->n_allele matrix with an estimate, for
-// each sample, of the copy number of each allele.
-// If PL or GL genotype likelihoods are available, these are used to derive
-// soft estimates of the allele copy numbers. A prior distribution on the genotypes
-// is applied in deriving these estimates, flat across all genotypes except
-// homozygous ref (0/0), which is multiplied by bias00. That is, the prior over
-// genotypes [0/0, 0/1, 1/1, ...] is proportional to [bias00, 1, 1, ..].
-// Otherwise, copy numbers are filled in based on the hard genotype calls.
-Status estimate_allele_copy_number(const bcf_hdr_t* header, bcf1_t *record, double bias00, std::vector<std::vector<double>>& ans);
+// Find zygosity_by_GQ for each allele based on the GT and GQ of the record in
+// specified samples. (see types.h for the definition of zygosity_by_GQ)
+Status bcf_zygosity_by_GQ(const bcf_hdr_t* header, bcf1_t* record, const std::vector<unsigned>& samples,
+                          std::vector<zygosity_by_GQ>& ans);
 
 // This function finds the maximum AQ of each allele in the record, across the given
 // subset of sample indices. (see types.h for the definition of AQ)

--- a/include/diploid.h
+++ b/include/diploid.h
@@ -22,7 +22,14 @@ unsigned alleles_gt(unsigned a1, unsigned a2);
 // genotypes [0/0, 0/1, 1/1, ...] is proportional to [bias00, 1, 1, ..].
 // Otherwise, copy numbers are filled in based on the hard genotype calls.
 Status estimate_allele_copy_number(const bcf_hdr_t* header, bcf1_t *record, double bias00, std::vector<std::vector<double>>& ans);
+
+// This function finds the maximum AQ of each allele in the record, across the given
+// subset of sample indices. (see types.h for the definition of AQ)
 Status bcf_alleles_maxAQ(const bcf_hdr_t* hdr, bcf1_t* record, const std::vector<unsigned>& samples, std::vector<int>& ans);
+
+// exposed for testing: find alleles' maxAQ for given multi-sample genotype likelihood
+// vector
+Status alleles_maxAQ(unsigned n_allele, unsigned n_sample, const std::vector<unsigned>& samples, const std::vector<double>& gl, std::vector<int>& ans);
 
 namespace trio {
 int mendelian_inconsistencies(int gt_p1, int gt_p2, int gt_ch);

--- a/include/discovery.h
+++ b/include/discovery.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "types.h"
+#include "BCFKeyValueData.h"
+
+// Algorithms used in allele discovery.
+
+namespace GLnexus {
+
+// Discover alleles from a RangeBCFIterator. Records not contained within pos will be ignored.
+Status discover_alleles_from_iterator(const std::set<std::string>& samples,
+                                      const range& pos,
+                                      RangeBCFIterator& iterator,
+                                      discovered_alleles& dsals);
+
+// verify that the discovered_alleles has a REF allele for each ALT allele, and that the REF
+// alleles are all consistent with each other.
+Status discovered_alleles_refcheck(const discovered_alleles& als,
+                                   const std::vector<std::pair<std::string,size_t>>& contigs);
+
+} // namespace GLnexus

--- a/include/types.h
+++ b/include/types.h
@@ -234,16 +234,16 @@ struct allele {
 struct discovered_allele_info {
     bool is_ref;
     float copy_number;
-    int maxGQ;
+    int maxAQ;
 
     bool operator==(const discovered_allele_info& rhs) const noexcept {
-        return is_ref == rhs.is_ref && fabs(copy_number - rhs.copy_number) < 0.0001 && maxGQ == rhs.maxGQ;
+        return is_ref == rhs.is_ref && fabs(copy_number - rhs.copy_number) < 0.0001 && maxAQ == rhs.maxAQ;
     }
     bool operator!=(const discovered_allele_info& rhs) const noexcept { return !(*this == rhs); }
 
     std::string str() const {
         std::ostringstream os;
-        os << "[ is_ref: " << std::boolalpha << is_ref << " copy number: " << copy_number << " maxGQ: " << maxGQ << "]";
+        os << "[ is_ref: " << std::boolalpha << is_ref << " copy number: " << copy_number << " maxAQ: " << maxAQ << "]";
         return os.str();
     }
 };
@@ -334,10 +334,8 @@ struct StatsRangeQuery {
 enum class UnifierPreference { Common, Small };
 
 struct unifier_config {
-    // GQ threshold for allele inclusion: to be included in the unified sites
-    // an allele must, across all the input gVCF records, be hard-called in a
-    // genotype with at least this GQ score.
-    int minGQ = 0;
+    // Allele Quality threshold for consideration of an allele (phred-scaled)
+    int minAQ = 0;
 
     // Keep only alleles with at least this estimated copy number discovered
     // in the cohort. The estimated copy number is a soft estimate based on

--- a/include/types.h
+++ b/include/types.h
@@ -333,7 +333,7 @@ struct unifier_config {
     // in the cohort. The estimated copy number is a soft estimate based on
     // the genotype likelihoods, so setting this somewhere between 0 and 1 can
     // filter out weak singleton observations.
-    float min_allele_copy_number = 0.0;
+    float min_allele_copy_number = 0.5;
 
     /// Maximum number of alleles per unified site; excess alleles will be
     /// pruned. If zero, then no specific limit is enforced.

--- a/include/types.h
+++ b/include/types.h
@@ -234,6 +234,14 @@ struct allele {
 struct discovered_allele_info {
     bool is_ref;
     float copy_number;
+
+    // *Allele Quality (AQ)* of an allele in a VCF genotype call is defined in terms of
+    // the genotype likelihoods as follows: (the maximum likelihood of any genotype
+    // containing an allele / the maximum likelihood of any genotype not containing that
+    // allele), expressed on phred scale and truncated below zero.
+    //
+    // maxAQ is the maximum AQ observed for this allelee across all genotype calls in the
+    // cohort.
     int maxAQ;
 
     bool operator==(const discovered_allele_info& rhs) const noexcept {

--- a/include/types.h
+++ b/include/types.h
@@ -233,6 +233,7 @@ struct allele {
 struct discovered_allele_info {
     bool is_ref;
     float copy_number;
+    int maxGQ;
 
     bool operator==(const discovered_allele_info& rhs) const noexcept { return is_ref == rhs.is_ref && copy_number == rhs.copy_number; }
 
@@ -334,6 +335,10 @@ struct unifier_config {
     // the genotype likelihoods, so setting this somewhere between 0 and 1 can
     // filter out weak singleton observations.
     float min_allele_copy_number = 0.5;
+
+    // Keep only alleles included in an input genotype hard-call with a GQ of
+    // at least this value.
+    int minGQ = 0;
 
     /// Maximum number of alleles per unified site; excess alleles will be
     /// pruned. If zero, then no specific limit is enforced.

--- a/include/types.h
+++ b/include/types.h
@@ -309,7 +309,7 @@ struct discovered_allele_info {
 
     std::string str() const {
         std::ostringstream os;
-        os << "[ is_ref: " << std::boolalpha << is_ref << " copy number: " << zGQ.copy_number() << "]";
+        os << "[ is_ref: " << std::boolalpha << is_ref << " maxAQ: " << maxAQ << " copy number: " << zGQ.copy_number() << "]";
         return os.str();
     }
 };
@@ -400,14 +400,18 @@ struct StatsRangeQuery {
 enum class UnifierPreference { Common, Small };
 
 struct unifier_config {
-    // Allele Quality threshold for consideration of an allele (phred-scaled)
-    int minAQ = 0;
+    // Phred quality score threshold, used in two ways:
+    // 1) minimum Allele Quality in the cohort for the unifier to include an allele
+    // 2) minimum Genotype Quality for an input genotype call to "count" towards
+    //    copy number estimates for the constituent alleles.
+    // All else equal, increasing min_quality will increase specificity and reduce
+    // sensitivity, and also speed up the genotyper (as fewer weak sites will be
+    // considered)
+    int min_quality = 0;
 
     // Keep only alleles with at least this estimated copy number discovered
-    // in the cohort. The estimated copy number is a soft estimate based on
-    // the genotype likelihoods, so setting this somewhere between 0 and 1 can
-    // filter out weak singleton observations.
-    float min_allele_copy_number = 0.5;
+    // in the cohort.
+    int min_allele_copy_number = 1;
 
     /// Maximum number of alleles per unified site; excess alleles will be
     /// pruned. If zero, then no specific limit is enforced.

--- a/include/types.h
+++ b/include/types.h
@@ -250,10 +250,15 @@ struct zygosity_by_GQ {
         memset(&M, 0, sizeof(int)*GQ_BANDS*PLOIDY);
     }
 
-    void add(unsigned zygosity, int GQ) {
+    zygosity_by_GQ(unsigned zygosity, int GQ, unsigned count=1) {
+        memset(&M, 0, sizeof(int)*GQ_BANDS*PLOIDY);
+        add(zygosity, GQ, count);
+    }
+
+    void add(unsigned zygosity, int GQ, unsigned count=1) {
         assert(zygosity >= 1 && zygosity <= PLOIDY);
         unsigned i = std::min(unsigned(std::max(GQ, 0))/10U,GQ_BANDS-1U);
-        M[i][zygosity-1]++;
+        M[i][zygosity-1] += count;
     }
 
     bool operator==(const zygosity_by_GQ& rhs) const {

--- a/include/types.h
+++ b/include/types.h
@@ -301,6 +301,12 @@ struct discovered_allele_info {
         return is_ref == rhs.is_ref && maxAQ == rhs.maxAQ && zGQ == rhs.zGQ;
     }
     bool operator!=(const discovered_allele_info& rhs) const noexcept { return !(*this == rhs); }
+
+    std::string str() const {
+        std::ostringstream os;
+        os << "[ is_ref: " << std::boolalpha << is_ref << " copy number: " << zGQ.copy_number() << "]";
+        return os.str();
+    }
 };
 using discovered_alleles = std::map<allele,discovered_allele_info>;
 Status merge_discovered_alleles(const discovered_alleles& src, discovered_alleles& dest);

--- a/src/BCFKeyValueData.cc
+++ b/src/BCFKeyValueData.cc
@@ -950,11 +950,10 @@ static Status validate_bcf(BCFBucketRange& rangeHelper,
         return Status::Invalid("gVCF contains record above maximum length", filename);
     }
 
-    // verify record ordering is monotonically increasing within a contig
-    if (prev_rid == bcf->rid &&
-        prev_pos >= bcf->pos) {
-        return Status::Invalid("gVCF record ordering is wrong ",
-                               filename + " " + std::to_string(prev_pos) + " >= " + range(bcf).str(contigs));
+    // verify record ordering is non-decreasing within a contig
+    if (prev_rid == bcf->rid && prev_pos > bcf->pos) {
+        return Status::Invalid("gVCF records are out-of-order ",
+                               filename + " " + std::to_string(prev_pos+1) + " >= " + range(bcf).str(contigs));
     }
 
     // verify record does not go over the length of the contig

--- a/src/diploid.cc
+++ b/src/diploid.cc
@@ -59,14 +59,18 @@ Status bcf_zygosity_by_GQ(const bcf_hdr_t* header, bcf1_t* record, const std::ve
 
     for (auto sample : samples) {
         auto sample_gq = gq.empty() ? 0 : gq[sample];
-        auto als = gt_alleles(gt[sample]);
+        auto pres1 = bcf_gt_is_missing(gt[sample*2]), pres2 = bcf_gt_is_missing(gt[sample*2]+1);
+        auto al1 = pres1 ? bcf_gt_allele(gt[sample*2]) : -1;
+        auto al2 = pres2 ? bcf_gt_allele(gt[sample*2+1]) : -1;
 
-        for (int i = 0; i < zygosity_by_GQ::ROWS && sample_gq >= i*10; i++) {
-            if (als.first == als.second) {
-                ans[als.first].M[i][1]++;
-            } else {
-                ans[als.first].M[i][0]++;
-                ans[als.second].M[i][0]++;
+        if (pres1 && pres2 && al1 == al2) {
+            ans[al1].add(2,sample_gq);
+        } else {
+            if (pres1) {
+                ans[al1].add(1,sample_gq);
+            }
+            if (pres2) {
+                ans[al2].add(1,sample_gq);
             }
         }
     }

--- a/src/diploid.cc
+++ b/src/diploid.cc
@@ -21,6 +21,7 @@ unsigned alleles_gt(unsigned i, unsigned j) {
 }
 
 // given a genotype index, return a pair with the indices of the constituent n_allele
+// TODO: memoize for small values of n_allele...
 pair<unsigned,unsigned> gt_alleles(unsigned gt) {
     /*
       0 1 2
@@ -54,7 +55,7 @@ GLnexus::Status bcf_get_genotype_likelihoods(const bcf_hdr_t* header, bcf1_t *re
         }
         return Status::OK();
     }
-
+/*
     // couldn't load PL; try GL
     htsvecbox<float> fgl;
     if (bcf_get_format_float(header, record, "GL", &fgl.v, &fgl.capacity) == record->n_sample*nGT) {
@@ -64,7 +65,7 @@ GLnexus::Status bcf_get_genotype_likelihoods(const bcf_hdr_t* header, bcf1_t *re
         }
         return Status::OK();
     }
-
+*/
     return Status::NotFound();
 }
 
@@ -127,9 +128,7 @@ GLnexus::Status estimate_allele_copy_number(const bcf_hdr_t* header, bcf1_t *rec
 GLnexus::Status alleles_maxAQ(unsigned n_allele, unsigned n_sample, const vector<unsigned>& samples,
                               const vector<double>& gl, vector<int>& ans) {
     unsigned nGT = genotypes(n_allele);
-    if (gl.size() != n_sample*nGT) {
-        return Status::Invalid("alleles_maxAQ");
-    }
+    if (gl.size() != n_sample*nGT) return Status::Invalid("alleles_maxAQ");
     ans.assign(n_allele,0);
 
     for (unsigned i : samples) {

--- a/src/discovery.cc
+++ b/src/discovery.cc
@@ -61,7 +61,10 @@ Status discover_alleles_from_iterator(const set<string>& samples,
                 string aldna(record->d.allele[i]);
                 transform(aldna.begin(), aldna.end(), aldna.begin(), ::toupper);
                 if (aldna.size() > 0 && regex_match(aldna, regex_dna)) {
-                    discovered_allele_info ai({ false, maxAQ[i], zGQ[i] });
+                    discovered_allele_info ai;
+                    ai.is_ref = false;
+                    ai.maxAQ = maxAQ[i];
+                    ai.zGQ = zGQ[i];
                     dsals.insert(make_pair(allele(rng, aldna), ai));
                     any_alt = true;
                 }
@@ -72,7 +75,10 @@ Status discover_alleles_from_iterator(const set<string>& samples,
             transform(refdna.begin(), refdna.end(), refdna.begin(), ::toupper);
             if (refdna.size() > 0 && regex_match(refdna, regex_dna)) {
                 if (any_alt) {
-                    discovered_allele_info ai({ true, maxAQ[0], zGQ[0] });
+                    discovered_allele_info ai;
+                    ai.is_ref = true;
+                    ai.maxAQ = maxAQ[0];
+                    ai.zGQ = zGQ[0];
                     dsals.insert(make_pair(allele(rng, refdna), ai));
                 }
             } else {

--- a/src/discovery.cc
+++ b/src/discovery.cc
@@ -1,0 +1,169 @@
+#include "discovery.h"
+#include "diploid.h"
+
+using namespace std;
+
+namespace GLnexus {
+
+// for each allele, find the max GQ of any hard-call of the allele across the given sample indices
+Status alleles_maxGQ(const bcf_hdr_t* hdr, bcf1_t* record, const vector<unsigned> samples, vector<int>& ans) {
+    auto dataset_nsamples = bcf_hdr_nsamples(hdr);
+    ans.assign(record->n_allele,0);
+
+    htsvecbox<int> gt;
+    htsvecbox<int32_t> gq;
+    int nGT = bcf_get_genotypes(hdr, record, &gt.v, &gt.capacity);
+    if (!gt.v || nGT != 2*dataset_nsamples) return Status::Failure("discover_alleles bcf_get_genotypes");
+    int nGQ = bcf_get_format_int32(hdr, record, "GQ", &gq.v, &gq.capacity);
+
+    if (nGQ != dataset_nsamples) return Status::OK();
+
+    for (unsigned sample : samples) {
+        assert(sample < dataset_nsamples);
+        #define update_maxGQ(ofs) \
+            if (!bcf_gt_is_missing(gt[2*sample+(ofs)])) {  \
+                int al = bcf_gt_allele(gt[2*sample+(ofs)]); \
+                if (al < 0 || al >= record->n_allele) return Status::Failure("discover_alleles bcf_get_genotypes invalid allele"); \
+                ans[al] = std::max(ans[al], gq[sample]); \
+            }
+        update_maxGQ(0)
+        update_maxGQ(1)
+    }
+
+    return Status::OK();
+}
+
+Status discover_alleles_from_iterator(const set<string>& samples,
+                                      const range& pos,
+                                      RangeBCFIterator& iterator,
+                                      discovered_alleles& final_dsals) {
+    Status s;
+
+    // get dataset BCF records
+    string dataset;
+    shared_ptr<const bcf_hdr_t> dataset_header;
+    vector<shared_ptr<bcf1_t>> records;
+    vector<vector<double>> copy_number;
+    while ((s = iterator.next(dataset, dataset_header, records)).ok()) {
+        discovered_alleles dsals;
+        // determine which of the dataset's samples are in the desired sample set
+        // TODO: FCMM-memoize this during the operation
+        size_t dataset_nsamples = bcf_hdr_nsamples(dataset_header.get());
+        vector<unsigned> dataset_relevant_samples;
+        for (unsigned i = 0; i < dataset_nsamples; i++) {
+            if (samples.find(string(bcf_hdr_int2id(dataset_header.get(), BCF_DT_SAMPLE, i))) != samples.end()) {
+                dataset_relevant_samples.push_back(i);
+            }
+        }
+
+        // for each BCF record
+        for (const auto& record : records) {
+            assert(!is_gvcf_ref_record(record.get()));
+            range rng(record);
+            assert(pos.overlaps(rng));
+            if (!pos.contains(rng)) {
+                // Skip records that dangle off the edge of the target range.
+                // The problem is that such alleles could overlap other
+                // alleles not overlapping the target range at all, and that
+                // we therefore won't see in our query. So it wouldn't be safe
+                // for us to make claims about the genotypes of the resulting
+                // sites.
+                continue;
+            }
+
+            // find the max GQ for each allele
+            vector<int> maxGQ;
+            S(alleles_maxGQ(dataset_header.get(), record.get(), dataset_relevant_samples, maxGQ));
+
+            // calculate estimated allele copy numbers for this record
+            // TODO: configurable bias00
+            // TODO: ideally we'd compute them only for relevant samples
+            S(diploid::estimate_allele_copy_number(dataset_header.get(), record.get(), 1.0, copy_number));
+            #define round4(x) (float(round(x*10000.0)/10000.0))
+
+            // FIXME -- minor potential bug -- double-counting copy number of
+            // alleles that span multiple discovery ranges
+
+            // create a discovered_alleles entry for each alt allele matching [ACGT]+
+            // In particular this excludes gVCF <NON_REF> symbolic alleles
+            bool any_alt = false;
+            for (int i = 1; i < record->n_allele; i++) {
+                double copy_number_i = 0.0;
+                for (unsigned sample : dataset_relevant_samples) {
+                    copy_number_i += copy_number[sample][i];
+                }
+                if (copy_number_i) {
+                    string aldna(record->d.allele[i]);
+                    transform(aldna.begin(), aldna.end(), aldna.begin(), ::toupper);
+                    if (aldna.size() > 0 && regex_match(aldna, regex_dna)) {
+                        discovered_allele_info ai = { false, round4(copy_number_i), maxGQ[i] };
+                        dsals.insert(make_pair(allele(rng, aldna), ai));
+                        any_alt = true;
+                    }
+                }
+            }
+
+            // create an entry for the ref allele, if we discovered at least one alt allele.
+            string refdna(record->d.allele[0]);
+            transform(refdna.begin(), refdna.end(), refdna.begin(), ::toupper);
+            if (refdna.size() > 0 && regex_match(refdna, regex_dna)) {
+                if (any_alt) {
+                    double ref_copy_number = 0.0;
+                    for (unsigned sample : dataset_relevant_samples) {
+                        ref_copy_number += copy_number[sample][0];
+                    }
+                    discovered_allele_info ai = { true, round4(ref_copy_number), maxGQ[0] };
+                    dsals.insert(make_pair(allele(rng, refdna), ai));
+                }
+            } else {
+                ostringstream errmsg;
+                errmsg << dataset << " " << refdna << "@" << rng.str();
+                return Status::Invalid("invalid reference allele", errmsg.str());
+            }
+        }
+        S(merge_discovered_alleles(dsals, final_dsals));
+        records.clear();
+    }
+
+    if (s != StatusCode::NOT_FOUND) {
+        return s;
+    }
+    return Status::OK();
+}
+
+Status discovered_alleles_refcheck(const discovered_alleles& als,
+                                   const vector<pair<string,size_t>>& contigs) {
+    set<range> ranges;
+    multimap<range,pair<string,bool> > refcheck;
+    for (const auto& it : als) {
+        UNPAIR(it,allele,ai)
+        refcheck.insert(make_pair(allele.pos, make_pair(allele.dna, ai.is_ref)));
+        ranges.insert(allele.pos);
+    }
+    for (const auto& rng : ranges) {
+        vector<string> refs;
+        auto its = refcheck.equal_range(rng);
+        for (auto it = its.first; it != its.second; it++) {
+            UNPAIR(*it, refcheck_rng, refcheckp)
+            UNPAIR(refcheckp, refcheck_dna, refcheck_is_ref)
+            assert (refcheck_rng == rng);
+            if (refcheck_is_ref) {
+                refs.push_back(refcheck_dna);
+            }
+        }
+        if (refs.size() > 1) {
+            ostringstream errmsg;
+            errmsg << rng.str(contigs);
+            for (const auto& r : refs) {
+                errmsg << ' ' << r;
+            }
+            return Status::Invalid("data sets contain inconsistent reference alleles", errmsg.str());
+        } else if (refs.size() == 0) {
+            return Status::Invalid("data sets contain no reference allele", rng.str(contigs));
+        }
+    }
+
+    return Status::OK();
+}
+
+}

--- a/src/discovery.cc
+++ b/src/discovery.cc
@@ -58,14 +58,12 @@ Status discover_alleles_from_iterator(const set<string>& samples,
             // In particular this excludes gVCF <NON_REF> symbolic alleles
             bool any_alt = false;
             for (int i = 1; i < record->n_allele; i++) {
-                if (zGQ[i].copy_number() > 0) {
-                    string aldna(record->d.allele[i]);
-                    transform(aldna.begin(), aldna.end(), aldna.begin(), ::toupper);
-                    if (aldna.size() > 0 && regex_match(aldna, regex_dna)) {
-                        discovered_allele_info ai = { false, maxAQ[i], zGQ[i] };
-                        dsals.insert(make_pair(allele(rng, aldna), ai));
-                        any_alt = true;
-                    }
+                string aldna(record->d.allele[i]);
+                transform(aldna.begin(), aldna.end(), aldna.begin(), ::toupper);
+                if (aldna.size() > 0 && regex_match(aldna, regex_dna) && zGQ[i].copy_number() > 0) {
+                    discovered_allele_info ai = { false, maxAQ[i], zGQ[i] };
+                    dsals.insert(make_pair(allele(rng, aldna), ai));
+                    any_alt = true;
                 }
             }
 

--- a/src/discovery.cc
+++ b/src/discovery.cc
@@ -60,7 +60,7 @@ Status discover_alleles_from_iterator(const set<string>& samples,
             for (int i = 1; i < record->n_allele; i++) {
                 string aldna(record->d.allele[i]);
                 transform(aldna.begin(), aldna.end(), aldna.begin(), ::toupper);
-                if (aldna.size() > 0 && regex_match(aldna, regex_dna) && zGQ[i].copy_number() > 0) {
+                if (aldna.size() > 0 && regex_match(aldna, regex_dna)) {
                     discovered_allele_info ai = { false, maxAQ[i], zGQ[i] };
                     dsals.insert(make_pair(allele(rng, aldna), ai));
                     any_alt = true;

--- a/src/discovery.cc
+++ b/src/discovery.cc
@@ -61,7 +61,7 @@ Status discover_alleles_from_iterator(const set<string>& samples,
                 string aldna(record->d.allele[i]);
                 transform(aldna.begin(), aldna.end(), aldna.begin(), ::toupper);
                 if (aldna.size() > 0 && regex_match(aldna, regex_dna)) {
-                    discovered_allele_info ai = { false, maxAQ[i], zGQ[i] };
+                    discovered_allele_info ai({ false, maxAQ[i], zGQ[i] });
                     dsals.insert(make_pair(allele(rng, aldna), ai));
                     any_alt = true;
                 }
@@ -72,7 +72,7 @@ Status discover_alleles_from_iterator(const set<string>& samples,
             transform(refdna.begin(), refdna.end(), refdna.begin(), ::toupper);
             if (refdna.size() > 0 && regex_match(refdna, regex_dna)) {
                 if (any_alt) {
-                    discovered_allele_info ai = { true, maxAQ[0], zGQ[0] };
+                    discovered_allele_info ai({ true, maxAQ[0], zGQ[0] });
                     dsals.insert(make_pair(allele(rng, refdna), ai));
                 }
             } else {

--- a/src/service.cc
+++ b/src/service.cc
@@ -1,5 +1,6 @@
 #include "service.h"
 #include "data.h"
+#include "discovery.h"
 #include "unifier.h"
 #include "genotyper.h"
 #include "residuals.h"
@@ -51,156 +52,6 @@ Status Service::Start(const service_config& cfg, Metadata& metadata, BCFData& da
     return MetadataCache::Start(metadata, svc->body_->metadata_);
 }
 
-// used on the thread pool below
-static Status discover_alleles_thread(const set<string>& samples,
-                                      const range& pos,
-                                      RangeBCFIterator& iterator,
-                                      discovered_alleles& final_dsals) {
-    Status s;
-
-    // get dataset BCF records
-    string dataset;
-    shared_ptr<const bcf_hdr_t> dataset_header;
-    vector<shared_ptr<bcf1_t>> records;
-    vector<vector<double>> copy_number;
-    while ((s = iterator.next(dataset, dataset_header, records)).ok()) {
-        discovered_alleles dsals;
-        // determine which of the dataset's samples are in the desired sample set
-        // TODO: FCMM-memoize this during the operation
-        size_t dataset_nsamples = bcf_hdr_nsamples(dataset_header.get());
-        vector<unsigned> dataset_relevant_samples;
-        for (unsigned i = 0; i < dataset_nsamples; i++) {
-            if (samples.find(string(bcf_hdr_int2id(dataset_header.get(), BCF_DT_SAMPLE, i))) != samples.end()) {
-                dataset_relevant_samples.push_back(i);
-            }
-        }
-
-        // for each BCF record
-        for (const auto& record : records) {
-            assert(!is_gvcf_ref_record(record.get()));
-            range rng(record);
-            assert(pos.overlaps(rng));
-            if (!pos.contains(rng)) {
-                // Skip records that dangle off the edge of the target range.
-                // The problem is that such alleles could overlap other
-                // alleles not overlapping the target range at all, and that
-                // we therefore won't see in our query. So it wouldn't be safe
-                // for us to make claims about the genotypes of the resulting
-                // sites.
-                continue;
-            }
-
-            // for each allele, find the max GQ of any hard-call of the allele
-            vector<int> maxGQ(record->n_allele,0);
-            htsvecbox<int> gt;
-            htsvecbox<int32_t> gq;
-            int nGT = bcf_get_genotypes(dataset_header.get(), record.get(), &gt.v, &gt.capacity);
-            if (!gt.v || nGT != 2*dataset_nsamples) return Status::Failure("discover_alleles bcf_get_genotypes");
-            int nGQ = bcf_get_format_int32(dataset_header.get(), record.get(), "GQ", &gq.v, &gq.capacity);
-            for (unsigned sample : dataset_relevant_samples) {
-                #define update_maxGQ(ofs) \
-                    if (!bcf_gt_is_missing(gt[2*sample+(ofs)])) {  \
-                        int al = bcf_gt_allele(gt[2*sample+(ofs)]); \
-                        if (al < 0 || al >= record->n_allele) return Status::Failure("discover_alleles bcf_get_genotypes invalid allele"); \
-                        maxGQ[al] = std::max(maxGQ[al], nGQ == dataset_nsamples ? gq[sample] : 99); \
-                    }
-                update_maxGQ(0)
-                update_maxGQ(1)
-            }
-
-            // calculate estimated allele copy numbers for this record
-            // TODO: configurable bias00
-            // TODO: ideally we'd compute them only for relevant samples
-            S(diploid::estimate_allele_copy_number(dataset_header.get(), record.get(), 1.0, copy_number));
-            #define round4(x) (float(round(x*10000.0)/10000.0))
-
-            // FIXME -- minor potential bug -- double-counting copy number of
-            // alleles that span multiple discovery ranges
-
-            // create a discovered_alleles entry for each alt allele matching [ACGT]+
-            // In particular this excludes gVCF <NON_REF> symbolic alleles
-            bool any_alt = false;
-            for (int i = 1; i < record->n_allele; i++) {
-                double copy_number_i = 0.0;
-                for (unsigned sample : dataset_relevant_samples) {
-                    copy_number_i += copy_number[sample][i];
-                }
-                if (copy_number_i) {
-                    string aldna(record->d.allele[i]);
-                    transform(aldna.begin(), aldna.end(), aldna.begin(), ::toupper);
-                    if (aldna.size() > 0 && regex_match(aldna, regex_dna)) {
-                        discovered_allele_info ai = { false, round4(copy_number_i), maxGQ[i] };
-                        dsals.insert(make_pair(allele(rng, aldna), ai));
-                        any_alt = true;
-                    }
-                }
-            }
-
-            // create an entry for the ref allele, if we discovered at least one alt allele.
-            string refdna(record->d.allele[0]);
-            transform(refdna.begin(), refdna.end(), refdna.begin(), ::toupper);
-            if (refdna.size() > 0 && regex_match(refdna, regex_dna)) {
-                if (any_alt) {
-                    double ref_copy_number = 0.0;
-                    for (unsigned sample : dataset_relevant_samples) {
-                        ref_copy_number += copy_number[sample][0];
-                    }
-                    discovered_allele_info ai = { true, round4(ref_copy_number), maxGQ[0] };
-                    dsals.insert(make_pair(allele(rng, refdna), ai));
-                }
-            } else {
-                ostringstream errmsg;
-                errmsg << dataset << " " << refdna << "@" << rng.str();
-                return Status::Invalid("invalid reference allele", errmsg.str());
-            }
-        }
-        S(merge_discovered_alleles(dsals, final_dsals));
-        records.clear();
-    }
-
-    if (s != StatusCode::NOT_FOUND) {
-        return s;
-    }
-    return Status::OK();
-}
-
-// verify that the discovered_alleles encodes the same reference allele at
-// each distinct range
-static Status discovered_alleles_refcheck(const discovered_alleles& als,
-                                          const vector<pair<string,size_t>>& contigs) {
-    set<range> ranges;
-    multimap<range,pair<string,bool> > refcheck;
-    for (const auto& it : als) {
-        UNPAIR(it,allele,ai)
-        refcheck.insert(make_pair(allele.pos, make_pair(allele.dna, ai.is_ref)));
-        ranges.insert(allele.pos);
-    }
-    for (const auto& rng : ranges) {
-        vector<string> refs;
-        auto its = refcheck.equal_range(rng);
-        for (auto it = its.first; it != its.second; it++) {
-            UNPAIR(*it, refcheck_rng, refcheckp)
-            UNPAIR(refcheckp, refcheck_dna, refcheck_is_ref)
-            assert (refcheck_rng == rng);
-            if (refcheck_is_ref) {
-                refs.push_back(refcheck_dna);
-            }
-        }
-        if (refs.size() > 1) {
-            ostringstream errmsg;
-            errmsg << rng.str(contigs);
-            for (const auto& r : refs) {
-                errmsg << ' ' << r;
-            }
-            return Status::Invalid("data sets contain inconsistent reference alleles", errmsg.str());
-        } else if (refs.size() == 0) {
-            return Status::Invalid("data sets contain no reference allele", rng.str(contigs));
-        }
-    }
-
-    return Status::OK();
-}
-
 Status Service::discover_alleles(const string& sampleset, const range& pos,
                                  discovered_alleles& ans, atomic<bool>* ext_abort) {
     // Find the data sets containing the samples in the sample set.
@@ -240,7 +91,7 @@ Status Service::discover_alleles(const string& sampleset, const range& pos,
             }
 
             discovered_alleles dsals;
-            Status ls = discover_alleles_thread(*samples, pos, *raw_iter, dsals);
+            Status ls = discover_alleles_from_iterator(*samples, pos, *raw_iter, dsals);
             results[i] = move(dsals);
             return ls;
         });

--- a/src/types.cc
+++ b/src/types.cc
@@ -261,7 +261,7 @@ Status unified_site::of_yaml(const YAML::Node& yaml, const vector<pair<string,si
         VR(ans.unification.find(al) == ans.unification.end(), "duplicate unification entries");
         ans.unification[al] = to;
     }
-    VR(ans.unification.size() >= 2, "not enough unification entries");
+    VR(ans.unification.size() >= 1, "not enough unification entries");
 
     ans.copy_number.clear();
     const auto n_obs = yaml["copy_number"];

--- a/src/types.cc
+++ b/src/types.cc
@@ -23,7 +23,7 @@ Status merge_discovered_alleles(const discovered_alleles& src, discovered_allele
                 return Status::Invalid("allele appears as both REF and ALT", allele.dna + "@" + allele.pos.str());
             }
             p->second.copy_number += ai.copy_number;
-            p->second.maxGQ = std::max(p->second.maxGQ, ai.maxGQ);
+            p->second.maxAQ = std::max(p->second.maxAQ, ai.maxAQ);
         }
     }
 
@@ -104,8 +104,8 @@ Status yaml_of_discovered_alleles(const discovered_alleles& dal,
             << YAML::Value << p.second.is_ref;
         out << YAML::Key << "copy_number"
             << YAML::Value << p.second.copy_number;
-        out << YAML::Key << "maxGQ"
-            << YAML::Value << p.second.maxGQ;
+        out << YAML::Key << "maxAQ"
+            << YAML::Value << p.second.maxAQ;
 
         out << YAML::EndMap;
     }
@@ -148,10 +148,10 @@ Status discovered_alleles_of_yaml(const YAML::Node& yaml,
         ai.copy_number = n_copy_number.as<float>();
         VR(std::isfinite(ai.copy_number) && !std::isnan(ai.copy_number), "invalid 'copy_number' field in entry");
 
-        const auto n_maxGQ = (*p)["maxGQ"];
-        VR(n_maxGQ && n_maxGQ.IsScalar(), "missing/invalid 'maxGQ' field in entry");
-        ai.maxGQ = n_maxGQ.as<int>();
-        VR(ai.maxGQ >= 0, "invalid 'maxGQ' field in entry");
+        const auto n_maxAQ = (*p)["maxAQ"];
+        VR(n_maxAQ && n_maxAQ.IsScalar(), "missing/invalid 'maxAQ' field in entry");
+        ai.maxAQ = n_maxAQ.as<int>();
+        VR(ai.maxAQ >= 0, "invalid 'maxAQ' field in entry");
 
         VR(ans.find(al) == ans.end(), "duplicate alleles");
         ans[al] = ai;
@@ -302,11 +302,11 @@ Status unifier_config::of_yaml(const YAML::Node& yaml, unifier_config& ans) {
         V(ans.min_allele_copy_number >= 0, "invalid min_allele_copy_number");
     }
 
-    const auto n_minGQ = yaml["minGQ"];
-    if (n_minGQ) {
-        V(n_minGQ.IsScalar(), "invalid minGQ");
-        ans.minGQ = n_minGQ.as<int>();
-        V(ans.minGQ >= 0, "invalid minGQ");
+    const auto n_minAQ = yaml["minAQ"];
+    if (n_minAQ) {
+        V(n_minAQ.IsScalar(), "invalid minAQ");
+        ans.minAQ = n_minAQ.as<int>();
+        V(ans.minAQ >= 0, "invalid minAQ");
     }
 
     const auto n_max_alleles_per_site = yaml["max_alleles_per_site"];
@@ -337,7 +337,7 @@ Status unifier_config::of_yaml(const YAML::Node& yaml, unifier_config& ans) {
 Status unifier_config::yaml(YAML::Emitter& ans) const {
     ans << YAML::BeginMap;
     ans << YAML::Key << "min_allele_copy_number" << YAML::Value << min_allele_copy_number;
-    ans << YAML::Key << "minGQ" << YAML::Value << minGQ;
+    ans << YAML::Key << "minAQ" << YAML::Value << minAQ;
     ans << YAML::Key << "max_alleles_per_site" << YAML::Value << max_alleles_per_site;
 
     ans << YAML::Key << "preference" << YAML::Value;

--- a/src/types.cc
+++ b/src/types.cc
@@ -11,7 +11,7 @@ regex regex_dna     ("[ACGTN]+")
     ;
 
 // Add src alleles to dest alleles. Identical alleles alleles are merged,
-// using the sum of their copy_numbers
+// updating maxAQ and combining zygosity_by_GQ
 Status merge_discovered_alleles(const discovered_alleles& src, discovered_alleles& dest) {
     for (auto& dsal : src) {
         UNPAIR(dsal,allele,ai)
@@ -22,8 +22,8 @@ Status merge_discovered_alleles(const discovered_alleles& src, discovered_allele
             if (ai.is_ref != p->second.is_ref) {
                 return Status::Invalid("allele appears as both REF and ALT", allele.dna + "@" + allele.pos.str());
             }
-            p->second.copy_number += ai.copy_number;
             p->second.maxAQ = std::max(p->second.maxAQ, ai.maxAQ);
+            p->second.zGQ += ai.zGQ;
         }
     }
 
@@ -102,10 +102,19 @@ Status yaml_of_discovered_alleles(const discovered_alleles& dal,
             << YAML::Value << p.first.dna;
         out << YAML::Key << "is_ref"
             << YAML::Value << p.second.is_ref;
-        out << YAML::Key << "copy_number"
-            << YAML::Value << p.second.copy_number;
         out << YAML::Key << "maxAQ"
             << YAML::Value << p.second.maxAQ;
+
+        out << YAML::Key << "zygosity_by_GQ"
+            << YAML::Value << YAML::BeginSeq;
+        for (unsigned i = 0; i < zygosity_by_GQ::ROWS; i++) {
+            out << YAML::BeginSeq;
+            for (unsigned j = 0; j < zygosity_by_GQ::COLS; j++) {
+                out << p.second.zGQ.M[i][j];
+            }
+            out << YAML::EndSeq;
+        }
+        out << YAML::EndSeq;
 
         out << YAML::EndMap;
     }
@@ -143,15 +152,24 @@ Status discovered_alleles_of_yaml(const YAML::Node& yaml,
         VR(n_is_ref && n_is_ref.IsScalar(), "missing/invalid 'is_ref' field in entry");
         ai.is_ref = n_is_ref.as<bool>();
 
-        const auto n_copy_number = (*p)["copy_number"];
-        VR(n_copy_number && n_copy_number.IsScalar(), "missing/invalid 'copy_number' field in entry");
-        ai.copy_number = n_copy_number.as<float>();
-        VR(std::isfinite(ai.copy_number) && !std::isnan(ai.copy_number), "invalid 'copy_number' field in entry");
-
         const auto n_maxAQ = (*p)["maxAQ"];
         VR(n_maxAQ && n_maxAQ.IsScalar(), "missing/invalid 'maxAQ' field in entry");
         ai.maxAQ = n_maxAQ.as<int>();
         VR(ai.maxAQ >= 0, "invalid 'maxAQ' field in entry");
+
+        const auto n_zygosity_by_GQ = (*p)["zygosity_by_GQ"];
+        VR(n_zygosity_by_GQ && n_zygosity_by_GQ.IsSequence(), "missing/invalid 'zygosity_by_GQ' field in entry");
+        VR(n_zygosity_by_GQ.size() == zygosity_by_GQ::ROWS, "unexpected row count in zygosity_by_GQ");
+        unsigned i = 0;
+        for (YAML::const_iterator q = n_zygosity_by_GQ.begin(); q != n_zygosity_by_GQ.end(); ++q, ++i) {
+            VR(q->IsSequence(), "invalid row in zygosity_by_GQ");
+            VR(q->size() == zygosity_by_GQ::COLS, "unexpected row size in zygosity_by_GQ");
+            unsigned j = 0;
+            for (YAML::const_iterator r = q->begin(); r != q->end(); ++r, ++j) {
+                VR(r->IsScalar() && r->as<int>() >= 0, "invalid entry in zygosity_by_GQ");
+                ai.zGQ.M[i][j] = (unsigned) r->as<int>();
+            }
+        }
 
         VR(ans.find(al) == ans.end(), "duplicate alleles");
         ans[al] = ai;

--- a/src/types.cc
+++ b/src/types.cc
@@ -107,9 +107,9 @@ Status yaml_of_discovered_alleles(const discovered_alleles& dal,
 
         out << YAML::Key << "zygosity_by_GQ"
             << YAML::Value << YAML::BeginSeq;
-        for (unsigned i = 0; i < zygosity_by_GQ::ROWS; i++) {
+        for (unsigned i = 0; i < zygosity_by_GQ::GQ_BANDS; i++) {
             out << YAML::BeginSeq;
-            for (unsigned j = 0; j < zygosity_by_GQ::COLS; j++) {
+            for (unsigned j = 0; j < zygosity_by_GQ::PLOIDY; j++) {
                 out << p.second.zGQ.M[i][j];
             }
             out << YAML::EndSeq;
@@ -159,11 +159,11 @@ Status discovered_alleles_of_yaml(const YAML::Node& yaml,
 
         const auto n_zygosity_by_GQ = (*p)["zygosity_by_GQ"];
         VR(n_zygosity_by_GQ && n_zygosity_by_GQ.IsSequence(), "missing/invalid 'zygosity_by_GQ' field in entry");
-        VR(n_zygosity_by_GQ.size() == zygosity_by_GQ::ROWS, "unexpected row count in zygosity_by_GQ");
+        VR(n_zygosity_by_GQ.size() == zygosity_by_GQ::GQ_BANDS, "unexpected row count in zygosity_by_GQ");
         unsigned i = 0;
         for (YAML::const_iterator q = n_zygosity_by_GQ.begin(); q != n_zygosity_by_GQ.end(); ++q, ++i) {
             VR(q->IsSequence(), "invalid row in zygosity_by_GQ");
-            VR(q->size() == zygosity_by_GQ::COLS, "unexpected row size in zygosity_by_GQ");
+            VR(q->size() == zygosity_by_GQ::PLOIDY, "unexpected row size in zygosity_by_GQ");
             unsigned j = 0;
             for (YAML::const_iterator r = q->begin(); r != q->end(); ++r, ++j) {
                 VR(r->IsScalar() && r->as<int>() >= 0, "invalid entry in zygosity_by_GQ");

--- a/src/types.cc
+++ b/src/types.cc
@@ -320,11 +320,11 @@ Status unifier_config::of_yaml(const YAML::Node& yaml, unifier_config& ans) {
         V(ans.min_allele_copy_number >= 0, "invalid min_allele_copy_number");
     }
 
-    const auto n_minAQ = yaml["minAQ"];
-    if (n_minAQ) {
-        V(n_minAQ.IsScalar(), "invalid minAQ");
-        ans.minAQ = n_minAQ.as<int>();
-        V(ans.minAQ >= 0, "invalid minAQ");
+    const auto n_min_quality = yaml["min_quality"];
+    if (n_min_quality) {
+        V(n_min_quality.IsScalar(), "invalid min_quality");
+        ans.min_quality = n_min_quality.as<int>();
+        V(ans.min_quality >= 0, "invalid min_quality");
     }
 
     const auto n_max_alleles_per_site = yaml["max_alleles_per_site"];
@@ -355,7 +355,7 @@ Status unifier_config::of_yaml(const YAML::Node& yaml, unifier_config& ans) {
 Status unifier_config::yaml(YAML::Emitter& ans) const {
     ans << YAML::BeginMap;
     ans << YAML::Key << "min_allele_copy_number" << YAML::Value << min_allele_copy_number;
-    ans << YAML::Key << "minAQ" << YAML::Value << minAQ;
+    ans << YAML::Key << "min_quality" << YAML::Value << min_quality;
     ans << YAML::Key << "max_alleles_per_site" << YAML::Value << max_alleles_per_site;
 
     ans << YAML::Key << "preference" << YAML::Value;

--- a/src/types.cc
+++ b/src/types.cc
@@ -23,7 +23,7 @@ Status merge_discovered_alleles(const discovered_alleles& src, discovered_allele
                 return Status::Invalid("allele appears as both REF and ALT", allele.dna + "@" + allele.pos.str());
             }
             p->second.copy_number += ai.copy_number;
-            p->second.maxGQ += ai.maxGQ;
+            p->second.maxGQ = std::max(p->second.maxGQ, ai.maxGQ);
         }
     }
 

--- a/src/unifier.cc
+++ b/src/unifier.cc
@@ -308,8 +308,7 @@ Status pad_alt_allele(const allele& ref, allele& alt) {
     return Status::OK();
 }
 
-/// Unify the alleles at one site. The given ALT alleles must all share at
-/// least one position in common.
+/// Unify the alleles at one site.
 Status unify_alleles(const unifier_config& cfg, const range& pos,
                      const discovered_alleles& refs, const minimized_alleles& alts,
                      unified_site& ans) {
@@ -349,9 +348,6 @@ Status unify_alleles(const unifier_config& cfg, const range& pos,
     // problematic because the copy numbers in discovered_alleles omit nearly
     // all homozygous ref genotypes.
     us.copy_number.push_back(0.0);
-    for (const auto& ref : refs) {
-        us.unification[ref.first] = 0;
-    }
     for (int i = 1; i <= valts.size(); i++) {
         const minimized_allele& p = valts[i-1];
         UNPAIR(p, alt, alt_info);

--- a/src/unifier.cc
+++ b/src/unifier.cc
@@ -20,7 +20,7 @@ using discovered_allele = pair<allele,discovered_allele_info>;
 struct minimized_allele_info {
     set<allele> originals;
     float copy_number = 0.0;
-    int maxGQ = 0;
+    int maxAQ = 0;
 
     string str() const {
         ostringstream os;
@@ -29,7 +29,7 @@ struct minimized_allele_info {
             os << "  " << al.str() << endl;
         }
         os << "Copy number: " << copy_number << endl;
-        os << "Max GQ: " << maxGQ << endl;
+        os << "Max AQ: " << maxAQ << endl;
         return os.str();
     }
 };
@@ -122,19 +122,19 @@ Status minimize_alleles(const discovered_alleles& src,
         // minimize the alt allele
         S(minimize_allele(rp->second.first, alt));
 
-        // add it to alts, combining originals, copy_number, and maxGQ with any
+        // add it to alts, combining originals, copy_number, and maxAQ with any
         // previously observed occurrences of the same minimized alt allele.
         auto ap = alts.find(alt);
         if (ap == alts.end()) {
             minimized_allele_info info;
             info.originals.insert(dal.first);
             info.copy_number = dal.second.copy_number;
-            info.maxGQ = dal.second.maxGQ;
+            info.maxAQ = dal.second.maxAQ;
             alts[alt] = move(info);
         } else {
             ap->second.originals.insert(dal.first);
             ap->second.copy_number += dal.second.copy_number;
-            ap->second.maxGQ = std::max(ap->second.maxGQ, dal.second.maxGQ);
+            ap->second.maxAQ = std::max(ap->second.maxAQ, dal.second.maxAQ);
         }
     }
 
@@ -186,8 +186,8 @@ auto prune_alleles(const unifier_config& cfg, const minimized_alleles& alleles, 
     vector<minimized_allele> valleles;
     valleles.reserve(alleles.size());
     for (const auto& allele : alleles) {
-        // filter alleles with insufficient copy number or GQ
-        if (allele.second.maxGQ >= cfg.minGQ &&
+        // filter alleles with insufficient copy number or AQ
+        if (allele.second.maxAQ >= cfg.minAQ &&
             allele.second.copy_number >= cfg.min_allele_copy_number) {
             valleles.push_back(allele);
         }

--- a/src/unifier.cc
+++ b/src/unifier.cc
@@ -50,13 +50,20 @@ bool minimized_allele_small_lt(const minimized_allele& p1, const minimized_allel
     if (p1.first.pos.size() != p2.first.pos.size()) {
         return p1.first.pos.size() < p2.first.pos.size();
     }
-    return p2.second.copy_number < p1.second.copy_number;
+    if (p2.second.copy_number != p1.second.copy_number) {
+        return p2.second.copy_number < p1.second.copy_number;
+    }
+    return p2.second.maxAQ < p1.second.maxAQ;
 }
 
 // UnifierPreference::Common
 bool minimized_allele_common_lt(const minimized_allele& p1, const minimized_allele& p2) {
-    if (p2.second.copy_number != p1.second.copy_number)
+    if (p2.second.copy_number != p1.second.copy_number) {
         return p2.second.copy_number < p1.second.copy_number;
+    }
+    if (p2.second.maxAQ != p1.second.maxAQ) {
+        return p2.second.maxAQ < p1.second.maxAQ;
+    }
     return minimized_allele_delta_lt(p1, p2);
 }
 

--- a/src/unifier.cc
+++ b/src/unifier.cc
@@ -100,7 +100,7 @@ Status minimize_allele(const allele& ref, allele& alt) {
 }
 
 // Separate discovered alleles into the REF alleles and minimized ALT alleles
-Status minimize_alleles(const discovered_alleles& src,
+Status minimize_alleles(const unifier_config& cfg, const discovered_alleles& src,
                         discovered_alleles& refs, minimized_alleles& alts) {
     Status s;
 
@@ -129,8 +129,7 @@ Status minimize_alleles(const discovered_alleles& src,
         // minimize the alt allele
         S(minimize_allele(rp->second.first, alt));
 
-        // TODO: configured minGQ for estimating copy number
-        unsigned copy_number = dal.second.zGQ.copy_number();
+        unsigned copy_number = dal.second.zGQ.copy_number(cfg.min_quality);
 
         // add it to alts, combining originals, copy_number, and maxAQ with any
         // previously observed occurrences of the same minimized alt allele.
@@ -197,7 +196,7 @@ auto prune_alleles(const unifier_config& cfg, const minimized_alleles& alleles, 
     valleles.reserve(alleles.size());
     for (const auto& allele : alleles) {
         // filter alleles with insufficient copy number or AQ
-        if (allele.second.maxAQ >= cfg.minAQ &&
+        if (allele.second.maxAQ >= cfg.min_quality &&
             allele.second.copy_number >= cfg.min_allele_copy_number) {
             valleles.push_back(allele);
         }
@@ -264,7 +263,7 @@ Status delineate_sites(const unifier_config& cfg, const discovered_alleles& alle
         // minimize the alt alleles
         discovered_alleles refs;
         minimized_alleles alts, pruned;
-        S(minimize_alleles(active_region.second, refs, alts));
+        S(minimize_alleles(cfg, active_region.second, refs, alts));
 
         // prune alt alleles as necessary to yield sites
         auto sites = prune_alleles(cfg, alts, pruned);

--- a/test/data/gvcf_test_cases/DP0_noAD.yml
+++ b/test/data/gvcf_test_cases/DP0_noAD.yml
@@ -54,9 +54,6 @@ truth_unified_sites:
       copy_number: [0, 1.4987]
       unification:
         - range: {beg: 1000, end: 1000}
-          alt: C
-          to: 0
-        - range: {beg: 1000, end: 1000}
           alt: CG
           to: 1
 

--- a/test/data/gvcf_test_cases/DP0_noAD.yml
+++ b/test/data/gvcf_test_cases/DP0_noAD.yml
@@ -51,7 +51,7 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1000}
       alleles: [C, CG]
-      copy_number: [0, 1.4987]
+      copy_number: [0, 2]
       unification:
         - range: {beg: 1000, end: 1000}
           alt: CG

--- a/test/data/gvcf_test_cases/discover_alleles_2_trios.yml
+++ b/test/data/gvcf_test_cases/discover_alleles_2_trios.yml
@@ -38,50 +38,50 @@ truth_discovered_alleles:
     - range: {ref: 'A', beg: 1001, end: 1001}
       dna: 'A'
       is_ref: true
-      copy_number: 6
       maxAQ: 0
+      zygosity_by_GQ: [[4,1],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1001, end: 1001}
       dna: 'G'
       is_ref: false
-      copy_number: 6
       maxAQ: 0
+      zygosity_by_GQ: [[4,1],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'C'
       is_ref: true
-      copy_number: 2
       maxAQ: 0
+      zygosity_by_GQ: [[0,1],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'A'
       is_ref: false
-      copy_number: 6
       maxAQ: 0
+      zygosity_by_GQ: [[0,3],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'G'
       is_ref: false
-      copy_number: 2
       maxAQ: 0
+      zygosity_by_GQ: [[0,1],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'T'
       is_ref: false
-      copy_number: 2
       maxAQ: 0
+      zygosity_by_GQ: [[0,1],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1011, end: 1012}
       dna: 'CC'
       is_ref: true
-      copy_number: 3
       maxAQ: 0
+      zygosity_by_GQ: [[3,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1011, end: 1012}
       dna: 'AG'
       is_ref: false
-      copy_number: 3
       maxAQ: 0
+      zygosity_by_GQ: [[3,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1011, end: 1013}
       dna: 'CCC'
       is_ref: true
-      copy_number: 4
       maxAQ: 0
+      zygosity_by_GQ: [[2,1],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1011, end: 1013}
       dna: 'AGA'
       is_ref: false
-      copy_number: 2
       maxAQ: 0
+      zygosity_by_GQ: [[2,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]

--- a/test/data/gvcf_test_cases/discover_alleles_2_trios.yml
+++ b/test/data/gvcf_test_cases/discover_alleles_2_trios.yml
@@ -39,49 +39,49 @@ truth_discovered_alleles:
       dna: 'A'
       is_ref: true
       copy_number: 6
-      maxGQ: 99
+      maxGQ: 0
     - range: {ref: 'A', beg: 1001, end: 1001}
       dna: 'G'
       is_ref: false
       copy_number: 6
-      maxGQ: 99
+      maxGQ: 0
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'C'
       is_ref: true
       copy_number: 2
-      maxGQ: 99
+      maxGQ: 0
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'A'
       is_ref: false
       copy_number: 6
-      maxGQ: 99
+      maxGQ: 0
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'G'
       is_ref: false
       copy_number: 2
-      maxGQ: 99
+      maxGQ: 0
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'T'
       is_ref: false
       copy_number: 2
-      maxGQ: 99
+      maxGQ: 0
     - range: {ref: 'A', beg: 1011, end: 1012}
       dna: 'CC'
       is_ref: true
       copy_number: 3
-      maxGQ: 99
+      maxGQ: 0
     - range: {ref: 'A', beg: 1011, end: 1012}
       dna: 'AG'
       is_ref: false
       copy_number: 3
-      maxGQ: 99
+      maxGQ: 0
     - range: {ref: 'A', beg: 1011, end: 1013}
       dna: 'CCC'
       is_ref: true
       copy_number: 4
-      maxGQ: 99
+      maxGQ: 0
     - range: {ref: 'A', beg: 1011, end: 1013}
       dna: 'AGA'
       is_ref: false
       copy_number: 2
-      maxGQ: 99
+      maxGQ: 0

--- a/test/data/gvcf_test_cases/discover_alleles_2_trios.yml
+++ b/test/data/gvcf_test_cases/discover_alleles_2_trios.yml
@@ -39,39 +39,49 @@ truth_discovered_alleles:
       dna: 'A'
       is_ref: true
       copy_number: 6
+      maxGQ: 99
     - range: {ref: 'A', beg: 1001, end: 1001}
       dna: 'G'
       is_ref: false
       copy_number: 6
+      maxGQ: 99
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'C'
       is_ref: true
       copy_number: 2
+      maxGQ: 99
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'A'
       is_ref: false
       copy_number: 6
+      maxGQ: 99
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'G'
       is_ref: false
       copy_number: 2
+      maxGQ: 99
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'T'
       is_ref: false
       copy_number: 2
+      maxGQ: 99
     - range: {ref: 'A', beg: 1011, end: 1012}
       dna: 'CC'
       is_ref: true
       copy_number: 3
+      maxGQ: 99
     - range: {ref: 'A', beg: 1011, end: 1012}
       dna: 'AG'
       is_ref: false
       copy_number: 3
+      maxGQ: 99
     - range: {ref: 'A', beg: 1011, end: 1013}
       dna: 'CCC'
       is_ref: true
       copy_number: 4
+      maxGQ: 99
     - range: {ref: 'A', beg: 1011, end: 1013}
       dna: 'AGA'
       is_ref: false
       copy_number: 2
+      maxGQ: 99

--- a/test/data/gvcf_test_cases/discover_alleles_2_trios.yml
+++ b/test/data/gvcf_test_cases/discover_alleles_2_trios.yml
@@ -39,49 +39,49 @@ truth_discovered_alleles:
       dna: 'A'
       is_ref: true
       copy_number: 6
-      maxGQ: 0
+      maxAQ: 0
     - range: {ref: 'A', beg: 1001, end: 1001}
       dna: 'G'
       is_ref: false
       copy_number: 6
-      maxGQ: 0
+      maxAQ: 0
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'C'
       is_ref: true
       copy_number: 2
-      maxGQ: 0
+      maxAQ: 0
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'A'
       is_ref: false
       copy_number: 6
-      maxGQ: 0
+      maxAQ: 0
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'G'
       is_ref: false
       copy_number: 2
-      maxGQ: 0
+      maxAQ: 0
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'T'
       is_ref: false
       copy_number: 2
-      maxGQ: 0
+      maxAQ: 0
     - range: {ref: 'A', beg: 1011, end: 1012}
       dna: 'CC'
       is_ref: true
       copy_number: 3
-      maxGQ: 0
+      maxAQ: 0
     - range: {ref: 'A', beg: 1011, end: 1012}
       dna: 'AG'
       is_ref: false
       copy_number: 3
-      maxGQ: 0
+      maxAQ: 0
     - range: {ref: 'A', beg: 1011, end: 1013}
       dna: 'CCC'
       is_ref: true
       copy_number: 4
-      maxGQ: 0
+      maxAQ: 0
     - range: {ref: 'A', beg: 1011, end: 1013}
       dna: 'AGA'
       is_ref: false
       copy_number: 2
-      maxGQ: 0
+      maxAQ: 0

--- a/test/data/gvcf_test_cases/discover_alleles_gvcf.yml
+++ b/test/data/gvcf_test_cases/discover_alleles_gvcf.yml
@@ -34,8 +34,10 @@ truth_discovered_alleles:
       dna: 'TA'
       is_ref: true
       copy_number: 1.0245
+      maxGQ: 16
     - range: {ref: '21', beg: 10009464, end: 10009465}
       dna: 'T'
       is_ref: false
       copy_number: 0.9755
+      maxGQ: 16
 

--- a/test/data/gvcf_test_cases/discover_alleles_gvcf.yml
+++ b/test/data/gvcf_test_cases/discover_alleles_gvcf.yml
@@ -33,11 +33,11 @@ truth_discovered_alleles:
     - range: {ref: '21', beg: 10009464, end: 10009465}
       dna: 'TA'
       is_ref: true
-      copy_number: 1.0245
       maxAQ: 240
+      zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: '21', beg: 10009464, end: 10009465}
       dna: 'T'
       is_ref: false
-      copy_number: 0.9755
       maxAQ: 16
+      zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 

--- a/test/data/gvcf_test_cases/discover_alleles_gvcf.yml
+++ b/test/data/gvcf_test_cases/discover_alleles_gvcf.yml
@@ -34,10 +34,10 @@ truth_discovered_alleles:
       dna: 'TA'
       is_ref: true
       copy_number: 1.0245
-      maxGQ: 16
+      maxAQ: 240
     - range: {ref: '21', beg: 10009464, end: 10009465}
       dna: 'T'
       is_ref: false
       copy_number: 0.9755
-      maxGQ: 16
+      maxAQ: 16
 

--- a/test/data/gvcf_test_cases/discover_alleles_gvcf_bogus.yml
+++ b/test/data/gvcf_test_cases/discover_alleles_gvcf_bogus.yml
@@ -31,8 +31,10 @@ truth_discovered_alleles:
       dna: 'TA'
       is_ref: true
       copy_number: 1.0245
+      maxGQ: 16
     - range: {ref: '22', beg: 10009464, end: 10009465}
       dna: 'T'
       is_ref: false
       copy_number: 0.9755
+      maxGQ: 16
 

--- a/test/data/gvcf_test_cases/discover_alleles_gvcf_bogus.yml
+++ b/test/data/gvcf_test_cases/discover_alleles_gvcf_bogus.yml
@@ -31,10 +31,10 @@ truth_discovered_alleles:
       dna: 'TA'
       is_ref: true
       copy_number: 1.0245
-      maxGQ: 16
+      maxAQ: 240
     - range: {ref: '22', beg: 10009464, end: 10009465}
       dna: 'T'
       is_ref: false
       copy_number: 0.9755
-      maxGQ: 16
+      maxAQ: 16
 

--- a/test/data/gvcf_test_cases/discover_alleles_gvcf_bogus.yml
+++ b/test/data/gvcf_test_cases/discover_alleles_gvcf_bogus.yml
@@ -30,11 +30,10 @@ truth_discovered_alleles:
     - range: {ref: '22', beg: 10009464, end: 10009465}
       dna: 'TA'
       is_ref: true
-      copy_number: 1.0245
       maxAQ: 240
+      zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: '22', beg: 10009464, end: 10009465}
       dna: 'T'
       is_ref: false
-      copy_number: 0.9755
       maxAQ: 16
-
+      zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]

--- a/test/data/gvcf_test_cases/format_fields_AD_fallback.yml
+++ b/test/data/gvcf_test_cases/format_fields_AD_fallback.yml
@@ -53,7 +53,7 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1000}
       alleles: [C, CG]
-      copy_number: [0, 1.4987]
+      copy_number: [0, 2]
       unification:
         - range: {beg: 1000, end: 1000}
           alt: CG

--- a/test/data/gvcf_test_cases/format_fields_AD_fallback.yml
+++ b/test/data/gvcf_test_cases/format_fields_AD_fallback.yml
@@ -56,9 +56,6 @@ truth_unified_sites:
       copy_number: [0, 1.4987]
       unification:
         - range: {beg: 1000, end: 1000}
-          alt: C
-          to: 0
-        - range: {beg: 1000, end: 1000}
           alt: CG
           to: 1
 

--- a/test/data/gvcf_test_cases/format_fields_combi.yml
+++ b/test/data/gvcf_test_cases/format_fields_combi.yml
@@ -64,12 +64,6 @@ truth_unified_sites:
       alleles: [CC, T, TC]
       copy_number: [0, 1.4987, 1.4684]
       unification:
-        - range: {beg: 1000, end: 1000}
-          alt: C
-          to: 0
-        - range: {beg: 1000, end: 1001}
-          alt: CC
-          to: 0
         - range: {beg: 1000, end: 1001}
           alt: T
           to: 1

--- a/test/data/gvcf_test_cases/format_fields_combi.yml
+++ b/test/data/gvcf_test_cases/format_fields_combi.yml
@@ -62,7 +62,7 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1001}
       alleles: [CC, T, TC]
-      copy_number: [0, 1.4987, 1.4684]
+      copy_number: [0, 2, 1]
       unification:
         - range: {beg: 1000, end: 1001}
           alt: T

--- a/test/data/gvcf_test_cases/format_fields_integrated.yml
+++ b/test/data/gvcf_test_cases/format_fields_integrated.yml
@@ -72,35 +72,35 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "21", beg: 10009461, end: 10009461}
       alleles: [T, A]
-      copy_number: [0, 1.951]
+      copy_number: [0, 2]
       unification:
         - range: {beg: 10009461, end: 10009461}
           alt: A
           to: 1
     - range: {ref: "21", beg: 10009462, end: 10009462}
       alleles: [T, A]
-      copy_number: [0, 0.9755]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009462, end: 10009462}
           alt: A
           to: 1
     - range: {ref: "21", beg: 10009463, end: 10009463}
       alleles: [C, G]
-      copy_number: [0, 0.9755]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009463, end: 10009463}
           alt: G
           to: 1
     - range: {ref: "21", beg: 10009464, end: 10009465}
       alleles: [TA, T]
-      copy_number: [0, 0.9755]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009464, end: 10009465}
           alt: T
           to: 1
     - range: {ref: "21", beg: 10009466, end: 10009467}
       alleles: [AA, GT]
-      copy_number: [0, 0.9755]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009466, end: 10009467}
           alt: GT

--- a/test/data/gvcf_test_cases/format_fields_integrated.yml
+++ b/test/data/gvcf_test_cases/format_fields_integrated.yml
@@ -75,18 +75,12 @@ truth_unified_sites:
       copy_number: [0, 1.951]
       unification:
         - range: {beg: 10009461, end: 10009461}
-          alt: T
-          to: 0
-        - range: {beg: 10009461, end: 10009461}
           alt: A
           to: 1
     - range: {ref: "21", beg: 10009462, end: 10009462}
       alleles: [T, A]
       copy_number: [0, 0.9755]
       unification:
-        - range: {beg: 10009462, end: 10009462}
-          alt: T
-          to: 0
         - range: {beg: 10009462, end: 10009462}
           alt: A
           to: 1
@@ -95,9 +89,6 @@ truth_unified_sites:
       copy_number: [0, 0.9755]
       unification:
         - range: {beg: 10009463, end: 10009463}
-          alt: C
-          to: 0
-        - range: {beg: 10009463, end: 10009463}
           alt: G
           to: 1
     - range: {ref: "21", beg: 10009464, end: 10009465}
@@ -105,18 +96,12 @@ truth_unified_sites:
       copy_number: [0, 0.9755]
       unification:
         - range: {beg: 10009464, end: 10009465}
-          alt: TA
-          to: 0
-        - range: {beg: 10009464, end: 10009465}
           alt: T
           to: 1
     - range: {ref: "21", beg: 10009466, end: 10009467}
       alleles: [AA, GT]
       copy_number: [0, 0.9755]
       unification:
-        - range: {beg: 10009466, end: 10009467}
-          alt: AA
-          to: 0
         - range: {beg: 10009466, end: 10009467}
           alt: GT
           to: 1

--- a/test/data/gvcf_test_cases/gvcf_services.yml
+++ b/test/data/gvcf_test_cases/gvcf_services.yml
@@ -39,28 +39,28 @@ input:
 truth_unified_sites:
     - range: {ref: "21", beg: 10009462, end: 10009462}
       alleles: [T, A]
-      copy_number: [0, 0.9755]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009462, end: 10009462}
           alt: A
           to: 1
     - range: {ref: "21", beg: 10009463, end: 10009463}
       alleles: [C, G]
-      copy_number: [0, 0.9755]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009463, end: 10009463}
           alt: G
           to: 1
     - range: {ref: "21", beg: 10009464, end: 10009465}
       alleles: [TA, T]
-      copy_number: [0, 0.9755]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009464, end: 10009465}
           alt: T
           to: 1
     - range: {ref: "21", beg: 10009466, end: 10009467}
       alleles: [AA, GT]
-      copy_number: [0, 0.9755]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009466, end: 10009467}
           alt: GT

--- a/test/data/gvcf_test_cases/gvcf_services.yml
+++ b/test/data/gvcf_test_cases/gvcf_services.yml
@@ -42,18 +42,12 @@ truth_unified_sites:
       copy_number: [0, 0.9755]
       unification:
         - range: {beg: 10009462, end: 10009462}
-          alt: T
-          to: 0
-        - range: {beg: 10009462, end: 10009462}
           alt: A
           to: 1
     - range: {ref: "21", beg: 10009463, end: 10009463}
       alleles: [C, G]
       copy_number: [0, 0.9755]
       unification:
-        - range: {beg: 10009463, end: 10009463}
-          alt: C
-          to: 0
         - range: {beg: 10009463, end: 10009463}
           alt: G
           to: 1
@@ -62,18 +56,12 @@ truth_unified_sites:
       copy_number: [0, 0.9755]
       unification:
         - range: {beg: 10009464, end: 10009465}
-          alt: TA
-          to: 0
-        - range: {beg: 10009464, end: 10009465}
           alt: T
           to: 1
     - range: {ref: "21", beg: 10009466, end: 10009467}
       alleles: [AA, GT]
       copy_number: [0, 0.9755]
       unification:
-        - range: {beg: 10009466, end: 10009467}
-          alt: AA
-          to: 0
         - range: {beg: 10009466, end: 10009467}
           alt: GT
           to: 1

--- a/test/data/gvcf_test_cases/gvcf_services_depth12.yml
+++ b/test/data/gvcf_test_cases/gvcf_services_depth12.yml
@@ -42,21 +42,21 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "21", beg: 10009464, end: 10009465}
       alleles: [TA, T]
-      copy_number: [0, 0.9755]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009464, end: 10009465}
           alt: T
           to: 1
     - range: {ref: "21", beg: 10009466, end: 10009466}
       alleles: [A, G]
-      copy_number: [0, 0.9755]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009466, end: 10009466}
           alt: G
           to: 1
     - range: {ref: "21", beg: 10009467, end: 10009467}
       alleles: [A, C]
-      copy_number: [0, 0.9755]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009467, end: 10009467}
           alt: C

--- a/test/data/gvcf_test_cases/gvcf_services_depth12.yml
+++ b/test/data/gvcf_test_cases/gvcf_services_depth12.yml
@@ -45,9 +45,6 @@ truth_unified_sites:
       copy_number: [0, 0.9755]
       unification:
         - range: {beg: 10009464, end: 10009465}
-          alt: TA
-          to: 0
-        - range: {beg: 10009464, end: 10009465}
           alt: T
           to: 1
     - range: {ref: "21", beg: 10009466, end: 10009466}
@@ -55,18 +52,12 @@ truth_unified_sites:
       copy_number: [0, 0.9755]
       unification:
         - range: {beg: 10009466, end: 10009466}
-          alt: A
-          to: 0
-        - range: {beg: 10009466, end: 10009466}
           alt: G
           to: 1
     - range: {ref: "21", beg: 10009467, end: 10009467}
       alleles: [A, C]
       copy_number: [0, 0.9755]
       unification:
-        - range: {beg: 10009467, end: 10009467}
-          alt: A
-          to: 0
         - range: {beg: 10009467, end: 10009467}
           alt: C
           to: 1

--- a/test/data/gvcf_test_cases/gvcf_services_depth9.yml
+++ b/test/data/gvcf_test_cases/gvcf_services_depth9.yml
@@ -40,7 +40,7 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "21", beg: 10009464, end: 10009465}
       alleles: [TA, T]
-      copy_number: [0, 0.9755]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009464, end: 10009465}
           alt: T

--- a/test/data/gvcf_test_cases/gvcf_services_depth9.yml
+++ b/test/data/gvcf_test_cases/gvcf_services_depth9.yml
@@ -43,9 +43,6 @@ truth_unified_sites:
       copy_number: [0, 0.9755]
       unification:
         - range: {beg: 10009464, end: 10009465}
-          alt: TA
-          to: 0
-        - range: {beg: 10009464, end: 10009465}
           alt: T
           to: 1
 

--- a/test/data/gvcf_test_cases/inconsistent_trim.yml
+++ b/test/data/gvcf_test_cases/inconsistent_trim.yml
@@ -43,17 +43,11 @@ input:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1001}
       alleles: [TA, TAA, TAAA, T]
-      copy_number: [0, 3.9693, 0.9999, 0.7583]
+      copy_number: [0, 3.9694, 0.9999, 0.7583]
       unification:
         - range: {beg: 1000, end: 1001}
-          alt: TA
-          to: 0
-        - range: {beg: 1000, end: 1002}
           alt: TAA
-          to: 0
-        - range: {beg: 1000, end: 1003}
-          alt: TAAA
-          to: 0
+          to: 1
         - range: {beg: 1000, end: 1002}
           alt: TAAA
           to: 1
@@ -63,6 +57,9 @@ truth_unified_sites:
         - range: {beg: 1000, end: 1001}
           alt: TAAA
           to: 2
+        - range: {beg: 1000, end: 1001}
+          alt: T
+          to: 3
         - range: {beg: 1000, end: 1002}
           alt: TA
           to: 3

--- a/test/data/gvcf_test_cases/inconsistent_trim.yml
+++ b/test/data/gvcf_test_cases/inconsistent_trim.yml
@@ -43,7 +43,7 @@ input:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1001}
       alleles: [TA, TAA, TAAA, T]
-      copy_number: [0, 3.9694, 0.9999, 0.7583]
+      copy_number: [0, 4, 1, 1]
       unification:
         - range: {beg: 1000, end: 1001}
           alt: TAA

--- a/test/data/gvcf_test_cases/join_3_gvcfs.yml
+++ b/test/data/gvcf_test_cases/join_3_gvcfs.yml
@@ -49,9 +49,6 @@ truth_unified_sites:
       copy_number: [0, 3]
       unification:
         - range: {beg: 1000, end: 1002}
-          alt: TTC
-          to: 0
-        - range: {beg: 1000, end: 1002}
           alt: T
           to: 1
 

--- a/test/data/gvcf_test_cases/join_gvcf_vcf.yml
+++ b/test/data/gvcf_test_cases/join_gvcf_vcf.yml
@@ -52,12 +52,6 @@ truth_unified_sites:
       copy_number: [0, 2, 1]
       unification:
         - range: {beg: 1000, end: 1000}
-          alt: T
-          to: 0
-        - range: {beg: 999, end: 1000}
-          alt: AT
-          to: 0
-        - range: {beg: 1000, end: 1000}
           alt: TC
           to: 1
         - range: {beg: 999, end: 1000}

--- a/test/data/gvcf_test_cases/join_gvcf_vcf_gvcf.yml
+++ b/test/data/gvcf_test_cases/join_gvcf_vcf_gvcf.yml
@@ -53,12 +53,6 @@ truth_unified_sites:
       copy_number: [0, 2, 1]
       unification:
         - range: {beg: 1000, end: 1000}
-          alt: T
-          to: 0
-        - range: {beg: 999, end: 1001}
-          alt: ATG
-          to: 0
-        - range: {beg: 1000, end: 1000}
           alt: TC
           to: 1
         - range: {beg: 999, end: 1001}

--- a/test/data/gvcf_test_cases/join_gvcfs.yml
+++ b/test/data/gvcf_test_cases/join_gvcfs.yml
@@ -48,9 +48,6 @@ truth_unified_sites:
       copy_number: [0, 3]
       unification:
         - range: {beg: 1000, end: 1002}
-          alt: TTC
-          to: 0
-        - range: {beg: 1000, end: 1002}
           alt: T
           to: 1
 

--- a/test/data/gvcf_test_cases/join_records_basic.yml
+++ b/test/data/gvcf_test_cases/join_records_basic.yml
@@ -46,12 +46,6 @@ truth_unified_sites:
       copy_number: [0, 2, 1]
       unification:
         - range: {beg: 1000, end: 1002}
-          alt: TTC
-          to: 0
-        - range: {beg: 1001, end: 1001}
-          alt: T
-          to: 0
-        - range: {beg: 1000, end: 1002}
           alt: T
           to: 1
         - range: {beg: 1001, end: 1001}

--- a/test/data/gvcf_test_cases/join_records_incomplete_span.yml
+++ b/test/data/gvcf_test_cases/join_records_incomplete_span.yml
@@ -40,15 +40,6 @@ truth_unified_sites:
       copy_number: [0, 2, 1, 1]
       unification:
         - range: {beg: 1000, end: 1002}
-          alt: TTC
-          to: 0
-        - range: {beg: 1000, end: 1000}
-          alt: T
-          to: 0
-        - range: {beg: 1002, end: 1002}
-          alt: C
-          to: 0
-        - range: {beg: 1000, end: 1002}
           alt: T
           to: 1
         - range: {beg: 1000, end: 1000}

--- a/test/data/gvcf_test_cases/join_records_insufficient_ref_depth.yml
+++ b/test/data/gvcf_test_cases/join_records_insufficient_ref_depth.yml
@@ -47,12 +47,6 @@ truth_unified_sites:
       copy_number: [0, 2, 1]
       unification:
         - range: {beg: 1000, end: 1002}
-          alt: TTC
-          to: 0
-        - range: {beg: 1001, end: 1001}
-          alt: T
-          to: 0
-        - range: {beg: 1000, end: 1002}
           alt: T
           to: 1
         - range: {beg: 1001, end: 1001}

--- a/test/data/gvcf_test_cases/join_records_overlapping.yml
+++ b/test/data/gvcf_test_cases/join_records_overlapping.yml
@@ -44,12 +44,6 @@ truth_unified_sites:
       alleles: [AC, AA, A]
       copy_number: [0, 3.2847, 0.7153]
       unification:
-        - range: {beg: 907970, end: 907971}
-          alt: AC
-          to: 0
-        - range: {beg: 907971, end: 907971}
-          alt: C
-          to: 0
         - range: {beg: 907971, end: 907971}
           alt: A
           to: 1

--- a/test/data/gvcf_test_cases/join_records_overlapping.yml
+++ b/test/data/gvcf_test_cases/join_records_overlapping.yml
@@ -42,7 +42,7 @@ input:
 truth_unified_sites:
     - range: {ref: A, beg: 907970, end: 907971}
       alleles: [AC, AA, A]
-      copy_number: [0, 3.2847, 0.7153]
+      copy_number: [0, 3, 1]
       unification:
         - range: {beg: 907971, end: 907971}
           alt: A

--- a/test/data/gvcf_test_cases/join_records_prefer_small.yml
+++ b/test/data/gvcf_test_cases/join_records_prefer_small.yml
@@ -40,24 +40,12 @@ truth_unified_sites:
       copy_number: [0, 1]
       unification:
         - range: {beg: 1000, end: 1000}
-          alt: T
-          to: 0
-        - range: {beg: 1000, end: 1002}
-          alt: TTC
-          to: 0
-        - range: {beg: 1000, end: 1000}
           alt: A
           to: 1
     - range: {ref: A, beg: 1002, end: 1002}
       alleles: [C, G]
       copy_number: [0, 1]
       unification:
-        - range: {beg: 1000, end: 1002}
-          alt: TTC
-          to: 0
-        - range: {beg: 1002, end: 1002}
-          alt: C
-          to: 0
         - range: {beg: 1002, end: 1002}
           alt: G
           to: 1

--- a/test/data/gvcf_test_cases/join_records_unjoinable.yml
+++ b/test/data/gvcf_test_cases/join_records_unjoinable.yml
@@ -43,15 +43,6 @@ truth_unified_sites:
       copy_number: [0, 2, 1, 1]
       unification:
         - range: {beg: 1000, end: 1002}
-          alt: TTC
-          to: 0
-        - range: {beg: 1000, end: 1000}
-          alt: T
-          to: 0
-        - range: {beg: 1002, end: 1002}
-          alt: C
-          to: 0
-        - range: {beg: 1000, end: 1002}
           alt: T
           to: 1
         - range: {beg: 1000, end: 1000}

--- a/test/data/gvcf_test_cases/join_vcf_gvcf.yml
+++ b/test/data/gvcf_test_cases/join_vcf_gvcf.yml
@@ -48,12 +48,6 @@ truth_unified_sites:
       copy_number: [0, 2, 1]
       unification:
         - range: {beg: 1000, end: 1000}
-          alt: A
-          to: 0
-        - range: {beg: 1000, end: 1001}
-          alt: AT
-          to: 0
-        - range: {beg: 1000, end: 1000}
           alt: AT
           to: 1
         - range: {beg: 1000, end: 1001}

--- a/test/data/gvcf_test_cases/lost_deletion.yml
+++ b/test/data/gvcf_test_cases/lost_deletion.yml
@@ -55,15 +55,6 @@ truth_unified_sites:
       alleles: [TGGGGCCG, T, TGGAGCCG]
       copy_number: [0, 4, 2]
       unification:
-        - range: {beg: 608819, end: 608843}
-          alt: AGGGACTGGGGCCGGGACCGGGACC
-          to: 0
-        - range: {beg: 608825, end: 608832}
-          alt: TGGGGCCG
-          to: 0
-        - range: {beg: 608828, end: 608828}
-          alt: G
-          to: 0
         - range: {beg: 608825, end: 608832}
           alt: T
           to: 1
@@ -74,12 +65,6 @@ truth_unified_sites:
       alleles: [ACCGGGACCGGGACTGGG, A]
       copy_number: [0, 4]
       unification:
-        - range: {beg: 608819, end: 608843}
-          alt: AGGGACTGGGGCCGGGACCGGGACC
-          to: 0
-        - range: {beg: 608835, end: 608852}
-          alt: ACCGGGACCGGGACTGGG
-          to: 0
         - range: {beg: 608835, end: 608852}
           alt: A
           to: 1

--- a/test/data/gvcf_test_cases/minAQ.yml
+++ b/test/data/gvcf_test_cases/minAQ.yml
@@ -6,6 +6,7 @@ readme: |
   3) Only one sample has an allele; the allele, and in fact the whole site, is pruned.
   4) Equivalent alleles with different representations are combined properly.
   5) Multi-allelic situation where one ALT allele qualifies and the other doesn't.
+  6) Case with low GQ but high AQ (ambiguity between 0/1 and 1/1)
 
 input:
   header : |-
@@ -33,6 +34,7 @@ input:
         21	10009462	.	T	<NON_REF>	.	.	END=10009463	GT:GQ:MIN_DP:PL	0/0:36:14:0,36,540
         21	10009464	.	TA	TC,<NON_REF>	0.03	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:12:12,0,240,46,246,292:1,9,1,1
         21	10009466	.	T	A,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:16:16,0,240,46,246,292:1,9,1,1
+        21	10009467	.	T	<NON_REF>	.	.	END=10009468	GT:GQ:MIN_DP:PL	0/0:36:14:0,36,540
     - NA12879.gvcf: |
         NA12879
         21	10009460	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
@@ -41,6 +43,7 @@ input:
         21	10009463	.	A	<NON_REF>	.	.	END=10009464	GT:DP:GQ:MIN_DP:PL:SB	0/0:13:0:13:0,0,342:1,1,1,1
         21	10009465	.	A	C,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:9:2:2,0,240,46,246,292:1,9,1,1
         21	10009466	.	T	G,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
+        21	10009467	.	T	A,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:1,6,0:7:9:198,0,9,46,246,292:1,9,1,1
 
 unifier_config:
   minAQ: 10
@@ -111,6 +114,16 @@ truth_discovered_alleles:
       is_ref: false
       copy_number: 0.6131
       maxAQ: 2
+    - range: {ref: "21", beg: 10009467, end: 10009467}
+      dna: 'T'
+      is_ref: true
+      copy_number: 0.8882
+      maxAQ: 9
+    - range: {ref: "21", beg: 10009467, end: 10009467}
+      dna: 'A'
+      is_ref: false
+      copy_number: 1.1118
+      maxAQ: 46
 
 truth_unified_sites:
     - range: {ref: "21", beg: 10009461, end: 10009461}
@@ -137,6 +150,13 @@ truth_unified_sites:
         - range: {beg: 10009466, end: 10009466}
           alt: A
           to: 1
+    - range: {ref: 21, beg: 10009467, end: 10009467}
+      alleles: [T, A]
+      copy_number: [0, 1.1118]
+      unification:
+        - range: {beg: 10009467, end: 10009467}
+          alt: A
+          to: 1
 
 truth_output_vcf:
   - truth.vcf: |
@@ -149,3 +169,4 @@ truth_output_vcf:
       21	10009461	.	T	A	.	.	.	GT:RNC	0/1:..	0/1:..
       21	10009465	.	A	C	.	.	.	GT:RNC	0/1:..	0/1:..
       21	10009466	.	T	A	.	.	.	GT:RNC	0/1:..	0/.:.L
+      21	10009467	.	T	A	.	.	.	GT:RNC	0/0:..	0/1:..

--- a/test/data/gvcf_test_cases/minAQ.yml
+++ b/test/data/gvcf_test_cases/minAQ.yml
@@ -1,7 +1,7 @@
 readme: |
-  Exercises the unifier's filtration of discovered alleles based on qualifying GQ.
+  Exercises the unifier's filtration of discovered alleles based on Allele Quality (AQ)
   Four sites in two samples:
-  1) Both samples have weak evidence for an allele, neither meeting the GQ threshold.
+  1) Both samples have weak evidence for an allele, neither meeting the AQ threshold.
   2) Similar but one strong, one weak -- allele is kept.
   3) Only one sample has an allele; the allele, and in fact the whole site, is pruned.
   4) Equivalent alleles with different representations are combined properly.
@@ -31,98 +31,98 @@ input:
         21	10009460	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
         21	10009461	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:20:2,0,240,46,246,292:1,9,1,1
         21	10009462	.	T	<NON_REF>	.	.	END=10009463	GT:GQ:MIN_DP:PL	0/0:36:14:0,36,540
-        21	10009464	.	TA	TC,<NON_REF>	0.03	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:12:2,0,240,46,246,292:1,9,1,1
+        21	10009464	.	TA	TC,<NON_REF>	0.03	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:12:12,0,240,46,246,292:1,9,1,1
         21	10009466	.	T	A,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:16:16,0,240,46,246,292:1,9,1,1
     - NA12879.gvcf: |
         NA12879
         21	10009460	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
-        21	10009461	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
+        21	10009461	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:20,0,240,46,246,292:1,9,1,1
         21	10009462	.	T	A,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
         21	10009463	.	A	<NON_REF>	.	.	END=10009464	GT:DP:GQ:MIN_DP:PL:SB	0/0:13:0:13:0,0,342:1,1,1,1
         21	10009465	.	A	C,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:9:2:2,0,240,46,246,292:1,9,1,1
         21	10009466	.	T	G,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
 
 unifier_config:
-  minGQ: 10
+  minAQ: 10
 
 truth_discovered_alleles:
     - range: {ref: "21", beg: 10009460, end: 10009460}
       dna: 'T'
       is_ref: true
       copy_number: 2.7738
-      maxGQ: 2
+      maxAQ: 240
     - range: {ref: "21", beg: 10009460, end: 10009460}
       dna: 'A'
       is_ref: false
       copy_number: 1.2262
-      maxGQ: 2
+      maxAQ: 2
     - range: {ref: "21", beg: 10009461, end: 10009461}
       dna: 'T'
       is_ref: true
-      copy_number: 2.7738
-      maxGQ: 20
+      copy_number: 2.3968
+      maxAQ: 240
     - range: {ref: "21", beg: 10009461, end: 10009461}
       dna: 'A'
       is_ref: false
-      copy_number: 1.2262
-      maxGQ: 20
+      copy_number: 1.6032
+      maxAQ: 20
     - range: {ref: "21", beg: 10009462, end: 10009462}
       dna: 'T'
       is_ref: true
       copy_number: 1.3869
-      maxGQ: 2
+      maxAQ: 240
     - range: {ref: "21", beg: 10009462, end: 10009462}
       dna: 'A'
       is_ref: false
       copy_number: 0.6131
-      maxGQ: 2
+      maxAQ: 2
     - range: {ref: "21", beg: 10009464, end: 10009465}
       dna: 'TA'
       is_ref: true
-      copy_number: 1.3869
-      maxGQ: 12
+      copy_number: 1.0593
+      maxAQ: 240
     - range: {ref: "21", beg: 10009464, end: 10009465}
       dna: 'TC'
       is_ref: false
-      copy_number: 0.6131
-      maxGQ: 12
+      copy_number: 0.9406
+      maxAQ: 12
     - range: {ref: "21", beg: 10009465, end: 10009465}
       dna: 'A'
       is_ref: true
       copy_number: 1.3869
-      maxGQ: 2
+      maxAQ: 240
     - range: {ref: "21", beg: 10009465, end: 10009465}
       dna: 'C'
       is_ref: false
       copy_number: 0.6131
-      maxGQ: 2
+      maxAQ: 2
     - range: {ref: "21", beg: 10009466, end: 10009466}
       dna: 'T'
       is_ref: true
       copy_number: 2.4114
-      maxGQ: 16
+      maxAQ: 240
     - range: {ref: "21", beg: 10009466, end: 10009466}
       dna: 'A'
       is_ref: false
       copy_number: 0.9755
-      maxGQ: 16
+      maxAQ: 16
     - range: {ref: "21", beg: 10009466, end: 10009466}
       dna: 'G'
       is_ref: false
       copy_number: 0.6131
-      maxGQ: 2    
+      maxAQ: 2
 
 truth_unified_sites:
     - range: {ref: "21", beg: 10009461, end: 10009461}
       alleles: [T, A]
-      copy_number: [0, 1.2262]
+      copy_number: [0, 1.6032]
       unification:
         - range: {beg: 10009461, end: 10009461}
           alt: A
           to: 1
     - range: {ref: "21", beg: 10009465, end: 10009465}
       alleles: [A, C]
-      copy_number: [0, 1.2262]
+      copy_number: [0, 1.5537]
       unification:
         - range: {beg: 10009464, end: 10009465}
           alt: TC

--- a/test/data/gvcf_test_cases/minAQ.yml
+++ b/test/data/gvcf_test_cases/minAQ.yml
@@ -52,90 +52,91 @@ truth_discovered_alleles:
     - range: {ref: "21", beg: 10009460, end: 10009460}
       dna: 'T'
       is_ref: true
-      copy_number: 2.7738
       maxAQ: 240
+      zygosity_by_GQ: [[2,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009460, end: 10009460}
       dna: 'A'
       is_ref: false
-      copy_number: 1.2262
       maxAQ: 2
+      zygosity_by_GQ: [[2,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009461, end: 10009461}
       dna: 'T'
       is_ref: true
-      copy_number: 2.3968
       maxAQ: 240
+      zygosity_by_GQ: [[1,0],[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009461, end: 10009461}
       dna: 'A'
       is_ref: false
-      copy_number: 1.6032
       maxAQ: 20
+      zygosity_by_GQ: [[1,0],[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009462, end: 10009462}
       dna: 'T'
       is_ref: true
-      copy_number: 1.3869
       maxAQ: 240
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009462, end: 10009462}
       dna: 'A'
       is_ref: false
-      copy_number: 0.6131
       maxAQ: 2
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009464, end: 10009465}
       dna: 'TA'
       is_ref: true
-      copy_number: 1.0593
       maxAQ: 240
+      zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009464, end: 10009465}
       dna: 'TC'
       is_ref: false
       copy_number: 0.9406
       maxAQ: 12
+      zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009465, end: 10009465}
       dna: 'A'
       is_ref: true
-      copy_number: 1.3869
       maxAQ: 240
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009465, end: 10009465}
       dna: 'C'
       is_ref: false
-      copy_number: 0.6131
       maxAQ: 2
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009466, end: 10009466}
       dna: 'T'
       is_ref: true
-      copy_number: 2.4114
       maxAQ: 240
+      zygosity_by_GQ: [[1,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009466, end: 10009466}
       dna: 'A'
       is_ref: false
-      copy_number: 0.9755
       maxAQ: 16
+      zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009466, end: 10009466}
       dna: 'G'
       is_ref: false
-      copy_number: 0.6131
       maxAQ: 2
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009467, end: 10009467}
       dna: 'T'
       is_ref: true
-      copy_number: 0.8882
       maxAQ: 9
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009467, end: 10009467}
       dna: 'A'
       is_ref: false
-      copy_number: 1.1118
       maxAQ: 46
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 
 truth_unified_sites:
     - range: {ref: "21", beg: 10009461, end: 10009461}
       alleles: [T, A]
-      copy_number: [0, 1.6032]
+      copy_number: [0, 2]
       unification:
         - range: {beg: 10009461, end: 10009461}
           alt: A
           to: 1
     - range: {ref: "21", beg: 10009465, end: 10009465}
       alleles: [A, C]
-      copy_number: [0, 1.5537]
+      copy_number: [0, 2]
       unification:
         - range: {beg: 10009464, end: 10009465}
           alt: TC
@@ -145,14 +146,14 @@ truth_unified_sites:
           to: 1
     - range: {ref: 21, beg: 10009466, end: 10009466}
       alleles: [T, A]
-      copy_number: [0, 0.9755]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009466, end: 10009466}
           alt: A
           to: 1
     - range: {ref: 21, beg: 10009467, end: 10009467}
       alleles: [T, A]
-      copy_number: [0, 1.1118]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009467, end: 10009467}
           alt: A

--- a/test/data/gvcf_test_cases/minGQ.yml
+++ b/test/data/gvcf_test_cases/minGQ.yml
@@ -1,10 +1,11 @@
 readme: |
-  Exercises the unifier's filtration of discovered alleles based on estimated copy number.
+  Exercises the unifier's filtration of discovered alleles based on qualifying GQ.
   Four sites in two samples:
-  1) Both samples have weak evidence for an allele, and only together is the copy number sufficient.
-  2) Only one sample has an allele; the allele, and in fact the whole site, is pruned.
-  3) Copy numbers of equivalent alleles with different representations are combined properly.
-  4) Multi-allelic situation where one ALT allele qualifies and the other doesn't.
+  1) Both samples have weak evidence for an allele, neither meeting the GQ threshold.
+  2) Similar but one strong, one weak -- allele is kept.
+  3) Only one sample has an allele; the allele, and in fact the whole site, is pruned.
+  4) Equivalent alleles with different representations are combined properly.
+  5) Multi-allelic situation where one ALT allele qualifies and the other doesn't.
 
 input:
   header : |-
@@ -27,20 +28,89 @@ input:
   body:
     - NA12878.gvcf: |
         NA12878
-        21	10009461	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
+        21	10009460	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
+        21	10009461	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:20:2,0,240,46,246,292:1,9,1,1
         21	10009462	.	T	<NON_REF>	.	.	END=10009463	GT:GQ:MIN_DP:PL	0/0:36:14:0,36,540
-        21	10009464	.	TA	TC,<NON_REF>	0.03	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
+        21	10009464	.	TA	TC,<NON_REF>	0.03	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:12:2,0,240,46,246,292:1,9,1,1
         21	10009466	.	T	A,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:16:16,0,240,46,246,292:1,9,1,1
     - NA12879.gvcf: |
         NA12879
+        21	10009460	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
         21	10009461	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
         21	10009462	.	T	A,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
         21	10009463	.	A	<NON_REF>	.	.	END=10009464	GT:DP:GQ:MIN_DP:PL:SB	0/0:13:0:13:0,0,342:1,1,1,1
-        21	10009465	.	A	C,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
+        21	10009465	.	A	C,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:9:2:2,0,240,46,246,292:1,9,1,1
         21	10009466	.	T	G,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
 
 unifier_config:
-  min_allele_copy_number: 0.9
+  minGQ: 10
+
+truth_discovered_alleles:
+    - range: {ref: "21", beg: 10009460, end: 10009460}
+      dna: 'T'
+      is_ref: true
+      copy_number: 2.7738
+      maxGQ: 2
+    - range: {ref: "21", beg: 10009460, end: 10009460}
+      dna: 'A'
+      is_ref: false
+      copy_number: 1.2262
+      maxGQ: 2
+    - range: {ref: "21", beg: 10009461, end: 10009461}
+      dna: 'T'
+      is_ref: true
+      copy_number: 2.7738
+      maxGQ: 20
+    - range: {ref: "21", beg: 10009461, end: 10009461}
+      dna: 'A'
+      is_ref: false
+      copy_number: 1.2262
+      maxGQ: 20
+    - range: {ref: "21", beg: 10009462, end: 10009462}
+      dna: 'T'
+      is_ref: true
+      copy_number: 1.3869
+      maxGQ: 2
+    - range: {ref: "21", beg: 10009462, end: 10009462}
+      dna: 'A'
+      is_ref: false
+      copy_number: 0.6131
+      maxGQ: 2
+    - range: {ref: "21", beg: 10009464, end: 10009465}
+      dna: 'TA'
+      is_ref: true
+      copy_number: 1.3869
+      maxGQ: 12
+    - range: {ref: "21", beg: 10009464, end: 10009465}
+      dna: 'TC'
+      is_ref: false
+      copy_number: 0.6131
+      maxGQ: 12
+    - range: {ref: "21", beg: 10009465, end: 10009465}
+      dna: 'A'
+      is_ref: true
+      copy_number: 1.3869
+      maxGQ: 2
+    - range: {ref: "21", beg: 10009465, end: 10009465}
+      dna: 'C'
+      is_ref: false
+      copy_number: 0.6131
+      maxGQ: 2
+    - range: {ref: "21", beg: 10009466, end: 10009466}
+      dna: 'T'
+      is_ref: true
+      copy_number: 2.4114
+      maxGQ: 16
+    - range: {ref: "21", beg: 10009466, end: 10009466}
+      dna: 'A'
+      is_ref: false
+      copy_number: 0.9755
+      maxGQ: 16
+    - range: {ref: "21", beg: 10009466, end: 10009466}
+      dna: 'G'
+      is_ref: false
+      copy_number: 0.6131
+      maxGQ: 2    
 
 truth_unified_sites:
     - range: {ref: "21", beg: 10009461, end: 10009461}

--- a/test/data/gvcf_test_cases/min_allele_copy_number.yml
+++ b/test/data/gvcf_test_cases/min_allele_copy_number.yml
@@ -30,7 +30,7 @@ input:
         21	10009461	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
         21	10009462	.	T	<NON_REF>	.	.	END=10009463	GT:GQ:MIN_DP:PL	0/0:36:14:0,36,540
         21	10009464	.	TA	TC,<NON_REF>	0.03	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
-        21	10009466	.	T	A,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:16:16,0,240,46,246,292:1,9,1,1
+        21	10009466	.	T	A,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	1/1:10,2,0:12:16:16,240,0,46,246,292:1,9,1,1
     - NA12879.gvcf: |
         NA12879
         21	10009461	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
@@ -40,19 +40,19 @@ input:
         21	10009466	.	T	G,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
 
 unifier_config:
-  min_allele_copy_number: 0.9
+  min_allele_copy_number: 2
 
 truth_unified_sites:
     - range: {ref: "21", beg: 10009461, end: 10009461}
       alleles: [T, A]
-      copy_number: [0, 1.2262]
+      copy_number: [0, 2]
       unification:
         - range: {beg: 10009461, end: 10009461}
           alt: A
           to: 1
     - range: {ref: "21", beg: 10009465, end: 10009465}
       alleles: [A, C]
-      copy_number: [0, 1.2262]
+      copy_number: [0, 2]
       unification:
         - range: {beg: 10009464, end: 10009465}
           alt: TC
@@ -62,7 +62,7 @@ truth_unified_sites:
           to: 1
     - range: {ref: 21, beg: 10009466, end: 10009466}
       alleles: [T, A]
-      copy_number: [0, 0.9755]
+      copy_number: [0, 2]
       unification:
         - range: {beg: 10009466, end: 10009466}
           alt: A
@@ -78,4 +78,4 @@ truth_output_vcf:
       #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878	NA12879
       21	10009461	.	T	A	.	.	.	GT:RNC	0/1:..	0/1:..
       21	10009465	.	A	C	.	.	.	GT:RNC	0/1:..	0/1:..
-      21	10009466	.	T	A	.	.	.	GT:RNC	0/1:..	0/.:.L
+      21	10009466	.	T	A	.	.	.	GT:RNC	1/1:..	0/.:.L

--- a/test/data/gvcf_test_cases/min_allele_copy_number.yml
+++ b/test/data/gvcf_test_cases/min_allele_copy_number.yml
@@ -48,21 +48,12 @@ truth_unified_sites:
       copy_number: [0, 1.2262]
       unification:
         - range: {beg: 10009461, end: 10009461}
-          alt: T
-          to: 0
-        - range: {beg: 10009461, end: 10009461}
           alt: A
           to: 1
     - range: {ref: "21", beg: 10009465, end: 10009465}
       alleles: [A, C]
       copy_number: [0, 1.2262]
       unification:
-        - range: {beg: 10009464, end: 10009465}
-          alt: TA
-          to: 0
-        - range: {beg: 10009465, end: 10009465}
-          alt: A
-          to: 0
         - range: {beg: 10009464, end: 10009465}
           alt: TC
           to: 1
@@ -73,9 +64,6 @@ truth_unified_sites:
       alleles: [T, A]
       copy_number: [0, 0.9755]
       unification:
-        - range: {beg: 10009466, end: 10009466}
-          alt: T
-          to: 0
         - range: {beg: 10009466, end: 10009466}
           alt: A
           to: 1

--- a/test/data/gvcf_test_cases/min_quality.yml
+++ b/test/data/gvcf_test_cases/min_quality.yml
@@ -43,10 +43,10 @@ input:
         21	10009463	.	A	<NON_REF>	.	.	END=10009464	GT:DP:GQ:MIN_DP:PL:SB	0/0:13:0:13:0,0,342:1,1,1,1
         21	10009465	.	A	C,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:9:2:2,0,240,46,246,292:1,9,1,1
         21	10009466	.	T	G,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
-        21	10009467	.	T	A,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:1,6,0:7:9:198,0,9,46,246,292:1,9,1,1
+        21	10009467	.	T	A,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:1,6,0:7:11:198,0,11,46,246,292:1,9,1,1
 
 unifier_config:
-  minAQ: 10
+  min_quality: 10
 
 truth_discovered_alleles:
     - range: {ref: "21", beg: 10009460, end: 10009460}
@@ -118,25 +118,25 @@ truth_discovered_alleles:
     - range: {ref: "21", beg: 10009467, end: 10009467}
       dna: 'T'
       is_ref: true
-      maxAQ: 9
-      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+      maxAQ: 11
+      zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009467, end: 10009467}
       dna: 'A'
       is_ref: false
       maxAQ: 46
-      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+      zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 
 truth_unified_sites:
     - range: {ref: "21", beg: 10009461, end: 10009461}
       alleles: [T, A]
-      copy_number: [0, 2]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009461, end: 10009461}
           alt: A
           to: 1
     - range: {ref: "21", beg: 10009465, end: 10009465}
       alleles: [A, C]
-      copy_number: [0, 2]
+      copy_number: [0, 1]
       unification:
         - range: {beg: 10009464, end: 10009465}
           alt: TC

--- a/test/data/gvcf_test_cases/rs11429009.yml
+++ b/test/data/gvcf_test_cases/rs11429009.yml
@@ -45,12 +45,6 @@ truth_unified_sites:
       copy_number: [0, 2, 1, 1]
       unification:
       - range: {beg: 15643381, end: 15643382}
-        alt: CA
-        to: 0
-      - range: {beg: 15643382, end: 15643382}
-        alt: A
-        to: 0
-      - range: {beg: 15643381, end: 15643382}
         alt: C
         to: 1
       - range: {beg: 15643381, end: 15643382}

--- a/test/data/gvcf_test_cases/rs11429009.yml
+++ b/test/data/gvcf_test_cases/rs11429009.yml
@@ -41,17 +41,17 @@ input:
         17	15643383	.	A	<NON_REF>	.	.	END=15643383	GT:DP:GQ:MIN_DP:PL	0/0:82:0:82:0,0,784
 truth_unified_sites:
     - range: {ref: 17, beg: 15643381, end: 15643382}
-      alleles: [CA, C, CAA, CAC]
+      alleles: [CA, C, CAC, CAA]
       copy_number: [0, 2, 1, 1]
       unification:
       - range: {beg: 15643381, end: 15643382}
         alt: C
         to: 1
-      - range: {beg: 15643381, end: 15643382}
-        alt: CAA
-        to: 2
       - range: {beg: 15643382, end: 15643382}
         alt: AC
+        to: 2
+      - range: {beg: 15643381, end: 15643382}
+        alt: CAA
         to: 3
 truth_output_vcf:
   - truth.vcf: |
@@ -61,4 +61,4 @@ truth_output_vcf:
       ##FORMAT=<ID=RNC,Number=G,Type=Character,Description="Reason for No Call in GT: . = n/a, M = Missing data, P = Partial data, D = insufficient Depth of coverage, - = unrepresentable overlapping deletion, L = Lost/unrepresentable allele (other than deletion), U = multiple Unphased variants present, O = multiple Overlapping variants present">
       ##contig=<ID=17,length=20000000>
       #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	A	B	C	D
-      17	15643381	.	CA	C,CAA,CAC	0	.	.	GT:RNC	0/1:..	0/1:..	0/2:..	0/3:..
+      17	15643381	.	CA	C,CAC,CAA	0	.	.	GT:RNC	0/1:..	0/1:..	0/3:..	0/2:..

--- a/test/data/gvcf_test_cases/rs141305015.yml
+++ b/test/data/gvcf_test_cases/rs141305015.yml
@@ -1,5 +1,7 @@
 readme: |
   This tests the treatment of "pseudo" reference confidence records that don't all overlap a variant record.
+
+  Also performs a detailed check of zygosity_by_GQ tabulation.
 input:
   header : |-
       ##fileformat=VCFv4.2
@@ -28,6 +30,53 @@ input:
     - C.gvcf: |
         C
         A	36643699	.	A	<NON_REF>	.	.	END=36645699	GT:DP:GQ:MIN_DP:PL	0/0:58:0:58:0,0,1608
+
+truth_discovered_alleles:
+    - range: {ref: A, beg: 36643697, end: 36643700}
+      dna: 'AACG'
+      is_ref: true
+      maxAQ: 2757
+      zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,1],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: A, beg: 36643697, end: 36643700}
+      dna: 'A'
+      is_ref: false
+      maxAQ: 0
+      zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: A, beg: 36643699, end: 36643702}
+      dna: 'CGAG'
+      is_ref: true
+      maxAQ: 2011
+      zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,1]]
+    - range: {ref: A, beg: 36643699, end: 36643702}
+      dna: 'C'
+      is_ref: false
+      maxAQ: 0
+      zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: A, beg: 36643700, end: 36643703}
+      dna: 'GAGA'
+      is_ref: true
+      maxAQ: 1026
+      zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[1,0]]
+    - range: {ref: A, beg: 36643700, end: 36643703}
+      dna: 'G'
+      is_ref: false
+      maxAQ: 1890
+      zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[1,1]]
+    - range: {ref: A, beg: 36643703, end: 36643703}
+      dna: 'A'
+      is_ref: true
+      maxAQ: 2639
+      zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,1],[0,0],[0,0],[0,0],[0,0],[0,0],[0,1]]
+    - range: {ref: A, beg: 36643703, end: 36643703}
+      dna: 'G'
+      is_ref: false
+      maxAQ: 0
+      zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: A, beg: 36643703, end: 36643703}
+      dna: 'T'
+      is_ref: false
+      maxAQ: 0
+      zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 
 truth_unified_sites:
     - range: {ref: A, beg: 36643700, end: 36643703}

--- a/test/data/gvcf_test_cases/rs141305015.yml
+++ b/test/data/gvcf_test_cases/rs141305015.yml
@@ -35,9 +35,6 @@ truth_unified_sites:
       copy_number: [0, 3]
       unification:
         - range: {beg: 36643700, end: 36643703}
-          alt: GAGA
-          to: 0
-        - range: {beg: 36643700, end: 36643703}
           alt: G
           to: 1
 

--- a/test/data/gvcf_test_cases/trim_input.yml
+++ b/test/data/gvcf_test_cases/trim_input.yml
@@ -45,14 +45,8 @@ truth_unified_sites:
       copy_number: [0, 8]
       unification:
         - range: {beg: 1000, end: 1001}
-          alt: AT
-          to: 0
-        - range: {beg: 1000, end: 1001}
           alt: A
           to: 1
-        - range: {beg: 1000, end: 1002}
-          alt: ATT
-          to: 0
         - range: {beg: 1000, end: 1002}
           alt: AT
           to: 1

--- a/test/data/gvcf_test_cases/vcf_services.yml
+++ b/test/data/gvcf_test_cases/vcf_services.yml
@@ -39,18 +39,12 @@ truth_unified_sites:
       copy_number: [0, 6]
       unification:
         - range: {beg: 1001, end: 1001}
-          alt: A
-          to: 0
-        - range: {beg: 1001, end: 1001}
           alt: G
           to: 1
     - range: {ref: "A", beg: 1002, end: 1002}
       alleles: [C, A, G, T]
       copy_number: [0, 6, 2, 2]
       unification:
-        - range: {beg: 1002, end: 1002}
-          alt: C
-          to: 0
         - range: {beg: 1002, end: 1002}
           alt: A
           to: 1
@@ -65,12 +59,6 @@ truth_unified_sites:
       copy_number: [0, 3, 2]
       unification:
         - range: {beg: 1011, end: 1012}
-          alt: CC
-          to: 0
-        - range: {beg: 1011, end: 1013}
-          alt: CCC
-          to: 0
-        - range: {beg: 1011, end: 1012}
           alt: AG
           to: 1
         - range: {beg: 1011, end: 1013}
@@ -81,24 +69,12 @@ truth_unified_sites:
       copy_number: [0, 3]
       unification:
         - range: {beg: 1101, end: 1101}
-          alt: C
-          to: 0
-        - range: {beg: 1101, end: 1103}
-          alt: CCC
-          to: 0
-        - range: {beg: 1101, end: 1101}
           alt: A
           to: 1
     - range: {ref: "A", beg: 1103, end: 1103}
       alleles: [C, G]
       copy_number: [0, 3]
       unification:
-        - range: {beg: 1101, end: 1103}
-          alt: CCC
-          to: 0
-        - range: {beg: 1103, end: 1103}
-          alt: C
-          to: 0
         - range: {beg: 1103, end: 1103}
           alt: G
           to: 1
@@ -106,9 +82,6 @@ truth_unified_sites:
       alleles: [C, A]
       copy_number: [0, 3]
       unification:
-        - range: {beg: 1201, end: 1201}
-          alt: C
-          to: 0
         - range: {beg: 1201, end: 1201}
           alt: A
           to: 1

--- a/test/diploid.cc
+++ b/test/diploid.cc
@@ -37,6 +37,66 @@ TEST_CASE("diploid::alleles_gt") {
     }
 }
 
+TEST_CASE("diploid::alleles_maxAQ") {
+    // tests with one overwhelmingly likely genotype
+    for (int n_allele=2; n_allele<16; n_allele++) {
+        auto nGT = diploid::genotypes(n_allele);
+        for (int gt=0; gt<nGT; gt++) {
+            auto al1 = diploid::gt_alleles(gt).first;
+            auto al2 = diploid::gt_alleles(gt).second;
+
+            vector<double> gl(diploid::genotypes(n_allele), 0.01);
+            gl[gt] = 1.0;
+            vector<int> AQ;
+            Status s = diploid::alleles_maxAQ(n_allele, 1, {0}, gl, AQ);
+            REQUIRE(AQ.size() == n_allele);
+            for (int al = 0; al<n_allele; al++) {
+                if (al == al1 || al == al2) {
+                    REQUIRE(AQ[al] == 20);
+                } else {
+                    REQUIRE(AQ[al] == 0);
+                }
+            }
+        }
+    }
+
+    // tests with a second-rank genotype
+    for (int n_allele=2; n_allele<16; n_allele++) {
+        auto nGT = diploid::genotypes(n_allele);
+        for (int gt=0; gt<nGT; gt++) {
+            auto al1 = diploid::gt_alleles(gt).first;
+            auto al2 = diploid::gt_alleles(gt).second;
+
+            for (int gt2=0; gt2<nGT; gt2++) {
+                if (gt != gt2) {
+                    auto al3 = diploid::gt_alleles(gt2).first;
+                    auto al4 = diploid::gt_alleles(gt2).second;
+
+                    vector<double> gl(diploid::genotypes(n_allele), 0.001);
+                    gl[gt] = 1.0;
+                    gl[gt2] = 0.1;
+                    vector<int> AQ;
+                    Status s = diploid::alleles_maxAQ(n_allele, 1, {0}, gl, AQ);
+                    REQUIRE(AQ.size() == n_allele);
+                    for (int al = 0; al<n_allele; al++) {
+                         if (al == al1 || al == al2) {
+                             if (al == al3 || al == al4) {
+                                 REQUIRE(AQ[al] == 30);
+                             } else {
+                                 REQUIRE(AQ[al] == 10);
+                             }
+                        } else {
+                            REQUIRE(AQ[al] == 0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // TODO: multi-sample tests
+}
+
 TEST_CASE("diploid::trio::mendelian_inconsistencies") {
     using namespace diploid;
 

--- a/test/gvcf_test_cases.cc
+++ b/test/gvcf_test_cases.cc
@@ -248,8 +248,17 @@ public:
         Status s = execute_discover_alleles(als, sampleset, pos);
         REQUIRE(s.ok());
 
-        // Print comparison pf dsals before failing
-        if (als != truth_dsals) {
+        bool eq = true;
+        auto lhs = als.begin(), rhs = truth_dsals.begin();
+        for (; lhs != als.end() && rhs != truth_dsals.end(); ++lhs, ++rhs) {
+            if (lhs->first != rhs->first || lhs->second != rhs->second) {
+                if (eq) print_header();
+                cout << lhs->first.str() << ":" << lhs->second.str() << endl;
+                cout << rhs->first.str() << ":" << rhs->second.str() << endl;
+                eq = false;
+            }
+        }
+        if (eq && (lhs != als.end() || rhs != truth_dsals.end())) {
             print_header();
             cout << "Expected discovered alleles \n";
             for (auto& dsal : truth_dsals) {
@@ -260,7 +269,9 @@ public:
             for (auto &dsal : als) {
                 cout << dsal.first.str() << ":" << dsal.second.str() << endl;
             }
+            eq = false;
         }
+        REQUIRE(eq);
 
         REQUIRE(als == truth_dsals);
         return Status::OK();
@@ -617,6 +628,10 @@ TEST_CASE("DP0_noAD") {
 
 TEST_CASE("min_allele_copy_number") {
     GVCFTestCase("min_allele_copy_number").perform_gvcf_test();
+}
+
+TEST_CASE("minGQ") {
+    GVCFTestCase("minGQ",true,true,true).perform_gvcf_test();
 }
 
 TEST_CASE("rs141305015") {

--- a/test/gvcf_test_cases.cc
+++ b/test/gvcf_test_cases.cc
@@ -452,10 +452,10 @@ TEST_CASE("services test: discover_alleles") {
         REQUIRE(als.size() == 7);
         auto p = als.find(allele(range(0, 1000, 1001), "G"));
         REQUIRE(p != als.end());
-        REQUIRE(p->second.copy_number == 4);
+        REQUIRE(p->second.zGQ.copy_number() == 4);
         p = als.find(allele(range(0, 1010, 1012), "CC"));
         REQUIRE(p != als.end());
-        REQUIRE(p->second.copy_number == 3);
+        REQUIRE(p->second.zGQ.copy_number() == 3);
     }
 
     SECTION("trio1 partial") {
@@ -468,7 +468,7 @@ TEST_CASE("services test: discover_alleles") {
         REQUIRE(s.ok());
 
         REQUIRE(als.size() == 2);
-        REQUIRE(als.find(allele(range(0, 1010, 1012), "CC"))->second.copy_number == 3);
+        REQUIRE(als.find(allele(range(0, 1010, 1012), "CC"))->second.zGQ.copy_number() == 3);
     }
 
     SECTION("spanning allele") {
@@ -480,7 +480,7 @@ TEST_CASE("services test: discover_alleles") {
         s = discover_allele_case.execute_discover_alleles(als, "<ALL>", range(1, 1001, 1016));
         REQUIRE(s.ok());
         REQUIRE(als.size() == 6);
-        REQUIRE(als.find(allele(range(1, 1001, 1016), "AAAAAAAAAAAAAAA"))->second.copy_number == 3);
+        REQUIRE(als.find(allele(range(1, 1001, 1016), "AAAAAAAAAAAAAAA"))->second.zGQ.copy_number() == 3);
     }
 
     SECTION("detect inconsistent reference alleles") {

--- a/test/gvcf_test_cases.cc
+++ b/test/gvcf_test_cases.cc
@@ -630,8 +630,8 @@ TEST_CASE("min_allele_copy_number") {
     GVCFTestCase("min_allele_copy_number").perform_gvcf_test();
 }
 
-TEST_CASE("minGQ") {
-    GVCFTestCase("minGQ",true,true,true).perform_gvcf_test();
+TEST_CASE("minAQ") {
+    GVCFTestCase("minAQ",true,true,true).perform_gvcf_test();
 }
 
 TEST_CASE("rs141305015") {

--- a/test/gvcf_test_cases.cc
+++ b/test/gvcf_test_cases.cc
@@ -635,7 +635,7 @@ TEST_CASE("min_quality") {
 }
 
 TEST_CASE("rs141305015") {
-    GVCFTestCase("rs141305015").perform_gvcf_test();
+    GVCFTestCase("rs141305015",true).perform_gvcf_test();
 }
 
 TEST_CASE("rs11429009 allele unifier test") {

--- a/test/gvcf_test_cases.cc
+++ b/test/gvcf_test_cases.cc
@@ -630,8 +630,8 @@ TEST_CASE("min_allele_copy_number") {
     GVCFTestCase("min_allele_copy_number").perform_gvcf_test();
 }
 
-TEST_CASE("minAQ") {
-    GVCFTestCase("minAQ",true,true,true).perform_gvcf_test();
+TEST_CASE("min_quality") {
+    GVCFTestCase("min_quality",true,true,true).perform_gvcf_test();
 }
 
 TEST_CASE("rs141305015") {

--- a/test/gvcf_test_cases.cc
+++ b/test/gvcf_test_cases.cc
@@ -490,23 +490,23 @@ TEST_CASE("services test: discover_alleles") {
         REQUIRE(s.str().find("allele appears as both REF and ALT") != string::npos);
     }
 
-    SECTION("only return alleles observed in desired samples") {
+    SECTION("calculate copy numbers from desired samples only") {
         // looking at all three samples in the dataset, we should receive all
         // three alleles at this position
         s = discover_allele_case.execute_discover_alleles(als, "discover_alleles_trio1", range(0, 1001, 1002));
         REQUIRE(s.ok());
         REQUIRE(als.size() == 3);
+        REQUIRE(als.find(allele(range(0, 1001, 1002), "C"))->second.zGQ.copy_number() == 2);
+        REQUIRE(als.find(allele(range(0, 1001, 1002), "G"))->second.zGQ.copy_number() == 2);
+        REQUIRE(als.find(allele(range(0, 1001, 1002), "T"))->second.zGQ.copy_number() == 2);
 
-        // looking only at one homozygous ref individual, we should get
-        // nothing
+        // looking only at one homozygous ref individual
         s = discover_allele_case.execute_discover_alleles(als, "trio1.fa", range(0, 1001, 1002));
         REQUIRE(s.ok());
-        REQUIRE(als.size() == 0);
-
-        // throw in a previous position as positive control
-        s = discover_allele_case.execute_discover_alleles(als, "trio1.fa", range(0, 1000, 1002));
-        REQUIRE(s.ok());
-        REQUIRE(als.size() == 2);
+        REQUIRE(als.size() == 3);
+        REQUIRE(als.find(allele(range(0, 1001, 1002), "C"))->second.zGQ.copy_number() == 2);
+        REQUIRE(als.find(allele(range(0, 1001, 1002), "G"))->second.zGQ.copy_number() == 0);
+        REQUIRE(als.find(allele(range(0, 1001, 1002), "T"))->second.zGQ.copy_number() == 0);
     }
 
     discover_allele_case.cleanup();

--- a/test/service.cc
+++ b/test/service.cc
@@ -69,28 +69,28 @@ TEST_CASE("service::discover_alleles") {
         REQUIRE(mals.size() == ranges.size());
 
         REQUIRE(mals[0].size() == 2);
-        REQUIRE(mals[0].find(allele(range(0, 1000, 1001), "A"))->second.copy_number == 6);
-        REQUIRE(mals[0].find(allele(range(0, 1000, 1001), "G"))->second.copy_number == 6);
+        REQUIRE(mals[0].find(allele(range(0, 1000, 1001), "A"))->second.zGQ.copy_number() == 6);
+        REQUIRE(mals[0].find(allele(range(0, 1000, 1001), "G"))->second.zGQ.copy_number() == 6);
 
         REQUIRE(mals[1].size() == 4);
-        REQUIRE(mals[1].find(allele(range(0, 1001, 1002), "A"))->second.copy_number == 6);
-        REQUIRE(mals[1].find(allele(range(0, 1001, 1002), "C"))->second.copy_number == 2);
-        REQUIRE(mals[1].find(allele(range(0, 1001, 1002), "G"))->second.copy_number == 2);
-        REQUIRE(mals[1].find(allele(range(0, 1001, 1002), "T"))->second.copy_number == 2);
+        REQUIRE(mals[1].find(allele(range(0, 1001, 1002), "A"))->second.zGQ.copy_number() == 6);
+        REQUIRE(mals[1].find(allele(range(0, 1001, 1002), "C"))->second.zGQ.copy_number() == 2);
+        REQUIRE(mals[1].find(allele(range(0, 1001, 1002), "G"))->second.zGQ.copy_number() == 2);
+        REQUIRE(mals[1].find(allele(range(0, 1001, 1002), "T"))->second.zGQ.copy_number() == 2);
 
         REQUIRE(mals[2].size() == 4);
-        REQUIRE(mals[2].find(allele(range(0, 1010, 1012), "AG"))->second.copy_number == 3);
-        REQUIRE(mals[2].find(allele(range(0, 1010, 1012), "CC"))->second.copy_number == 3);
-        REQUIRE(mals[2].find(allele(range(0, 1010, 1013), "AGA"))->second.copy_number == 2);
-        REQUIRE(mals[2].find(allele(range(0, 1010, 1013), "CCC"))->second.copy_number == 4);
+        REQUIRE(mals[2].find(allele(range(0, 1010, 1012), "AG"))->second.zGQ.copy_number() == 3);
+        REQUIRE(mals[2].find(allele(range(0, 1010, 1012), "CC"))->second.zGQ.copy_number() == 3);
+        REQUIRE(mals[2].find(allele(range(0, 1010, 1013), "AGA"))->second.zGQ.copy_number() == 2);
+        REQUIRE(mals[2].find(allele(range(0, 1010, 1013), "CCC"))->second.zGQ.copy_number() == 4);
 
         REQUIRE(mals[3].size() == 2);
-        REQUIRE(mals[3].find(allele(range(1, 1000, 1001), "A"))->second.copy_number == 2);
-        REQUIRE(mals[3].find(allele(range(1, 1000, 1001), "AA"))->second.copy_number == 4);
+        REQUIRE(mals[3].find(allele(range(1, 1000, 1001), "A"))->second.zGQ.copy_number() == 2);
+        REQUIRE(mals[3].find(allele(range(1, 1000, 1001), "AA"))->second.zGQ.copy_number() == 4);
 
         REQUIRE(mals[4].size() == 2);
-        REQUIRE(mals[4].find(allele(range(1, 1010, 1012), "AG"))->second.copy_number == 3);
-        REQUIRE(mals[4].find(allele(range(1, 1010, 1012), "CC"))->second.copy_number == 3);
+        REQUIRE(mals[4].find(allele(range(1, 1010, 1012), "AG"))->second.zGQ.copy_number() == 3);
+        REQUIRE(mals[4].find(allele(range(1, 1010, 1012), "CC"))->second.zGQ.copy_number() == 3);
 
         REQUIRE(mals[5].empty());
     }
@@ -168,10 +168,10 @@ TEST_CASE("service::discover_alleles gVCF") {
         REQUIRE(als.size() == 2);
         auto p = als.find(allele(range(0, 10009463, 10009465), "TA"));
         REQUIRE(p != als.end());
-        REQUIRE(p->second.copy_number == 1.0245f);
+        REQUIRE(p->second.zGQ.copy_number() == 1);
         p = als.find(allele(range(0, 10009463, 10009465), "T"));
         REQUIRE(p != als.end());
-        REQUIRE(p->second.copy_number == 0.9755f);
+        REQUIRE(p->second.zGQ.copy_number() == 1);
     }
 
     SECTION("exclusion/detection of bogus alleles") {
@@ -180,10 +180,10 @@ TEST_CASE("service::discover_alleles gVCF") {
         REQUIRE(als.size() == 2);
         auto p = als.find(allele(range(1, 10009463, 10009465), "TA"));
         REQUIRE(p != als.end());
-        REQUIRE(p->second.copy_number == 1.0245f);
+        REQUIRE(p->second.zGQ.copy_number() == 1);
         p = als.find(allele(range(1, 10009463, 10009465), "T"));
         REQUIRE(p != als.end());
-        REQUIRE(p->second.copy_number == 0.9755f);
+        REQUIRE(p->second.zGQ.copy_number() == 1);
 
         s = svc->discover_alleles("<ALL>", range(1, 10009465, 10009466), als);
         REQUIRE(s == StatusCode::INVALID);

--- a/test/types.cc
+++ b/test/types.cc
@@ -751,3 +751,23 @@ liftover_fields:
         }
     }
 }
+
+TEST_CASE("zygosity_by_GQ") {
+    for (int gq = 0; gq <= 100; gq++) {
+        for (int z = 1; z <= zygosity_by_GQ::PLOIDY; z++) {
+            zygosity_by_GQ zGQ;
+            zGQ.add(z, gq);
+            REQUIRE(zGQ.M[std::min(gq/10,int(zygosity_by_GQ::GQ_BANDS-1))][z-1] == 1);
+            REQUIRE(zGQ.copy_number() == z);
+            REQUIRE(zGQ.copy_number(gq) == z);
+            if (gq < 90) REQUIRE(zGQ.copy_number(gq+10) == 0);
+
+            for (int gq2 = 0; gq2 < zygosity_by_GQ::GQ_BANDS; gq2++) {
+                zygosity_by_GQ zGQ2;
+                zGQ2.add(1, gq2);
+                zGQ2 += zGQ;
+                REQUIRE(zGQ2.copy_number() == z+1);
+            }
+        }
+    }
+}

--- a/test/types.cc
+++ b/test/types.cc
@@ -408,9 +408,6 @@ range: {ref: '17', beg: 100, end: 100}
 alleles: [A, G]
 copy_number: [100, 51]
 unification:
-  - range: {beg: 100, end: 100}
-    alt: A
-    to: 0
 )";
         n = YAML::Load(snp_bogus);
         REQUIRE(unified_site::of_yaml(n, contigs, us).bad());

--- a/test/types.cc
+++ b/test/types.cc
@@ -86,23 +86,23 @@ TEST_CASE("discovered_alleles_of_yaml") {
 - range: {ref: '17', beg: 100, end: 100}
   dna: A
   is_ref: true
-  copy_number: 100
   maxAQ: 99
+  zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 - range: {ref: '17', beg: 100, end: 100}
   dna: G
   is_ref: false
-  copy_number: 10.5
   maxAQ: 99
+  zygosity_by_GQ: [[0,0],[10,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,5]]
 )";
 
     #define VERIFY_DA(dal) \
         REQUIRE((dal).size() == 2); \
         REQUIRE((dal).find(allele(range(1, 99, 100),"A")) != (dal).end()); \
         REQUIRE((dal)[allele(range(1, 99, 100),"A")].is_ref == true); \
-        REQUIRE((dal)[allele(range(1, 99, 100),"A")].copy_number == 100); \
+        REQUIRE((dal)[allele(range(1, 99, 100),"A")].zGQ.copy_number() == 100); \
         REQUIRE((dal).find(allele(range(1, 99, 100),"G")) != (dal).end()); \
         REQUIRE((dal)[allele(range(1, 99, 100),"G")].is_ref == false); \
-        REQUIRE((dal)[allele(range(1, 99, 100),"G")].copy_number == 10.5);
+        REQUIRE((dal)[allele(range(1, 99, 100),"G")].zGQ.copy_number() == 20);
 
     SECTION("basic") {
         YAML::Node n = YAML::Load(da_yaml);
@@ -230,13 +230,13 @@ TEST_CASE("yaml_of_discovered_alleles") {
 - range: {ref: '17', beg: 100, end: 100}
   dna: A
   is_ref: true
-  copy_number: 100
   maxAQ: 99
+  zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 - range: {ref: '17', beg: 100, end: 100}
   dna: G
   is_ref: false
-  copy_number: 10.5
   maxAQ: 99
+  zygosity_by_GQ: [[0,0],[10,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,5]]
 )";
 
         YAML::Node n = YAML::Load(da_yaml);

--- a/test/types.cc
+++ b/test/types.cc
@@ -87,10 +87,12 @@ TEST_CASE("discovered_alleles_of_yaml") {
   dna: A
   is_ref: true
   copy_number: 100
+  maxGQ: 99
 - range: {ref: '17', beg: 100, end: 100}
   dna: G
   is_ref: false
   copy_number: 10.5
+  maxGQ: 99
 )";
 
     #define VERIFY_DA(dal) \
@@ -117,10 +119,12 @@ TEST_CASE("discovered_alleles_of_yaml") {
   dna: A
   is_ref: true
   copy_number: 100
+  maxGQ: 99
 - range: {ref: 'bogus', beg: 100, end: 100}
   dna: G
   is_ref: false
   copy_number: 10.5
+  maxGQ: 99
 )");
 
         discovered_alleles dal;
@@ -131,6 +135,7 @@ TEST_CASE("discovered_alleles_of_yaml") {
 - dna: A
   is_ref: true
   copy_number: 100
+  maxGQ: 99
 )");
 
         s = discovered_alleles_of_yaml(n, contigs, dal);
@@ -141,6 +146,7 @@ TEST_CASE("discovered_alleles_of_yaml") {
   dna: A
   is_ref: true
   copy_number: 100
+  maxGQ: 99
 )");
 
         s = discovered_alleles_of_yaml(n, contigs, dal);
@@ -153,10 +159,12 @@ TEST_CASE("discovered_alleles_of_yaml") {
   dna: A
   is_ref: true
   copy_number: 100
+  maxGQ: 99
 - range: {ref: '17', beg: 100, end: 100}
   dna: BOGUS
   is_ref: false
   copy_number: 10.5
+  maxGQ: 99
 )");
 
         discovered_alleles dal;
@@ -170,10 +178,31 @@ TEST_CASE("discovered_alleles_of_yaml") {
   dna: A
   is_ref: true
   copy_number: 100
+  maxGQ: 99
 - range: {ref: '17', beg: 100, end: 100}
   dna: G
   is_ref: false
   copy_number: [x]
+  maxGQ: 99
+)");
+
+        discovered_alleles dal;
+        Status s = discovered_alleles_of_yaml(n, contigs, dal);
+        REQUIRE(s.bad());
+    }
+
+    SECTION("bogus maxGQ") {
+        YAML::Node n = YAML::Load(1 + R"(
+- range: {ref: '17', beg: 100, end: 100}
+  dna: A
+  is_ref: true
+  copy_number: 100
+  maxGQ: 99
+- range: {ref: '17', beg: 100, end: 100}
+  dna: G
+  is_ref: false
+  copy_number: 100
+  maxGQ: ['z']
 )");
 
         discovered_alleles dal;
@@ -202,10 +231,12 @@ TEST_CASE("yaml_of_discovered_alleles") {
   dna: A
   is_ref: true
   copy_number: 100
+  maxGQ: 99
 - range: {ref: '17', beg: 100, end: 100}
   dna: G
   is_ref: false
   copy_number: 10.5
+  maxGQ: 99
 )";
 
         YAML::Node n = YAML::Load(da_yaml);
@@ -460,6 +491,7 @@ TEST_CASE("unifier_config") {
 )";
     const char* buf2 = 1 + R"(
         {min_allele_copy_number: 5.0,
+         minGQ: 60,
          max_alleles_per_site:  1,
          preference: small}
 )";

--- a/test/types.cc
+++ b/test/types.cc
@@ -87,12 +87,12 @@ TEST_CASE("discovered_alleles_of_yaml") {
   dna: A
   is_ref: true
   copy_number: 100
-  maxGQ: 99
+  maxAQ: 99
 - range: {ref: '17', beg: 100, end: 100}
   dna: G
   is_ref: false
   copy_number: 10.5
-  maxGQ: 99
+  maxAQ: 99
 )";
 
     #define VERIFY_DA(dal) \
@@ -119,12 +119,12 @@ TEST_CASE("discovered_alleles_of_yaml") {
   dna: A
   is_ref: true
   copy_number: 100
-  maxGQ: 99
+  maxAQ: 99
 - range: {ref: 'bogus', beg: 100, end: 100}
   dna: G
   is_ref: false
   copy_number: 10.5
-  maxGQ: 99
+  maxAQ: 99
 )");
 
         discovered_alleles dal;
@@ -135,7 +135,7 @@ TEST_CASE("discovered_alleles_of_yaml") {
 - dna: A
   is_ref: true
   copy_number: 100
-  maxGQ: 99
+  maxAQ: 99
 )");
 
         s = discovered_alleles_of_yaml(n, contigs, dal);
@@ -146,7 +146,7 @@ TEST_CASE("discovered_alleles_of_yaml") {
   dna: A
   is_ref: true
   copy_number: 100
-  maxGQ: 99
+  maxAQ: 99
 )");
 
         s = discovered_alleles_of_yaml(n, contigs, dal);
@@ -159,12 +159,12 @@ TEST_CASE("discovered_alleles_of_yaml") {
   dna: A
   is_ref: true
   copy_number: 100
-  maxGQ: 99
+  maxAQ: 99
 - range: {ref: '17', beg: 100, end: 100}
   dna: BOGUS
   is_ref: false
   copy_number: 10.5
-  maxGQ: 99
+  maxAQ: 99
 )");
 
         discovered_alleles dal;
@@ -178,12 +178,12 @@ TEST_CASE("discovered_alleles_of_yaml") {
   dna: A
   is_ref: true
   copy_number: 100
-  maxGQ: 99
+  maxAQ: 99
 - range: {ref: '17', beg: 100, end: 100}
   dna: G
   is_ref: false
   copy_number: [x]
-  maxGQ: 99
+  maxAQ: 99
 )");
 
         discovered_alleles dal;
@@ -191,18 +191,18 @@ TEST_CASE("discovered_alleles_of_yaml") {
         REQUIRE(s.bad());
     }
 
-    SECTION("bogus maxGQ") {
+    SECTION("bogus maxAQ") {
         YAML::Node n = YAML::Load(1 + R"(
 - range: {ref: '17', beg: 100, end: 100}
   dna: A
   is_ref: true
   copy_number: 100
-  maxGQ: 99
+  maxAQ: 99
 - range: {ref: '17', beg: 100, end: 100}
   dna: G
   is_ref: false
   copy_number: 100
-  maxGQ: ['z']
+  maxAQ: ['z']
 )");
 
         discovered_alleles dal;
@@ -231,12 +231,12 @@ TEST_CASE("yaml_of_discovered_alleles") {
   dna: A
   is_ref: true
   copy_number: 100
-  maxGQ: 99
+  maxAQ: 99
 - range: {ref: '17', beg: 100, end: 100}
   dna: G
   is_ref: false
   copy_number: 10.5
-  maxGQ: 99
+  maxAQ: 99
 )";
 
         YAML::Node n = YAML::Load(da_yaml);

--- a/test/unifier.cc
+++ b/test/unifier.cc
@@ -7,14 +7,22 @@ using namespace GLnexus;
 
 TEST_CASE("unifier max_alleles_per_site") {
     discovered_alleles dal;
+    discovered_allele_info dai;
 
-    dal[allele(range(0, 100, 101), "A")] = discovered_allele_info({true, 99, zygosity_by_GQ(1,0,100)});
-    dal[allele(range(0, 100, 101), "G")] = discovered_allele_info({false, 99, zygosity_by_GQ(1,0,100)});
-    dal[allele(range(0, 100, 101), "C")] = discovered_allele_info({false, 99, zygosity_by_GQ(1,0,10)});
-    dal[allele(range(0, 100, 101), "T")] = discovered_allele_info({false, 99, zygosity_by_GQ(1,0,10)});
-    dal[allele(range(0, 100, 102), "AA")] = discovered_allele_info({true, 99, zygosity_by_GQ(1,0,100)});
-    dal[allele(range(0, 100, 102), "GG")] = discovered_allele_info({false, 99, zygosity_by_GQ(1,0,100)});
-    dal[allele(range(0, 100, 102), "GC")] = discovered_allele_info({false, 99, zygosity_by_GQ(1,0,1)});
+    dai.is_ref = true; dai.maxAQ = 99; dai.zGQ = zygosity_by_GQ(1,0,100);
+    dal[allele(range(0, 100, 101), "A")] = dai;
+    dai.is_ref = false; dai.maxAQ = 99; dai.zGQ = zygosity_by_GQ(1,0,100);
+    dal[allele(range(0, 100, 101), "G")] = dai;
+    dai.is_ref = false; dai.maxAQ = 99; dai.zGQ = zygosity_by_GQ(1,0,10);
+    dal[allele(range(0, 100, 101), "C")] = dai;
+    dai.is_ref = false; dai.maxAQ = 99; dai.zGQ = zygosity_by_GQ(1,0,10);
+    dal[allele(range(0, 100, 101), "T")] = dai;
+    dai.is_ref = true; dai.maxAQ = 99; dai.zGQ = zygosity_by_GQ(1,0,100);
+    dal[allele(range(0, 100, 102), "AA")] = dai;
+    dai.is_ref = false; dai.maxAQ = 99; dai.zGQ = zygosity_by_GQ(1,0,100);
+    dal[allele(range(0, 100, 102), "GG")] = dai;
+    dai.is_ref = false; dai.maxAQ = 99; dai.zGQ = zygosity_by_GQ(1,0,1);
+    dal[allele(range(0, 100, 102), "GC")] = dai;
 
     unifier_config cfg;
     vector<unified_site> sites;

--- a/test/unifier.cc
+++ b/test/unifier.cc
@@ -8,13 +8,13 @@ using namespace GLnexus;
 TEST_CASE("unifier max_alleles_per_site") {
     discovered_alleles dal;
 
-    dal[allele(range(0, 100, 101), "A")] = discovered_allele_info({true, 100});
-    dal[allele(range(0, 100, 101), "G")] = discovered_allele_info({false, 100});
-    dal[allele(range(0, 100, 101), "C")] = discovered_allele_info({false, 10});
-    dal[allele(range(0, 100, 101), "T")] = discovered_allele_info({false, 10});
-    dal[allele(range(0, 100, 102), "AA")] = discovered_allele_info({true, 100});
-    dal[allele(range(0, 100, 102), "GG")] = discovered_allele_info({false, 100});
-    dal[allele(range(0, 100, 102), "GC")] = discovered_allele_info({false, 1});
+    dal[allele(range(0, 100, 101), "A")] = discovered_allele_info({true, 99, zygosity_by_GQ(1,0,100)});
+    dal[allele(range(0, 100, 101), "G")] = discovered_allele_info({false, 99, zygosity_by_GQ(1,0,100)});
+    dal[allele(range(0, 100, 101), "C")] = discovered_allele_info({false, 99, zygosity_by_GQ(1,0,10)});
+    dal[allele(range(0, 100, 101), "T")] = discovered_allele_info({false, 99, zygosity_by_GQ(1,0,10)});
+    dal[allele(range(0, 100, 102), "AA")] = discovered_allele_info({true, 99, zygosity_by_GQ(1,0,100)});
+    dal[allele(range(0, 100, 102), "GG")] = discovered_allele_info({false, 99, zygosity_by_GQ(1,0,100)});
+    dal[allele(range(0, 100, 102), "GC")] = discovered_allele_info({false, 99, zygosity_by_GQ(1,0,1)});
 
     unifier_config cfg;
     vector<unified_site> sites;


### PR DESCRIPTION
Fairly drastic revision to the way we use genotype likelihoods to decide whether to include an allele in the final site list, and estimate copy numbers. `unifier_config::min_quality` is a phred-scale threshold controlling this.

Puts allele discovery algos in `discovery.{h,cc}`