### PR TITLE
Further revisions to unifier quality thresholds

### DIFF
--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -84,7 +84,9 @@ static GLnexus::Status check_sanity_multiple_dsals(
 // should reside in some user-modifiable yml file
 static const char* config_presets_yml = R"eof(
 unifier_config:
-  min_quality: 50
+  min_AQ1: 60
+  min_AQ2: 40
+  min_GQ: 60
 genotyper_config:
   required_dp: 1
   liftover_fields:

--- a/include/diploid.h
+++ b/include/diploid.h
@@ -17,13 +17,15 @@ unsigned alleles_gt(unsigned a1, unsigned a2);
 Status bcf_zygosity_by_GQ(const bcf_hdr_t* header, bcf1_t* record, const std::vector<unsigned>& samples,
                           std::vector<zygosity_by_GQ>& ans);
 
-// This function finds the maximum AQ of each allele in the record, across the given
+// This function finds the maximum AQs for each allele in the record, across the given
 // subset of sample indices. (see types.h for the definition of AQ)
-Status bcf_alleles_maxAQ(const bcf_hdr_t* hdr, bcf1_t* record, const std::vector<unsigned>& samples, std::vector<int>& ans);
+Status bcf_alleles_topAQ(const bcf_hdr_t* hdr, bcf1_t* record, const std::vector<unsigned>& samples,
+                         std::vector<top_AQ>& ans);
 
 // exposed for testing: find alleles' maxAQ for given multi-sample genotype likelihood
 // vector
-Status alleles_maxAQ(unsigned n_allele, unsigned n_sample, const std::vector<unsigned>& samples, const std::vector<double>& gl, std::vector<int>& ans);
+Status alleles_topAQ(unsigned n_allele, unsigned n_sample, const std::vector<unsigned>& samples,
+                     const std::vector<double>& gl, std::vector<top_AQ>& ans);
 
 namespace trio {
 int mendelian_inconsistencies(int gt_p1, int gt_p2, int gt_ch);

--- a/include/types.h
+++ b/include/types.h
@@ -458,14 +458,18 @@ struct StatsRangeQuery {
 enum class UnifierPreference { Common, Small };
 
 struct unifier_config {
-    // Phred quality score threshold, used in two ways:
-    // 1) minimum Allele Quality in the cohort for the unifier to include an allele
-    // 2) minimum Genotype Quality for an input genotype call to "count" towards
-    //    copy number estimates for the constituent alleles.
-    // All else equal, increasing min_quality will increase specificity and reduce
-    // sensitivity, and also speed up the genotyper (as fewer weak sites will be
-    // considered)
-    int min_quality = 0;
+    // AQ phred score thresholds: the unifier will include alleles having any
+    // observation with AQ > min_AQ1, or having multiple observations with
+    // AQ > min_AQ2 (min_AQ1 >= min_AQ2).
+    //
+    // All else equal, increasing min_AQ will increase specificity and reduce
+    // sensitivity, and also speed up the genotyper (as fewer weak sites will
+    // be considered)
+    int min_AQ1 = 0, min_AQ2 = 0;
+
+    // GQ phred score threshold for an input genotype call to "count" towards
+    // copy number estimates for the constituent alleles.
+    int min_GQ = 0;
 
     // Keep only alleles with at least this estimated copy number discovered
     // in the cohort.

--- a/include/types.h
+++ b/include/types.h
@@ -241,6 +241,55 @@ struct allele {
     }
 };
 
+// *Allele Quality (AQ)* of an allele in a VCF genotype call is defined in terms of
+// the genotype likelihoods as follows: (the maximum likelihood of any genotype
+// containing an allele / the maximum likelihood of any genotype not containing that
+// allele), expressed on phred scale, truncated below zero.
+//
+// top_AQ is used to store the highest COUNT observations (descending order) of
+// AQ for an allele across all genotype calls in the cohort.
+struct top_AQ {
+    static const unsigned COUNT = 10;
+    int V[COUNT] __attribute__ ((aligned));
+    std::vector<int> addbuf;
+
+    top_AQ() {
+        clear();
+    }
+
+    top_AQ(int AQ1) {
+        clear();
+        V[0] = AQ1;
+    }
+
+    void clear() {
+        memset(&V, 0, sizeof(int)*COUNT);
+        addbuf.clear();
+    }
+
+    void add(const int* rhs, const size_t rhs_count) {
+        addbuf.resize(COUNT+rhs_count);
+        memcpy(addbuf.data(), &V, COUNT*sizeof(int));
+        memcpy(addbuf.data()+COUNT, rhs, rhs_count*sizeof(int));
+        std::partial_sort(addbuf.begin(), addbuf.begin()+COUNT, addbuf.end(), std::greater<int>());
+        memcpy(&V, addbuf.data(), COUNT*sizeof(int));
+    }
+
+    void operator+=(const top_AQ& rhs) {
+        add(rhs.V, COUNT);
+    }
+
+    void operator+=(const std::vector<int>& rhs) {
+        if (rhs.size()) {
+            add(rhs.data(), rhs.size());
+        }
+    }
+
+    bool operator==(const top_AQ& rhs) const {
+        return memcmp(V, rhs.V, sizeof(int)*COUNT) == 0;
+    }
+};
+
 // zygosity_by_GQ: holds information about how many times an allele is observed
 // during the discovery process, stratified by genotype quality.
 // A 10x2 matrix (M), the GQ_BANDS correspond to ten bands of phred-scaled GQ:
@@ -257,12 +306,16 @@ struct zygosity_by_GQ {
     unsigned M[GQ_BANDS][PLOIDY] __attribute__ ((aligned));
 
     zygosity_by_GQ() {
-        memset(&M, 0, sizeof(int)*GQ_BANDS*PLOIDY);
+        clear();
     }
 
     zygosity_by_GQ(unsigned zygosity, int GQ, unsigned count=1) {
-        memset(&M, 0, sizeof(int)*GQ_BANDS*PLOIDY);
+        clear();
         add(zygosity, GQ, count);
+    }
+
+    void clear() {
+        memset(&M, 0, sizeof(unsigned)*GQ_BANDS*PLOIDY);
     }
 
     void add(unsigned zygosity, int GQ, unsigned count=1) {
@@ -301,25 +354,20 @@ struct zygosity_by_GQ {
 struct discovered_allele_info {
     bool is_ref = false;
 
-    // *Allele Quality (AQ)* of an allele in a VCF genotype call is defined in terms of
-    // the genotype likelihoods as follows: (the maximum likelihood of any genotype
-    // containing an allele / the maximum likelihood of any genotype not containing that
-    // allele), expressed on phred scale, truncated below zero.
-    //
-    // maxAQ is the maximum AQ observed for this allele across all genotype calls in the
-    // cohort.
-    int maxAQ = 0;
+    // top_AQ statistics are used to adjudicate allele existence 
+    top_AQ topAQ;
 
+    // zygosity_by_GQ statsitics are used to estimate allele copy number
     zygosity_by_GQ zGQ;
 
     bool operator==(const discovered_allele_info& rhs) const noexcept {
-        return is_ref == rhs.is_ref && maxAQ == rhs.maxAQ && zGQ == rhs.zGQ;
+        return is_ref == rhs.is_ref && topAQ == rhs.topAQ && zGQ == rhs.zGQ;
     }
     bool operator!=(const discovered_allele_info& rhs) const noexcept { return !(*this == rhs); }
 
     std::string str() const {
         std::ostringstream os;
-        os << "[ is_ref: " << std::boolalpha << is_ref << " maxAQ: " << maxAQ << " copy number: " << zGQ.copy_number() << "]";
+        os << "[ is_ref: " << std::boolalpha << is_ref << " maxAQ: " << topAQ.V[0] << " copy number: " << zGQ.copy_number() << "]";
         return os.str();
     }
 };

--- a/src/types.cc
+++ b/src/types.cc
@@ -332,11 +332,25 @@ Status unifier_config::of_yaml(const YAML::Node& yaml, unifier_config& ans) {
         V(ans.min_allele_copy_number >= 0, "invalid min_allele_copy_number");
     }
 
-    const auto n_min_quality = yaml["min_quality"];
-    if (n_min_quality) {
-        V(n_min_quality.IsScalar(), "invalid min_quality");
-        ans.min_quality = n_min_quality.as<int>();
-        V(ans.min_quality >= 0, "invalid min_quality");
+    const auto n_min_AQ1 = yaml["min_AQ1"];
+    if (n_min_AQ1) {
+        V(n_min_AQ1.IsScalar(), "invalid min_AQ1");
+        ans.min_AQ1 = n_min_AQ1.as<int>();
+        V(ans.min_AQ1 >= 0, "invalid min_AQ1");
+    }
+
+    const auto n_min_AQ2 = yaml["min_AQ2"];
+    if (n_min_AQ2) {
+        V(n_min_AQ2.IsScalar(), "invalid min_AQ2");
+        ans.min_AQ2 = n_min_AQ2.as<int>();
+        V(ans.min_AQ2 >= 0, "invalid min_AQ2");
+    }
+
+    const auto n_min_GQ = yaml["min_GQ"];
+    if (n_min_GQ) {
+        V(n_min_GQ.IsScalar(), "invalid min_GQ");
+        ans.min_GQ = n_min_GQ.as<int>();
+        V(ans.min_GQ >= 0, "invalid min_GQ");
     }
 
     const auto n_max_alleles_per_site = yaml["max_alleles_per_site"];
@@ -367,7 +381,9 @@ Status unifier_config::of_yaml(const YAML::Node& yaml, unifier_config& ans) {
 Status unifier_config::yaml(YAML::Emitter& ans) const {
     ans << YAML::BeginMap;
     ans << YAML::Key << "min_allele_copy_number" << YAML::Value << min_allele_copy_number;
-    ans << YAML::Key << "min_quality" << YAML::Value << min_quality;
+    ans << YAML::Key << "min_AQ1" << YAML::Value << min_AQ1;
+    ans << YAML::Key << "min_AQ2" << YAML::Value << min_AQ2;
+    ans << YAML::Key << "min_GQ" << YAML::Value << min_GQ;
     ans << YAML::Key << "max_alleles_per_site" << YAML::Value << max_alleles_per_site;
 
     ans << YAML::Key << "preference" << YAML::Value;

--- a/src/unifier.cc
+++ b/src/unifier.cc
@@ -19,7 +19,7 @@ using discovered_allele = pair<allele,discovered_allele_info>;
 // original representations.
 struct minimized_allele_info {
     set<allele> originals;
-    int maxAQ = 0;
+    top_AQ topAQ;
     unsigned copy_number = 0;
 
     string str() const {
@@ -28,7 +28,7 @@ struct minimized_allele_info {
         for (auto& al : originals) {
             os << "  " << al.str() << endl;
         }
-        os << "Max AQ: " << maxAQ << endl;
+        os << "Max AQ: " << topAQ.V[0] << endl;
         os << "Copy number: " << copy_number << endl;
         return os.str();
     }
@@ -53,7 +53,7 @@ bool minimized_allele_small_lt(const minimized_allele& p1, const minimized_allel
     if (p2.second.copy_number != p1.second.copy_number) {
         return p2.second.copy_number < p1.second.copy_number;
     }
-    return p2.second.maxAQ < p1.second.maxAQ;
+    return p2.second.topAQ.V[0] < p1.second.topAQ.V[0];
 }
 
 // UnifierPreference::Common
@@ -61,8 +61,8 @@ bool minimized_allele_common_lt(const minimized_allele& p1, const minimized_alle
     if (p2.second.copy_number != p1.second.copy_number) {
         return p2.second.copy_number < p1.second.copy_number;
     }
-    if (p2.second.maxAQ != p1.second.maxAQ) {
-        return p2.second.maxAQ < p1.second.maxAQ;
+    if (p2.second.topAQ.V[0] != p1.second.topAQ.V[0]) {
+        return p2.second.topAQ.V[0] < p1.second.topAQ.V[0];
     }
     return minimized_allele_delta_lt(p1, p2);
 }
@@ -131,18 +131,18 @@ Status minimize_alleles(const unifier_config& cfg, const discovered_alleles& src
 
         unsigned copy_number = dal.second.zGQ.copy_number(cfg.min_quality);
 
-        // add it to alts, combining originals, copy_number, and maxAQ with any
+        // add it to alts, combining originals, copy_number, and topAQ with any
         // previously observed occurrences of the same minimized alt allele.
         auto ap = alts.find(alt);
         if (ap == alts.end()) {
             minimized_allele_info info;
             info.originals.insert(dal.first);
-            info.maxAQ = dal.second.maxAQ;
+            info.topAQ = dal.second.topAQ;
             info.copy_number = copy_number;
             alts[alt] = move(info);
         } else {
             ap->second.originals.insert(dal.first);
-            ap->second.maxAQ = std::max(ap->second.maxAQ, dal.second.maxAQ);
+            ap->second.topAQ += dal.second.topAQ;
             ap->second.copy_number += copy_number;
         }
     }
@@ -152,7 +152,7 @@ Status minimize_alleles(const unifier_config& cfg, const discovered_alleles& src
     // individuals carrying an allele have weak, homozygous-alt genotype calls
     if (cfg.min_quality > 0) {
         for (auto& al : alts) {
-            if (al.second.maxAQ >= cfg.min_quality) {
+            if (al.second.topAQ.V[0] >= cfg.min_quality) {
                 al.second.copy_number = std::max(al.second.copy_number, 1U);
             }
         }
@@ -207,7 +207,7 @@ auto prune_alleles(const unifier_config& cfg, const minimized_alleles& alleles, 
     valleles.reserve(alleles.size());
     for (const auto& allele : alleles) {
         // filter alleles with insufficient copy number or AQ
-        if (allele.second.maxAQ >= cfg.min_quality &&
+        if (allele.second.topAQ.V[0] >= cfg.min_quality &&
             allele.second.copy_number >= cfg.min_allele_copy_number) {
             valleles.push_back(allele);
         }

--- a/test/cli_utils.cc
+++ b/test/cli_utils.cc
@@ -16,12 +16,12 @@ TEST_CASE("cli_utils") {
 - range: {ref: '16', beg: 100, end: 100}
   dna: A
   is_ref: true
-  maxAQ: 99
+  top_AQ: [99]
   zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 - range: {ref: '16', beg: 113, end: 120}
   dna: G
   is_ref: false
-  maxAQ: 99
+  top_AQ: [99]
   zygosity_by_GQ: [[0,0],[10,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,5]]
 )";
 
@@ -29,12 +29,12 @@ TEST_CASE("cli_utils") {
 - range: {ref: '17', beg: 100, end: 100}
   dna: A
   is_ref: true
-  maxAQ: 99
+  top_AQ: [99]
   zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 - range: {ref: '17', beg: 200, end: 310}
   dna: G
   is_ref: false
-  maxAQ: 99
+  top_AQ: [99]
   zygosity_by_GQ: [[0,0],[10,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,5]]
 )";
 

--- a/test/data/gvcf_test_cases/discover_alleles_2_trios.yml
+++ b/test/data/gvcf_test_cases/discover_alleles_2_trios.yml
@@ -38,50 +38,50 @@ truth_discovered_alleles:
     - range: {ref: 'A', beg: 1001, end: 1001}
       dna: 'A'
       is_ref: true
-      maxAQ: 0
+      top_AQ: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       zygosity_by_GQ: [[4,1],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1001, end: 1001}
       dna: 'G'
       is_ref: false
-      maxAQ: 0
+      top_AQ: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       zygosity_by_GQ: [[4,1],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'C'
       is_ref: true
-      maxAQ: 0
+      top_AQ: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       zygosity_by_GQ: [[0,1],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'A'
       is_ref: false
-      maxAQ: 0
+      top_AQ: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       zygosity_by_GQ: [[0,3],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'G'
       is_ref: false
-      maxAQ: 0
+      top_AQ: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       zygosity_by_GQ: [[0,1],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1002, end: 1002}
       dna: 'T'
       is_ref: false
-      maxAQ: 0
+      top_AQ: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       zygosity_by_GQ: [[0,1],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1011, end: 1012}
       dna: 'CC'
       is_ref: true
-      maxAQ: 0
+      top_AQ: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       zygosity_by_GQ: [[3,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1011, end: 1012}
       dna: 'AG'
       is_ref: false
-      maxAQ: 0
+      top_AQ: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       zygosity_by_GQ: [[3,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1011, end: 1013}
       dna: 'CCC'
       is_ref: true
-      maxAQ: 0
+      top_AQ: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       zygosity_by_GQ: [[2,1],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: 'A', beg: 1011, end: 1013}
       dna: 'AGA'
       is_ref: false
-      maxAQ: 0
+      top_AQ: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       zygosity_by_GQ: [[2,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]

--- a/test/data/gvcf_test_cases/discover_alleles_gvcf.yml
+++ b/test/data/gvcf_test_cases/discover_alleles_gvcf.yml
@@ -33,11 +33,11 @@ truth_discovered_alleles:
     - range: {ref: '21', beg: 10009464, end: 10009465}
       dna: 'TA'
       is_ref: true
-      maxAQ: 240
+      top_AQ: [240]
       zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: '21', beg: 10009464, end: 10009465}
       dna: 'T'
       is_ref: false
-      maxAQ: 16
+      top_AQ: [16]
       zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 

--- a/test/data/gvcf_test_cases/discover_alleles_gvcf_bogus.yml
+++ b/test/data/gvcf_test_cases/discover_alleles_gvcf_bogus.yml
@@ -30,10 +30,10 @@ truth_discovered_alleles:
     - range: {ref: '22', beg: 10009464, end: 10009465}
       dna: 'TA'
       is_ref: true
-      maxAQ: 240
+      top_AQ: [240]
       zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: '22', beg: 10009464, end: 10009465}
       dna: 'T'
       is_ref: false
-      maxAQ: 16
+      top_AQ: [16]
       zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]

--- a/test/data/gvcf_test_cases/min_quality.yml
+++ b/test/data/gvcf_test_cases/min_quality.yml
@@ -52,78 +52,78 @@ truth_discovered_alleles:
     - range: {ref: "21", beg: 10009460, end: 10009460}
       dna: 'T'
       is_ref: true
-      maxAQ: 240
+      top_AQ: [240,240]
       zygosity_by_GQ: [[2,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009460, end: 10009460}
       dna: 'A'
       is_ref: false
-      maxAQ: 2
+      top_AQ: [2,2]
       zygosity_by_GQ: [[2,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009461, end: 10009461}
       dna: 'T'
       is_ref: true
-      maxAQ: 240
+      top_AQ: [240,240]
       zygosity_by_GQ: [[1,0],[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009461, end: 10009461}
       dna: 'A'
       is_ref: false
-      maxAQ: 20
+      top_AQ: [20,2]
       zygosity_by_GQ: [[1,0],[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009462, end: 10009462}
       dna: 'T'
       is_ref: true
-      maxAQ: 240
+      top_AQ: [240]
       zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009462, end: 10009462}
       dna: 'A'
       is_ref: false
-      maxAQ: 2
+      top_AQ: [2]
       zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009464, end: 10009465}
       dna: 'TA'
       is_ref: true
-      maxAQ: 240
+      top_AQ: [240]
       zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009464, end: 10009465}
       dna: 'TC'
       is_ref: false
       copy_number: 0.9406
-      maxAQ: 12
+      top_AQ: [12]
       zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009465, end: 10009465}
       dna: 'A'
       is_ref: true
-      maxAQ: 240
+      top_AQ: [240]
       zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009465, end: 10009465}
       dna: 'C'
       is_ref: false
-      maxAQ: 2
+      top_AQ: [2]
       zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009466, end: 10009466}
       dna: 'T'
       is_ref: true
-      maxAQ: 240
+      top_AQ: [240,240]
       zygosity_by_GQ: [[1,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009466, end: 10009466}
       dna: 'A'
       is_ref: false
-      maxAQ: 16
+      top_AQ: [16]
       zygosity_by_GQ: [[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009466, end: 10009466}
       dna: 'G'
       is_ref: false
-      maxAQ: 2
+      top_AQ: [2]
       zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009467, end: 10009467}
       dna: 'T'
       is_ref: true
-      maxAQ: 9
+      top_AQ: [9]
       zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "21", beg: 10009467, end: 10009467}
       dna: 'A'
       is_ref: false
-      maxAQ: 46
+      top_AQ: [46]
       zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 
 truth_unified_sites:

--- a/test/data/gvcf_test_cases/min_quality.yml
+++ b/test/data/gvcf_test_cases/min_quality.yml
@@ -7,6 +7,7 @@ readme: |
   4) Equivalent alleles with different representations are combined properly.
   5) Multi-allelic situation where one ALT allele qualifies and the other doesn't.
   6) Case with low GQ but high AQ (ambiguity between 0/1 and 1/1)
+  7) Both samples have weak evidence for an allele, meeting the min_AQ2 criterion.
 
 input:
   header : |-
@@ -35,6 +36,7 @@ input:
         21	10009464	.	TA	TC,<NON_REF>	0.03	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:12:12,0,240,46,246,292:1,9,1,1
         21	10009466	.	T	A,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:16:16,0,240,46,246,292:1,9,1,1
         21	10009467	.	T	<NON_REF>	.	.	END=10009468	GT:GQ:MIN_DP:PL	0/0:36:14:0,36,540
+        21	10009468	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:20:5,0,240,46,246,292:1,9,1,1
     - NA12879.gvcf: |
         NA12879
         21	10009460	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
@@ -44,9 +46,12 @@ input:
         21	10009465	.	A	C,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:9:2:2,0,240,46,246,292:1,9,1,1
         21	10009466	.	T	G,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:2,0,240,46,246,292:1,9,1,1
         21	10009467	.	T	A,<NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:1,6,0:7:9:198,0,9,46,246,292:1,9,1,1
+        21	10009468	.	T	A, <NON_REF>	.	.	.	GT:AD:DP:GQ:PL:SB	0/1:10,2,0:12:2:6,0,240,46,246,292:1,9,1,1
 
 unifier_config:
-  min_quality: 10
+  min_AQ1: 10
+  min_AQ2: 5
+  min_GQ: 10
 
 truth_discovered_alleles:
     - range: {ref: "21", beg: 10009460, end: 10009460}
@@ -125,6 +130,16 @@ truth_discovered_alleles:
       is_ref: false
       top_AQ: [46]
       zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: "21", beg: 10009468, end: 10009468}
+      dna: 'T'
+      is_ref: true
+      top_AQ: [240,240]
+      zygosity_by_GQ: [[1,0],[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: "21", beg: 10009468, end: 10009468}
+      dna: 'A'
+      is_ref: false
+      top_AQ: [6,5]
+      zygosity_by_GQ: [[1,0],[0,0],[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 
 truth_unified_sites:
     - range: {ref: "21", beg: 10009461, end: 10009461}
@@ -158,6 +173,14 @@ truth_unified_sites:
         - range: {beg: 10009467, end: 10009467}
           alt: A
           to: 1
+    - range: {ref: "21", beg: 10009468, end: 10009468}
+      alleles: [T, A]
+      copy_number: [0, 2]
+      unification:
+        - range: {beg: 10009468, end: 10009468}
+          alt: A
+          to: 1
+
 
 truth_output_vcf:
   - truth.vcf: |
@@ -171,3 +194,4 @@ truth_output_vcf:
       21	10009465	.	A	C	.	.	.	GT:RNC	0/1:..	0/1:..
       21	10009466	.	T	A	.	.	.	GT:RNC	0/1:..	0/.:.L
       21	10009467	.	T	A	.	.	.	GT:RNC	0/0:..	0/1:..
+      21	10009468	.	T	A	.	.	.	GT:RNC	0/1:..	0/1:..

--- a/test/data/gvcf_test_cases/rs141305015.yml
+++ b/test/data/gvcf_test_cases/rs141305015.yml
@@ -35,47 +35,47 @@ truth_discovered_alleles:
     - range: {ref: A, beg: 36643697, end: 36643700}
       dna: 'AACG'
       is_ref: true
-      maxAQ: 2757
+      top_AQ: [2757]
       zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,1],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: A, beg: 36643697, end: 36643700}
       dna: 'A'
       is_ref: false
-      maxAQ: 0
+      top_AQ: [0]
       zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: A, beg: 36643699, end: 36643702}
       dna: 'CGAG'
       is_ref: true
-      maxAQ: 2011
+      top_AQ: [2011]
       zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,1]]
     - range: {ref: A, beg: 36643699, end: 36643702}
       dna: 'C'
       is_ref: false
-      maxAQ: 0
+      top_AQ: [0]
       zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: A, beg: 36643700, end: 36643703}
       dna: 'GAGA'
       is_ref: true
-      maxAQ: 1026
+      top_AQ: [1026]
       zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[1,0]]
     - range: {ref: A, beg: 36643700, end: 36643703}
       dna: 'G'
       is_ref: false
-      maxAQ: 1890
+      top_AQ: [1890,629]
       zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[1,1]]
     - range: {ref: A, beg: 36643703, end: 36643703}
       dna: 'A'
       is_ref: true
-      maxAQ: 2639
+      top_AQ: [2639,1949]
       zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,1],[0,0],[0,0],[0,0],[0,0],[0,0],[0,1]]
     - range: {ref: A, beg: 36643703, end: 36643703}
       dna: 'G'
       is_ref: false
-      maxAQ: 0
+      top_AQ: [0]
       zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: A, beg: 36643703, end: 36643703}
       dna: 'T'
       is_ref: false
-      maxAQ: 0
+      top_AQ: [0]
       zygosity_by_GQ: [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 
 truth_unified_sites:

--- a/test/diploid.cc
+++ b/test/diploid.cc
@@ -96,7 +96,58 @@ TEST_CASE("diploid::alleles_topAQ") {
         }
     }
 
-    // TODO: top_AQ rank tests
+    SECTION("top_AQ ranking") {
+        top_AQ topAQ, topAQ2;
+        auto &V = topAQ.V, &V2 = topAQ2.V;
+        vector<int> v {1, 5, 4};
+        topAQ += v;
+        REQUIRE(V[0] == 5);
+        REQUIRE(V[1] == 4);
+        REQUIRE(V[2] == 1);
+        REQUIRE(V[3] == 0);
+        v = {2, 8, 3}; topAQ += v;
+        REQUIRE(V[0] == 8);
+        REQUIRE(V[1] == 5);
+        REQUIRE(V[2] == 4);
+        REQUIRE(V[3] == 3);
+        REQUIRE(V[4] == 2);
+        REQUIRE(V[5] == 1);
+        REQUIRE(V[6] == 0);
+        v = {8, 2, 3}; topAQ += v;
+        REQUIRE(V[0] == 8);
+        REQUIRE(V[1] == 8);
+        REQUIRE(V[2] == 5);
+        REQUIRE(V[3] == 4);
+        REQUIRE(V[4] == 3);
+        REQUIRE(V[5] == 3);
+        REQUIRE(V[6] == 2);
+        REQUIRE(V[7] == 2);
+        REQUIRE(V[8] == 1);
+        REQUIRE(V[9] == 0);
+        v = {6, 7, 9, 0}; topAQ += v;
+        REQUIRE(V[0] == 9);
+        REQUIRE(V[1] == 8);
+        REQUIRE(V[2] == 8);
+        REQUIRE(V[3] == 7);
+        REQUIRE(V[4] == 6);
+        REQUIRE(V[5] == 5);
+        REQUIRE(V[6] == 4);
+        REQUIRE(V[7] == 3);
+        REQUIRE(V[8] == 3);
+        REQUIRE(V[9] == 2);
+        topAQ2 = topAQ;
+        topAQ2 += topAQ;
+        REQUIRE(V2[0] == 9);
+        REQUIRE(V2[1] == 9);
+        REQUIRE(V2[2] == 8);
+        REQUIRE(V2[3] == 8);
+        REQUIRE(V2[4] == 8);
+        REQUIRE(V2[5] == 8);
+        REQUIRE(V2[6] == 7);
+        REQUIRE(V2[7] == 7);
+        REQUIRE(V2[8] == 6);
+        REQUIRE(V2[9] == 6);
+    }
 
     SECTION("potential phred underflow") {
         vector<int32_t> pl {4364,0,4983};

--- a/test/diploid.cc
+++ b/test/diploid.cc
@@ -37,7 +37,7 @@ TEST_CASE("diploid::alleles_gt") {
     }
 }
 
-TEST_CASE("diploid::alleles_maxAQ") {
+TEST_CASE("diploid::alleles_topAQ") {
     // tests with one overwhelmingly likely genotype
     for (int n_allele=2; n_allele<16; n_allele++) {
         auto nGT = diploid::genotypes(n_allele);
@@ -47,15 +47,15 @@ TEST_CASE("diploid::alleles_maxAQ") {
 
             vector<double> gll(diploid::genotypes(n_allele), log(0.01));
             gll[gt] = log(1.0);
-            vector<int> AQ;
-            Status s = diploid::alleles_maxAQ(n_allele, 1, {0}, gll, AQ);
+            vector<top_AQ> AQ;
+            Status s = diploid::alleles_topAQ(n_allele, 1, {0}, gll, AQ);
             REQUIRE(s.ok());
             REQUIRE(AQ.size() == n_allele);
             for (int al = 0; al<n_allele; al++) {
                 if (al == al1 || al == al2) {
-                    REQUIRE(AQ[al] == 20);
+                    REQUIRE(AQ[al].V[0] == 20);
                 } else {
-                    REQUIRE(AQ[al] == 0);
+                    REQUIRE(AQ[al].V[0] == 0);
                 }
             }
         }
@@ -76,19 +76,19 @@ TEST_CASE("diploid::alleles_maxAQ") {
                     vector<double> gll(diploid::genotypes(n_allele), log(0.001));
                     gll[gt] = log(1.0);
                     gll[gt2] = log(0.1);
-                    vector<int> AQ;
-                    Status s = diploid::alleles_maxAQ(n_allele, 1, {0}, gll, AQ);
+                    vector<top_AQ> AQ;
+                    Status s = diploid::alleles_topAQ(n_allele, 1, {0}, gll, AQ);
                     REQUIRE(s.ok());
                     REQUIRE(AQ.size() == n_allele);
                     for (int al = 0; al<n_allele; al++) {
                          if (al == al1 || al == al2) {
                              if (al == al3 || al == al4) {
-                                 REQUIRE(AQ[al] == 30);
+                                 REQUIRE(AQ[al].V[0] == 30);
                              } else {
-                                 REQUIRE(AQ[al] == 10);
+                                 REQUIRE(AQ[al].V[0] == 10);
                              }
                         } else {
-                            REQUIRE(AQ[al] == 0);
+                            REQUIRE(AQ[al].V[0] == 0);
                         }
                     }
                 }
@@ -96,17 +96,19 @@ TEST_CASE("diploid::alleles_maxAQ") {
         }
     }
 
+    // TODO: top_AQ rank tests
+
     SECTION("potential phred underflow") {
         vector<int32_t> pl {4364,0,4983};
         vector<double> gll;
         for (auto pl_i : pl) {
             gll.push_back(double(pl_i)/(-10.0)/log10(exp(1.0)));
         }
-        vector<int> AQ;
-        Status s = diploid::alleles_maxAQ(2, 1, {0}, gll, AQ);
+        vector<top_AQ> AQ;
+        Status s = diploid::alleles_topAQ(2, 1, {0}, gll, AQ);
         REQUIRE(s.ok());
-        REQUIRE(AQ[0] == 4983);
-        REQUIRE(AQ[1] == 4364);
+        REQUIRE(AQ[0].V[0] == 4983);
+        REQUIRE(AQ[1].V[0] == 4364);
     }
 
     // TODO: multi-sample tests

--- a/test/types.cc
+++ b/test/types.cc
@@ -86,12 +86,12 @@ TEST_CASE("discovered_alleles_of_yaml") {
 - range: {ref: '17', beg: 100, end: 100}
   dna: A
   is_ref: true
-  maxAQ: 99
+  top_AQ: [99]
   zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 - range: {ref: '17', beg: 100, end: 100}
   dna: G
   is_ref: false
-  maxAQ: 99
+  top_AQ: [99]
   zygosity_by_GQ: [[0,0],[10,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,5]]
 )";
 
@@ -118,13 +118,13 @@ TEST_CASE("discovered_alleles_of_yaml") {
 - range: {ref: '17', beg: 100, end: 100}
   dna: A
   is_ref: true
-  copy_number: 100
-  maxAQ: 99
+  top_AQ: [99]
+  zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 - range: {ref: 'bogus', beg: 100, end: 100}
   dna: G
   is_ref: false
-  copy_number: 10.5
-  maxAQ: 99
+  top_AQ: [99]
+  zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 )");
 
         discovered_alleles dal;
@@ -134,8 +134,8 @@ TEST_CASE("discovered_alleles_of_yaml") {
         n = YAML::Load(1 + R"(
 - dna: A
   is_ref: true
-  copy_number: 100
-  maxAQ: 99
+  top_AQ: [99]
+  zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 )");
 
         s = discovered_alleles_of_yaml(n, contigs, dal);
@@ -145,8 +145,8 @@ TEST_CASE("discovered_alleles_of_yaml") {
 - range: 123
   dna: A
   is_ref: true
-  copy_number: 100
-  maxAQ: 99
+  top_AQ: [99]
+  zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 )");
 
         s = discovered_alleles_of_yaml(n, contigs, dal);
@@ -158,13 +158,13 @@ TEST_CASE("discovered_alleles_of_yaml") {
 - range: {ref: '17', beg: 100, end: 100}
   dna: A
   is_ref: true
-  copy_number: 100
-  maxAQ: 99
+  top_AQ: [99]
+  zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 - range: {ref: '17', beg: 100, end: 100}
   dna: BOGUS
   is_ref: false
-  copy_number: 10.5
-  maxAQ: 99
+  top_AQ: [99]
+  zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 )");
 
         discovered_alleles dal;
@@ -172,18 +172,18 @@ TEST_CASE("discovered_alleles_of_yaml") {
         REQUIRE(s.bad());
     }
 
-    SECTION("bogus copy_number") {
+    SECTION("bogus zygosity_by_GQ") {
         YAML::Node n = YAML::Load(1 + R"(
 - range: {ref: '17', beg: 100, end: 100}
   dna: A
   is_ref: true
-  copy_number: 100
-  maxAQ: 99
+  top_AQ: [99]
+  zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 - range: {ref: '17', beg: 100, end: 100}
   dna: G
   is_ref: false
-  copy_number: [x]
-  maxAQ: 99
+  top_AQ: [99]
+  zygosity_by_GQ: 100
 )");
 
         discovered_alleles dal;
@@ -191,18 +191,18 @@ TEST_CASE("discovered_alleles_of_yaml") {
         REQUIRE(s.bad());
     }
 
-    SECTION("bogus maxAQ") {
+    SECTION("bogus top_AQ") {
         YAML::Node n = YAML::Load(1 + R"(
 - range: {ref: '17', beg: 100, end: 100}
   dna: A
   is_ref: true
-  copy_number: 100
-  maxAQ: 99
+  top_AQ: [99]
+  zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 - range: {ref: '17', beg: 100, end: 100}
   dna: G
   is_ref: false
-  copy_number: 100
-  maxAQ: ['z']
+  top_AQ: false
+  zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 )");
 
         discovered_alleles dal;
@@ -230,12 +230,12 @@ TEST_CASE("yaml_of_discovered_alleles") {
 - range: {ref: '17', beg: 100, end: 100}
   dna: A
   is_ref: true
-  maxAQ: 99
+  top_AQ: [99]
   zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
 - range: {ref: '17', beg: 100, end: 100}
   dna: G
   is_ref: false
-  maxAQ: 99
+  top_AQ: [99]
   zygosity_by_GQ: [[0,0],[10,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,5]]
 )";
 

--- a/test/unifier.cc
+++ b/test/unifier.cc
@@ -9,19 +9,19 @@ TEST_CASE("unifier max_alleles_per_site") {
     discovered_alleles dal;
     discovered_allele_info dai;
 
-    dai.is_ref = true; dai.maxAQ = 99; dai.zGQ = zygosity_by_GQ(1,0,100);
+    dai.is_ref = true; dai.topAQ = top_AQ(99); dai.zGQ = zygosity_by_GQ(1,0,100);
     dal[allele(range(0, 100, 101), "A")] = dai;
-    dai.is_ref = false; dai.maxAQ = 99; dai.zGQ = zygosity_by_GQ(1,0,100);
+    dai.is_ref = false; dai.topAQ = top_AQ(99); dai.zGQ = zygosity_by_GQ(1,0,100);
     dal[allele(range(0, 100, 101), "G")] = dai;
-    dai.is_ref = false; dai.maxAQ = 99; dai.zGQ = zygosity_by_GQ(1,0,10);
+    dai.is_ref = false; dai.topAQ = top_AQ(99); dai.zGQ = zygosity_by_GQ(1,0,10);
     dal[allele(range(0, 100, 101), "C")] = dai;
-    dai.is_ref = false; dai.maxAQ = 99; dai.zGQ = zygosity_by_GQ(1,0,10);
+    dai.is_ref = false; dai.topAQ = top_AQ(99); dai.zGQ = zygosity_by_GQ(1,0,10);
     dal[allele(range(0, 100, 101), "T")] = dai;
-    dai.is_ref = true; dai.maxAQ = 99; dai.zGQ = zygosity_by_GQ(1,0,100);
+    dai.is_ref = true; dai.topAQ = top_AQ(99); dai.zGQ = zygosity_by_GQ(1,0,100);
     dal[allele(range(0, 100, 102), "AA")] = dai;
-    dai.is_ref = false; dai.maxAQ = 99; dai.zGQ = zygosity_by_GQ(1,0,100);
+    dai.is_ref = false; dai.topAQ = top_AQ(99); dai.zGQ = zygosity_by_GQ(1,0,100);
     dal[allele(range(0, 100, 102), "GG")] = dai;
-    dai.is_ref = false; dai.maxAQ = 99; dai.zGQ = zygosity_by_GQ(1,0,1);
+    dai.is_ref = false; dai.topAQ = top_AQ(99); dai.zGQ = zygosity_by_GQ(1,0,1);
     dal[allele(range(0, 100, 102), "GC")] = dai;
 
     unifier_config cfg;


### PR DESCRIPTION
Trifurcate `unifier_config::min_quality` to `min_AQ1`, `min_AQ2`, and `min_GQ`.

The AQ thresholds control adjudication of allele existence. The unifier includes alleles having any
observation with AQ > min_AQ1, or having more than one observation each with AQ > min_AQ2 (min_AQ1 >= min_AQ2).

The GQ threshold affects estimates of allele copy number. Genotype calls with GQ >= min_GQ count towards the copy number estimates of the constituent alleles.