### PR TITLE
Simplify bridge between allele discovery and site unification

### DIFF
--- a/cli/dxapplet/src/code.sh
+++ b/cli/dxapplet/src/code.sh
@@ -135,7 +135,7 @@ main() {
         # numactl explanation: https://blog.jcole.us/2010/09/28/mysql-swap-insanity-and-the-numa-architecture/
         time numactl --interleave=all glnexus_cli discover_alleles GLnexus.db --bed ranges.bed $config_flag > discovered_alleles.yml
 
-        time numactl --interleave=all glnexus_cli unify_sites discovered_alleles.yml $config_flag > unified_sites.yml
+        time numactl --interleave=all glnexus_cli unify_sites discovered_alleles.yml --bed ranges.bed $config_flag > unified_sites.yml
 
         mkdir -p out/vcf
         time numactl --interleave=all glnexus_cli genotype GLnexus.db unified_sites.yml $residuals_flag $config_flag | bcftools view - | $vcf_compressor -c > "out/vcf/${output_name}.vcf.${compress_ext}"

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -785,11 +785,6 @@ int main_unify_sites(int argc, char *argv[]) {
         for (auto &us : sites) {
             H("find target range containing site " + us.pos.str(contigs),
               utils::find_containing_range(ranges, us.pos, us.containing_target));
-//            s = utils::find_containing_range(ranges, us.pos, us.containing_target);
-//            if  (s.bad()) {
-//                cout << "Error " << s.str() << " find target range containing site "
-//                     << us.pos.str(contigs) << endl;
-//            }
         }
     }
 

--- a/include/cli_utils.h
+++ b/include/cli_utils.h
@@ -24,13 +24,13 @@ Status LoadYAMLFile(const std::string& filename, YAML::Node &node);
 
 // Serialize the contigs, and discovered alleles to YAML
 Status yaml_of_contigs_alleles(const std::vector<std::pair<std::string,size_t> > &contigs,
-                               const std::vector<discovered_alleles> &valleles,
+                               const discovered_alleles &dsals,
                                YAML::Emitter &yaml);
 
 // Load a YAML file, previously created with the above function
 Status contigs_alleles_of_yaml(const YAML::Node& yaml,
                                std::vector<std::pair<std::string,size_t> > &contigs,
-                               std::vector<discovered_alleles> &valleles);
+                               discovered_alleles &dsals);
 
 // Serialize a vector of unified-alleles to YAML.
 Status yaml_of_unified_sites(const std::vector<unified_site> &sites,
@@ -42,12 +42,15 @@ Status unified_sites_of_yaml(const YAML::Node& yaml,
                              const std::vector<std::pair<std::string,size_t> > &contigs,
                              std::vector<unified_site> &sites);
 
+Status merge_all(const std::vector<discovered_alleles> &valleles,
+                 discovered_alleles &dsals);
+
 // Merge a bunch of discovered-allele files, all in YAML format.
 //
 Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
                                      const std::vector<std::string> &filenames,
                                      std::vector<std::pair<std::string,size_t>> &contigs,
-                                     std::vector<discovered_alleles> &valleles);
+                                     discovered_alleles &dsals);
 
 
 // Find which range contains [pos].

--- a/include/cli_utils.h
+++ b/include/cli_utils.h
@@ -42,9 +42,6 @@ Status unified_sites_of_yaml(const YAML::Node& yaml,
                              const std::vector<std::pair<std::string,size_t> > &contigs,
                              std::vector<unified_site> &sites);
 
-Status merge_all(const std::vector<discovered_alleles> &valleles,
-                 discovered_alleles &dsals);
-
 // Merge a bunch of discovered-allele files, all in YAML format.
 //
 Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
@@ -53,7 +50,7 @@ Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
                                      discovered_alleles &dsals);
 
 
-// Find which range contains [pos].
+// Find which range contains [pos]. The ranges are assumed to be non-overlapping.
 Status find_containing_range(const std::set<range> &ranges,
                              const range &pos,
                              range &ans);

--- a/include/cli_utils.h
+++ b/include/cli_utils.h
@@ -22,17 +22,15 @@ bool parse_ranges(const std::vector<std::pair<std::string,size_t> >& contigs,
 // Read from disk and parse a YAML file
 Status LoadYAMLFile(const std::string& filename, YAML::Node &node);
 
-// Serialize the contigs, ranges, and discovered alleles to YAML
-Status yaml_of_contigs_alleles_ranges(const std::vector<std::pair<std::string,size_t> > &contigs,
-                                      const std::vector<range> &ranges,
-                                      const std::vector<discovered_alleles> &valleles,
-                                      YAML::Emitter &yaml);
+// Serialize the contigs, and discovered alleles to YAML
+Status yaml_of_contigs_alleles(const std::vector<std::pair<std::string,size_t> > &contigs,
+                               const std::vector<discovered_alleles> &valleles,
+                               YAML::Emitter &yaml);
 
 // Load a YAML file, previously created with the above function
-Status contigs_alleles_ranges_of_yaml(const YAML::Node& yaml,
-                                      std::vector<std::pair<std::string,size_t> > &contigs,
-                                      std::vector<range> &ranges,
-                                      std::vector<discovered_alleles> &valleles);
+Status contigs_alleles_of_yaml(const YAML::Node& yaml,
+                               std::vector<std::pair<std::string,size_t> > &contigs,
+                               std::vector<discovered_alleles> &valleles);
 
 // Serialize a vector of unified-alleles to YAML.
 Status yaml_of_unified_sites(const std::vector<unified_site> &sites,
@@ -46,13 +44,17 @@ Status unified_sites_of_yaml(const YAML::Node& yaml,
 
 // Merge a bunch of discovered-allele files, all in YAML format.
 //
-// Note: each file could have a different set of containing ranges, and we want to merge
-// alleles in each range separately.
 Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
                                      const std::vector<std::string> &filenames,
                                      std::vector<std::pair<std::string,size_t>> &contigs,
-                                     std::vector<range> &ranges,
                                      std::vector<discovered_alleles> &valleles);
+
+
+// Find which range contains [pos].
+Status find_containing_range(const std::set<range> &ranges,
+                             const range &pos,
+                             range &ans);
+
 }}}
 
 #endif

--- a/include/unifier.h
+++ b/include/unifier.h
@@ -9,10 +9,8 @@ namespace GLnexus {
 
 /// Compute unified sites from all discovered alleles in some genomic region
 Status unified_sites(const unifier_config& cfg,
-	                 const discovered_alleles& alleles,
-	                 std::vector<unified_site>& ans,
-	                 range containing_target = range(-1,-1,-1));
-
+                     const discovered_alleles& alleles,
+                     std::vector<unified_site>& ans);
 }
 
 #endif

--- a/src/cli_utils.cc
+++ b/src/cli_utils.cc
@@ -264,13 +264,40 @@ Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
 Status find_containing_range(const std::set<range> &ranges,
                              const range &pos,
                              range &ans) {
+    // deal with special cases first
+    int nm_elem = ranges.size();
+    if (nm_elem == 0) {
+        return Status::NotFound();
+    }
+    if (nm_elem == 1) {
+        auto it = ranges.begin();
+        if (it->contains(pos)) {
+            ans = *it;
+            return Status::OK();
+        }
+        return Status::NotFound();
+    }
+
+    // The returned value here is the first element that is
+    // greater or equal to [pos].
     auto it = ranges.lower_bound(pos);
     if (it == ranges.end()) {
-        ans = range(-1,-1,-1);
+        it = std::prev(ranges.end());
+    }
+
+    if (it->contains(pos)) {
+        // we got the right range
+        ans = *it;
         return Status::OK();
     }
-    ans = *it;
-    return Status::OK();
+
+    // we landed one range after the one we need
+    it = std::prev(it);
+    if (it->contains(pos)) {
+        ans = *it;
+        return Status::OK();
+    }
+    return Status::NotFound();
 }
 
 }}}

--- a/src/cli_utils.cc
+++ b/src/cli_utils.cc
@@ -210,8 +210,7 @@ Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
     const string& first_file = filenames[0];
     S(LoadYAMLFile(first_file, node));
     S(contigs_alleles_of_yaml(node, contigs, dsals));
-    if (logger != nullptr)
-        logger->info() << "loaded " << dsals.size() << " alleles from " << first_file;
+    logger->info() << "loaded " << dsals.size() << " alleles from " << first_file;
 
     if (filenames.size() == 1)
         return Status::OK();
@@ -225,8 +224,7 @@ Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
 
         S(LoadYAMLFile(crnt_file, node));
         S(contigs_alleles_of_yaml(node, contigs2, dsals2));
-        if (logger != nullptr)
-            logger->info() << "loaded " << dsals2.size() << " alleles from " << crnt_file;
+        logger->info() << "loaded " << dsals2.size() << " alleles from " << crnt_file;
 
         // verify that the contigs are the same
         if (contigs.size() != contigs2.size())

--- a/src/cli_utils.cc
+++ b/src/cli_utils.cc
@@ -264,36 +264,23 @@ Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
 Status find_containing_range(const std::set<range> &ranges,
                              const range &pos,
                              range &ans) {
-    // deal with special cases first
-    int nm_elem = ranges.size();
-    if (nm_elem == 0) {
-        return Status::NotFound();
-    }
-    if (nm_elem == 1) {
-        auto it = ranges.begin();
-        if (it->contains(pos)) {
-            ans = *it;
-            return Status::OK();
-        }
+    if (ranges.size() == 0) {
         return Status::NotFound();
     }
 
     // The returned value here is the first element that is
     // greater or equal to [pos].
     auto it = ranges.lower_bound(pos);
-    if (it == ranges.end()) {
-        it = std::prev(ranges.end());
+    if (it == ranges.end() ||
+        (pos.rid == it->rid && pos.beg < it->beg)) {
+        // we landed one range after the one we need
+        if (it != ranges.begin()) {
+            it = std::prev(it);
+        }
     }
 
     if (it->contains(pos)) {
         // we got the right range
-        ans = *it;
-        return Status::OK();
-    }
-
-    // we landed one range after the one we need
-    it = std::prev(it);
-    if (it->contains(pos)) {
         ans = *it;
         return Status::OK();
     }

--- a/src/types.cc
+++ b/src/types.cc
@@ -187,7 +187,9 @@ Status discovered_alleles_of_yaml(const YAML::Node& yaml,
         ans[al] = ai;
         #undef VR
     }
-    V(ans.size() >= 1, "not enough alleles");
+
+    // We might serialize to disk an empty list of alleles for a site.
+    //V(ans.size() >= 1, "not enough alleles");
 
     #undef V
     return Status::OK();

--- a/src/unifier.cc
+++ b/src/unifier.cc
@@ -395,8 +395,7 @@ Status unify_alleles(const unifier_config& cfg, const range& pos,
 
 Status unified_sites(const unifier_config& cfg,
                      const discovered_alleles& alleles,
-                     vector<unified_site>& ans,
-                     range containing_target) {
+                     vector<unified_site>& ans) {
     Status s;
 
     map<range,pair<discovered_alleles,minimized_alleles>> sites;
@@ -408,8 +407,6 @@ Status unified_sites(const unifier_config& cfg,
         UNPAIR(site_alleles, ref_alleles, alt_alleles);
         unified_site us(pos);
         S(unify_alleles(cfg, pos, ref_alleles, alt_alleles, us));
-        assert(containing_target.rid < 0 || containing_target.contains(pos));
-        us.containing_target = containing_target;
         ans.push_back(us);
     }
     return Status::OK();

--- a/test/cli_utils.cc
+++ b/test/cli_utils.cc
@@ -435,7 +435,6 @@ unification:
         discovered_alleles dsals;
         Status s = utils::merge_discovered_allele_files(console, filenames, contigs, dsals);
     }
-
 }
 
 TEST_CASE("find_containing_range") {
@@ -463,6 +462,11 @@ TEST_CASE("find_containing_range") {
 
         // last
         pos = range(3,1200,1218);
+        s = utils::find_containing_range(ranges, pos, ans);
+        REQUIRE(s.ok());
+        REQUIRE(ans == range(3,1000,1507));
+
+        pos = range(3,1000,1000);
         s = utils::find_containing_range(ranges, pos, ans);
         REQUIRE(s.ok());
         REQUIRE(ans == range(3,1000,1507));
@@ -526,5 +530,36 @@ TEST_CASE("find_containing_range") {
         range pos(1,17,18);
         s = utils::find_containing_range(ranges, pos, ans);
         REQUIRE(s.bad());
+    }
+
+    SECTION("larger example") {
+        vector<pair<string,size_t>> contigs;
+        contigs.push_back(make_pair("1",260000000));
+        contigs.push_back(make_pair("10",140000000));
+        contigs.push_back(make_pair("11",100000000));
+
+        set<range> ranges;
+        ranges.insert(range(1,30366,30503));
+        ranges.insert(range(1,35720,35737));
+        ranges.insert(range(1,69090,70009));
+        ranges.insert(range(1,249152026,249152059));
+        ranges.insert(range(1,249208061,249208079));
+        ranges.insert(range(1,249210800,249214146));
+        ranges.insert(range(2,92996,94055));
+        ranges.insert(range(2,95121,95179));
+        ranges.insert(range(2,255828,255989));
+        ranges.insert(range(2,135480471,135481678));
+        ranges.insert(range(2,135491589,135491842));
+        ranges.insert(range(3,168957,169053));
+        ranges.insert(range(3,180208,180405));
+        ranges.insert(range(3,5685264,5685404));
+        ranges.insert(range(3,5700990,5701408));
+        ranges.insert(range(3,5717462,5717886));
+
+        range pos(1, 249211350, 249211350);
+        range ans(-1,-1,-1);
+        Status s = utils::find_containing_range(ranges,pos,ans);
+        REQUIRE(s.ok());
+        REQUIRE(ans == range(1,249210800,249214146));
     }
 }

--- a/test/cli_utils.cc
+++ b/test/cli_utils.cc
@@ -389,3 +389,84 @@ unification:
     }
 
 }
+
+TEST_CASE("find_containing_range") {
+    vector<pair<string,size_t>> contigs;
+    contigs.push_back(make_pair("1",100000));
+    contigs.push_back(make_pair("2",130001));
+    contigs.push_back(make_pair("3",24006));
+
+    SECTION("5 ranges") {
+        std::set<range> ranges;
+        ranges.insert(range(1,15,20));
+        ranges.insert(range(1,108,151));
+        ranges.insert(range(2,31,50));
+        ranges.insert(range(2,42,48));
+        ranges.insert(range(3,1000,1507));
+
+        Status s;
+        range ans(-1,-1,-1);
+
+        // beginning
+        range pos(1,17,18);
+        s = utils::find_containing_range(ranges, pos, ans);
+        REQUIRE(s.ok());
+        REQUIRE(ans == range(1,15,20));
+
+        // last
+        pos = range(3,1200,1218);
+        s = utils::find_containing_range(ranges, pos, ans);
+        REQUIRE(s.ok());
+        REQUIRE(ans == range(3,1000,1507));
+
+        // middle
+        pos = range(2,31,35);
+        s = utils::find_containing_range(ranges, pos, ans);
+        REQUIRE(s.ok());
+        REQUIRE(ans == range(2,31,50));
+
+        // missing range
+        pos = range(2,301,302);
+        s = utils::find_containing_range(ranges, pos, ans);
+        REQUIRE(s.bad());
+
+        // missing range
+        pos = range(3,2000,2003);
+        s = utils::find_containing_range(ranges, pos, ans);
+        REQUIRE(s.bad());
+
+        // missing range
+        pos = range(1,2,4);
+        s = utils::find_containing_range(ranges, pos, ans);
+        REQUIRE(s.bad());
+    }
+
+    SECTION("1 range") {
+        std::set<range> ranges;
+        ranges.insert(range(1,15,20));
+
+        Status s;
+        range ans(-1,-1,-1);
+
+        // beginning
+        range pos(1,17,18);
+        s = utils::find_containing_range(ranges, pos, ans);
+        REQUIRE(s.ok());
+        REQUIRE(ans == range(1,15,20));
+
+        // missing range
+        pos = range(3,1200,1218);
+        s = utils::find_containing_range(ranges, pos, ans);
+        REQUIRE(s.bad());
+
+        // missing range
+        pos = range(1,2,5);
+        s = utils::find_containing_range(ranges, pos, ans);
+        REQUIRE(s.bad());
+
+        // non overlapping
+        pos = range(1,15,30);
+        s = utils::find_containing_range(ranges, pos, ans);
+        REQUIRE(s.bad());
+    }
+}

--- a/test/cli_utils.cc
+++ b/test/cli_utils.cc
@@ -10,9 +10,8 @@ using namespace GLnexus;
 using namespace GLnexus::cli;
 
         // create two yaml files in the right format
-static void yaml_file_of_discover_alleles(const string &filename,
+static void yaml_file_of_discovered_alleles(const string &filename,
                                           const vector<pair<string,size_t>> &contigs,
-                                          const vector<range> ranges,
                                           const char* buf) {
     std::remove(filename.c_str());
 
@@ -24,7 +23,7 @@ static void yaml_file_of_discover_alleles(const string &filename,
     valleles.push_back(dal1);
 
     YAML::Emitter yaml;
-    s = utils::yaml_of_contigs_alleles_ranges(contigs, ranges, valleles, yaml);
+    s = utils::yaml_of_contigs_alleles(contigs, valleles, yaml);
     REQUIRE(s.ok());
 
     ofstream fos;
@@ -98,11 +97,23 @@ TEST_CASE("cli_utils") {
         REQUIRE(utils::parse_ranges(contigs, cmdline, ranges));
     }
 
-    SECTION("yaml_discovered_alleles") {
-        vector<range> ranges;
-        ranges.push_back(range(0, 1000, 1100));
-        ranges.push_back(range(1, 40, 70));
+    SECTION("yaml_discovered_alleles, an empty list") {
+        // an empty list
+        YAML::Emitter yaml;
+        {
+            GLnexus::discovered_alleles dsals;
+            Status s = yaml_of_discovered_alleles(dsals, contigs, yaml);
+            REQUIRE(s.ok());
+        }
 
+        YAML::Node n = YAML::Load(yaml.c_str());
+        discovered_alleles dal_empty;
+        Status s = discovered_alleles_of_yaml(n, contigs, dal_empty);
+        cout << s.str() << endl;
+        REQUIRE(s.ok());
+    }
+
+    SECTION("yaml_discovered_alleles") {
         vector<discovered_alleles> valleles;
         {
             YAML::Node n = YAML::Load(da_yaml1);
@@ -116,33 +127,22 @@ TEST_CASE("cli_utils") {
             s = discovered_alleles_of_yaml(n, contigs, dal2);
             REQUIRE(s.ok());
             valleles.push_back(dal2);
+
         }
 
         YAML::Emitter yaml;
-        Status s = utils::yaml_of_contigs_alleles_ranges(contigs, ranges, valleles, yaml);
+        Status s = utils::yaml_of_contigs_alleles(contigs, valleles, yaml);
         REQUIRE(s.ok());
 
         YAML::Node n = YAML::Load(yaml.c_str());
         std::vector<std::pair<std::string,size_t> > contigs2;
-        std::vector<range> ranges2;
         std::vector<discovered_alleles> valleles2;
 
-        s = utils::contigs_alleles_ranges_of_yaml(n, contigs2, ranges2, valleles2);
+        s = utils::contigs_alleles_of_yaml(n, contigs2, valleles2);
         REQUIRE(valleles.size() == valleles2.size());
         for (int i=0; i < valleles.size(); i++) {
             REQUIRE(valleles[i] == valleles2[i]);
         }
-    }
-
-    SECTION("yaml_discovered_alleles, #ranges does not match #valleles") {
-        vector<range> ranges;
-        ranges.push_back(range(0, 1000, 1100));
-        ranges.push_back(range(1, 40, 70));
-
-        vector<discovered_alleles> valleles;
-        YAML::Emitter yaml;
-        Status s = utils::yaml_of_contigs_alleles_ranges(contigs, ranges, valleles, yaml);
-        REQUIRE(s.bad());
     }
 
 
@@ -287,19 +287,15 @@ unification:
 
 
     SECTION("merging discovered allele files, special case, only one file") {
-        vector<range> ranges;
-        ranges.push_back(range(0, 1, 1100));
-
         string tmp_file_name1 = "/tmp/xxx_1.yml";
-        yaml_file_of_discover_alleles(tmp_file_name1, contigs, ranges, da_yaml1);
+        yaml_file_of_discovered_alleles(tmp_file_name1, contigs, da_yaml1);
 
         vector<string> filenames;
         filenames.push_back(tmp_file_name1);
 
         vector<pair<string,size_t>> contigs2;
-        vector<range> ranges2;
         vector<discovered_alleles> valleles2;
-        Status s = utils::merge_discovered_allele_files(console, filenames, contigs2, ranges2, valleles2);
+        Status s = utils::merge_discovered_allele_files(console, filenames, contigs2, valleles2);
         REQUIRE(s.ok());
         REQUIRE(contigs2.size() == contigs.size());
     }
@@ -307,51 +303,37 @@ unification:
     SECTION("merging discovered allele files, 2 files") {
         // create two files, with different ranges
         string tmp_file_name1 = "/tmp/xxx_1.yml";
-        {
-            vector<range> ranges;
-            ranges.push_back(range(0, 1, 1100));
-            yaml_file_of_discover_alleles(tmp_file_name1, contigs, ranges, da_yaml1);
-        }
+        yaml_file_of_discovered_alleles(tmp_file_name1, contigs, da_yaml1);
 
         string tmp_file_name2 = "/tmp/xxx_2.yml";
-        {
-            vector<range> ranges2;
-            ranges2.push_back(range(0, 2002, 2208));
-            yaml_file_of_discover_alleles(tmp_file_name2, contigs, ranges2, da_yaml2);
-        }
+        yaml_file_of_discovered_alleles(tmp_file_name2, contigs, da_yaml2);
 
         vector<string> filenames;
         filenames.push_back(tmp_file_name1);
         filenames.push_back(tmp_file_name2);
 
         vector<pair<string,size_t>> contigs2;
-        vector<range> ranges2;
         vector<discovered_alleles> valleles;
-        Status s = utils::merge_discovered_allele_files(console, filenames, contigs2, ranges2, valleles);
+        Status s = utils::merge_discovered_allele_files(console, filenames, contigs2, valleles);
         REQUIRE(s.ok());
         REQUIRE(contigs2.size() == contigs.size());
-        REQUIRE(valleles.size() == 2);
-        REQUIRE(valleles[0].size() == 2);
-        REQUIRE(valleles[1].size() == 2);
+        REQUIRE(valleles.size() == 1);
+        REQUIRE(valleles[0].size() == 4);
     }
 
     SECTION("merging discovered allele files, 3 files") {
-        vector<range> ranges;
-        ranges.push_back(range(0, 1, 1100));
-
         vector<string> filenames;
         const char* yamls[] = {da_yaml1, da_yaml2, da_yaml3};
         const char* i_filenames[3] = {"/tmp/xxx_1.yml", "/tmp/xxx_2.yml", "/tmp/xxx_3.yml"};
         for (int i=0; i < 3; i++) {
             string fname = string(i_filenames[i]);
-            yaml_file_of_discover_alleles(fname, contigs, ranges, yamls[i]);
+            yaml_file_of_discovered_alleles(fname, contigs, yamls[i]);
             filenames.push_back(fname);
         }
 
         vector<pair<string,size_t>> contigs2;
-        vector<range> ranges2;
         vector<discovered_alleles> valleles;
-        Status s = utils::merge_discovered_allele_files(console, filenames, contigs2, ranges2, valleles);
+        Status s = utils::merge_discovered_allele_files(console, filenames, contigs2, valleles);
         REQUIRE(s.ok());
         REQUIRE(contigs2.size() == contigs.size());
         REQUIRE(valleles.size() == 1);
@@ -359,12 +341,51 @@ unification:
     }
 
     SECTION("merging discovered allele files, error, no files provided") {
-        vector<range> ranges;
-        ranges.push_back(range(0, 1, 1100));
         vector<string> filenames;
         vector<discovered_alleles> valleles;
 
-        Status s = utils::merge_discovered_allele_files(console, filenames, contigs, ranges, valleles);
+        Status s = utils::merge_discovered_allele_files(console, filenames, contigs, valleles);
+    }
+
+
+    const char* da_yaml10 = 1 + R"(
+- range: {ref: '16', beg: 107, end: 109}
+  dna: A
+  is_ref: true
+  top_AQ: [99]
+  zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+)";
+
+    const char* da_yaml11 = 1 + R"(
+- range: {ref: '16', beg: 107, end: 109}
+  dna: G
+  is_ref: true
+  top_AQ: [99]
+  zygosity_by_GQ: [[100,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+- range: {ref: '17', beg: 500, end: 501}
+  dna: G
+  is_ref: true
+  top_AQ: [99]
+  zygosity_by_GQ: [[0,0],[10,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,5]]
+- range: {ref: '17', beg: 1190, end: 1200}
+  dna: G
+  is_ref: true
+  top_AQ: [99]
+  zygosity_by_GQ: [[0,0],[10,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,5]]
+)";
+
+    SECTION("merging discovered allele files, error, number of sites doesn't match") {
+        vector<string> filenames;
+        const char* yamls[] = {da_yaml10, da_yaml11};
+        const char* i_filenames[3] = {"/tmp/xxx_1.yml", "/tmp/xxx_2.yml"};
+        for (int i=0; i < 2; i++) {
+            string fname = string(i_filenames[i]);
+            yaml_file_of_discovered_alleles(fname, contigs, yamls[i]);
+            filenames.push_back(fname);
+        }
+
+        vector<discovered_alleles> valleles;
+        Status s = utils::merge_discovered_allele_files(console, filenames, contigs, valleles);
     }
 
 }

--- a/test/cli_utils.cc
+++ b/test/cli_utils.cc
@@ -145,6 +145,45 @@ TEST_CASE("cli_utils") {
         }
     }
 
+    const char* bad_yaml_1 = 1 + R"(
+contigs: xxx
+alleles: yyy
+)";
+
+    const char* bad_yaml_2 = 1 + R"(
+contigs:
+  - name: A1
+    size: 1000
+  - name: A2
+    size: 300000
+alleles: yyy
+)";
+
+
+    SECTION("bad yaml inputs for contigs_alleles_of_yaml") {
+        std::vector<discovered_alleles> valleles;
+        {
+            YAML::Node n = YAML::Load("aaa");
+            Status s = utils::contigs_alleles_of_yaml(n, contigs, valleles);
+            REQUIRE(s.bad());
+            cout << s.str() << endl;
+        }
+
+        {
+            YAML::Node n = YAML::Load(bad_yaml_1);
+            Status s = utils::contigs_alleles_of_yaml(n, contigs, valleles);
+            REQUIRE(s.bad());
+            cout << s.str() << endl;
+        }
+
+        {
+            YAML::Node n = YAML::Load(bad_yaml_2);
+            Status s = utils::contigs_alleles_of_yaml(n, contigs, valleles);
+            REQUIRE(s.bad());
+            cout << s.str() << endl;
+        }
+    }
+
 
     const char* snp = 1 + R"(
 range: {ref: '17', beg: 100, end: 100}

--- a/test/cli_utils.cc
+++ b/test/cli_utils.cc
@@ -372,8 +372,29 @@ unification:
         discovered_alleles dsals;
 
         Status s = utils::merge_discovered_allele_files(console, filenames, contigs, dsals);
+        REQUIRE(s.bad());
     }
 
+    SECTION("merging discovered allele files, error 2") {
+        // create two files, with different ranges
+        string tmp_file_name1 = "/tmp/xxx_1.yml";
+        yaml_file_of_discovered_alleles(tmp_file_name1, contigs, da_yaml1);
+
+        vector<pair<string,size_t>> contigs2;
+        contigs2.push_back(make_pair("16",550000));
+        contigs2.push_back(make_pair("17",8811991));
+        string tmp_file_name2 = "/tmp/xxx_2.yml";
+        yaml_file_of_discovered_alleles(tmp_file_name2, contigs2, da_yaml2);
+
+        vector<string> filenames;
+        filenames.push_back(tmp_file_name1);
+        filenames.push_back(tmp_file_name2);
+
+        vector<pair<string,size_t>> contigs3;
+        discovered_alleles dsals;
+        Status s = utils::merge_discovered_allele_files(console, filenames, contigs3, dsals);
+        REQUIRE(s.bad());
+    }
 
     const char* da_yaml10 = 1 + R"(
 - range: {ref: '16', beg: 107, end: 109}
@@ -493,6 +514,16 @@ TEST_CASE("find_containing_range") {
 
         // non overlapping
         pos = range(1,15,30);
+        s = utils::find_containing_range(ranges, pos, ans);
+        REQUIRE(s.bad());
+    }
+
+    SECTION("no ranges") {
+        Status s;
+        range ans(-1,-1,-1);
+        std::set<range> ranges;
+
+        range pos(1,17,18);
         s = utils::find_containing_range(ranges, pos, ans);
         REQUIRE(s.bad());
     }


### PR DESCRIPTION
1) Simplify yaml formats connecting allele discovery and site unification
2) Look up containing range in the site-unification stage, by reading a bed file
3) Add sanity check, that the input ranges have no overlaps.