### PR TITLE
Streaming for unify-sites file

### DIFF
--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -787,9 +787,7 @@ int main_unify_sites(int argc, char *argv[]) {
     }
 
     // Write the unified sites to stdout
-    YAML::Emitter yaml;
-    H("write results as yaml", utils::yaml_of_unified_sites(sites, contigs, yaml));
-    cout << yaml.c_str() << endl;
+    H("write results as yaml", utils::yaml_stream_of_unified_sites(sites, contigs, cout));
 
     return 0;
 }
@@ -883,10 +881,15 @@ int main_genotype(int argc, char *argv[]) {
 
         vector<GLnexus::unified_site> sites;
         {
-            YAML::Node node;
-            H("Load discovered alleles file", utils::LoadYAMLFile(unified_sites_file, node));
+            std::ifstream ifs;
+            ifs.open(unified_sites_file, std::ifstream::in);
+            if (!ifs.good()) {
+                console->info() << "Error opening file " << unified_sites_file;
+                return 1;
+            }
             H("load unified sites",
-              utils::unified_sites_of_yaml(node, contigs, sites));
+              utils::unified_sites_of_yaml_stream(ifs, contigs, sites));
+            ifs.close();
         }
         console->info() << "loaded " << sites.size() << " sites from " << unified_sites_file;
 

--- a/include/cli_utils.h
+++ b/include/cli_utils.h
@@ -42,14 +42,14 @@ Status discovered_alleles_of_yaml_stream(std::istream &is,
                                          discovered_alleles &dsals);
 
 // Serialize a vector of unified-alleles to YAML.
-Status yaml_of_unified_sites(const std::vector<unified_site> &sites,
-                             const std::vector<std::pair<std::string,size_t> > &contigs,
-                             YAML::Emitter &yaml);
+Status yaml_stream_of_unified_sites(const std::vector<unified_site> &sites,
+                                    const std::vector<std::pair<std::string,size_t> > &contigs,
+                                    std::ostream &os);
 
 // Load from a file, data previously serialized with the above function
-Status unified_sites_of_yaml(const YAML::Node& yaml,
-                             const std::vector<std::pair<std::string,size_t> > &contigs,
-                             std::vector<unified_site> &sites);
+Status unified_sites_of_yaml_stream(std::istream &is,
+                                    const std::vector<std::pair<std::string,size_t> > &contigs,
+                                    std::vector<unified_site> &sites);
 
 // Merge a bunch of discovered-allele files, all in YAML format.
 //

--- a/test/cli_utils.cc
+++ b/test/cli_utils.cc
@@ -271,17 +271,16 @@ unification:
         }
 
         // convert to yaml
-        YAML::Emitter yaml;
+        stringstream ss;
         {
-            Status s = utils::yaml_of_unified_sites(sites, contigs, yaml);
+            Status s = utils::yaml_stream_of_unified_sites(sites, contigs, ss);
             REQUIRE(s.ok());
         }
 
         // convert back and compare
         {
-            YAML::Node n = YAML::Load(yaml.c_str());
             vector<unified_site> sites2;
-            Status s = utils::unified_sites_of_yaml(n, contigs, sites2);
+            Status s = utils::unified_sites_of_yaml_stream(ss, contigs, sites2);
             REQUIRE(s.ok());
             REQUIRE(sites.size() == sites2.size());
             for (int i=0; i < sites.size(); i++) {


### PR DESCRIPTION
The unify-sites file can get fairly large. The default (de)serialization provided by the yaml_cpp library requires keeping the data-structure for the entire file in memory, this causes high RAM usage. This modification drastically reduces memory consumption, by performing yaml conversion per site. Only a small part of the file is kept in memory at any one time.  