### PR TITLE
Orodeh discovered alleles parallel load

### DIFF
--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -694,6 +694,7 @@ void help_unify_sites(const char* prog) {
          << "Options:" << endl
          << "  --bed FILE, -b FILE  path to three-column BED file, the ranges have to the same same as the discover-alleles phase" << endl
          << "  --config X, -c X     apply unifier/genotyper configuration preset X" << endl
+         << "  --threads N, -t N    override thread pool size (default: nproc)" << endl
          << endl;
 }
 
@@ -708,11 +709,13 @@ int main_unify_sites(int argc, char *argv[]) {
         {"help", no_argument, 0, 'h'},
         {"bed", required_argument, 0, 'b'},
         {"config", required_argument, 0, 'c'},
+        {"threads", required_argument, 0, 't'},
         {0, 0, 0, 0}
     };
 
     string bedfilename;
     string config_preset;
+    size_t threads = 0;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -728,6 +731,10 @@ int main_unify_sites(int argc, char *argv[]) {
                 break;
             case 'c':
                 config_preset = string(optarg);
+                break;
+            case 't':
+                threads = strtoul(optarg, nullptr, 10);
+                console->info() << "pooling " << threads << " threads for site unification";
                 break;
             case 'h':
             case '?':
@@ -762,7 +769,7 @@ int main_unify_sites(int argc, char *argv[]) {
     vector<pair<string,size_t> > contigs;
     GLnexus::discovered_alleles dsals;
     H("merge discovered allele files",
-      utils::merge_discovered_allele_files(console, discovered_allele_files, contigs, dsals));
+      utils::merge_discovered_allele_files(console, threads, discovered_allele_files, contigs, dsals));
     console->info() << "consolidated to " << dsals.size() << " alleles for site unification";
 
     set<GLnexus::range> ranges;

--- a/include/cli_utils.h
+++ b/include/cli_utils.h
@@ -54,6 +54,7 @@ Status unified_sites_of_yaml_stream(std::istream &is,
 // Merge a bunch of discovered-allele files, all in YAML format.
 //
 Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
+                                     size_t nr_threads,
                                      const std::vector<std::string> &filenames,
                                      std::vector<std::pair<std::string,size_t>> &contigs,
                                      discovered_alleles &dsals);

--- a/src/cli_utils.cc
+++ b/src/cli_utils.cc
@@ -13,8 +13,6 @@ namespace GLnexus {
 namespace cli {
 namespace utils {
 
-int const MAX_CONCURRENCY = 8;
-
 // Parse a range like chr1:1000-2000. The item can also just be the name of a
 // contig, in which case it gets mapped to the contig's full length.
 bool parse_range(const vector<pair<string,size_t> >& contigs,

--- a/src/cli_utils.cc
+++ b/src/cli_utils.cc
@@ -308,12 +308,18 @@ Status unified_sites_of_yaml_stream(std::istream &is,
 
 // Load first file
 Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
+                                     size_t nr_threads,
                                      const vector<string> &filenames,
                                      vector<pair<string,size_t>> &contigs,
                                      discovered_alleles &dsals) {
     Status s;
     mutex mu;
-    ctpl::thread_pool threadpool(thread::hardware_concurrency());
+
+    if (nr_threads == 0) {
+        // by default, we use the number of cores for the thread pool size.
+        nr_threads = thread::hardware_concurrency();
+    }
+    ctpl::thread_pool threadpool(nr_threads);
 
     if (filenames.size() == 0)
         return Status::Invalid("no discovered allele files provided");

--- a/src/cli_utils.cc
+++ b/src/cli_utils.cc
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <regex>
 #include "cli_utils.h"
+#include "ctpl_stl.h"
 
 // This file has utilities employed by the glnexus applet.
 using namespace std;
@@ -11,6 +12,8 @@ using namespace std;
 namespace GLnexus {
 namespace cli {
 namespace utils {
+
+int const MAX_CONCURRENCY = 8;
 
 // Parse a range like chr1:1000-2000. The item can also just be the name of a
 // contig, in which case it gets mapped to the contig's full length.
@@ -309,41 +312,60 @@ Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
                                      vector<pair<string,size_t>> &contigs,
                                      discovered_alleles &dsals) {
     Status s;
+    mutex mu;
+    ctpl::thread_pool threadpool(thread::hardware_concurrency());
+
     if (filenames.size() == 0)
         return Status::Invalid("no discovered allele files provided");
     contigs.clear();
     dsals.clear();
 
-    // Load the first file
-    const string& first_file = filenames[0];
-    {
-        std::ifstream ifs(first_file.c_str());
-        S(discovered_alleles_of_yaml_stream(ifs, contigs, dsals));
-        logger->info() << "loaded " << dsals.size() << " alleles from " << first_file;
-        ifs.close();
+    // Load the files in parallel, and merge
+    vector<future<GLnexus::Status>> statuses;
+    for (const auto& dsal_file: filenames) {
+        auto fut = threadpool.push([&, dsal_file](int tid){
+            discovered_alleles dsals2;
+            vector<pair<string,size_t>> contigs2;
+
+            std::ifstream ifs(dsal_file.c_str());
+            Status s = discovered_alleles_of_yaml_stream(ifs, contigs2, dsals2);
+            ifs.close();
+            if (!s.ok()) {
+                logger->info() << "Error loading alleles from " << dsal_file;
+                return s;
+            }
+            logger->info() << "loaded " << dsals2.size() << " alleles from " << dsal_file;
+
+            lock_guard<mutex> lock(mu);
+            if (contigs.empty()) {
+                // This is the first file, initialize the result data-structures
+                contigs = contigs2;
+                dsals = dsals2;
+                return Status::OK();
+            }
+            
+            // We have already loaded and merged some files. 
+            // Verify that the contigs are the same
+            if (contigs != contigs2) {
+                return Status::Invalid("The contigs do not match");
+            }
+
+            // Merge the discovered alleles
+            return merge_discovered_alleles(dsals2, dsals);
+            });
+        statuses.push_back(move(fut));
     }
 
-    if (filenames.size() == 1)
-        return Status::OK();
-
-    // Load the rest of the files, and merge
-    for (auto it = filenames.begin() + 1; it != filenames.end(); ++it) {
-        vector<pair<string,size_t>> contigs2;
-        discovered_alleles dsals2;
-        const string &crnt_file = *it;
-        std::ifstream ifs(crnt_file.c_str());
-
-        S(discovered_alleles_of_yaml_stream(ifs, contigs2, dsals2));
-        logger->info() << "loaded " << dsals2.size() << " alleles from " << crnt_file;
-        ifs.close();
-
-        // verify that the contigs are the same
-        if (contigs != contigs2) {
-            return Status::Invalid("The contigs are different between", first_file + " " + crnt_file);
+    // collect results, wait for all threads to complete operation
+    vector<GLnexus::Status> failures;
+    for (size_t i = 0; i < filenames.size(); i++) {
+        GLnexus::Status s_i(move(statuses[i].get()));
+        if (!s_i.ok()) {
+            failures.push_back(move(s_i));
         }
-
-        S(merge_discovered_alleles(dsals2, dsals));
     }
+    if (!failures.empty())
+        return move(failures[0]);
 
     return Status::OK();
 }

--- a/test/cli_utils.cc
+++ b/test/cli_utils.cc
@@ -369,7 +369,7 @@ unification:
 
         vector<pair<string,size_t>> contigs2;
         discovered_alleles dsals2;
-        Status s = utils::merge_discovered_allele_files(console, filenames, contigs2, dsals2);
+        Status s = utils::merge_discovered_allele_files(console, 0, filenames, contigs2, dsals2);
         REQUIRE(s.ok());
         REQUIRE(contigs2.size() == contigs.size());
     }
@@ -388,7 +388,7 @@ unification:
 
         vector<pair<string,size_t>> contigs2;
         discovered_alleles dsals;
-        Status s = utils::merge_discovered_allele_files(console, filenames, contigs2, dsals);
+        Status s = utils::merge_discovered_allele_files(console, 0, filenames, contigs2, dsals);
         REQUIRE(s.ok());
         REQUIRE(contigs2.size() == contigs.size());
         REQUIRE(dsals.size() == 4);
@@ -406,7 +406,7 @@ unification:
 
         vector<pair<string,size_t>> contigs2;
         discovered_alleles dsals;
-        Status s = utils::merge_discovered_allele_files(console, filenames, contigs2, dsals);
+        Status s = utils::merge_discovered_allele_files(console, 0, filenames, contigs2, dsals);
         REQUIRE(s.ok());
         REQUIRE(contigs2.size() == contigs.size());
         REQUIRE(dsals.size() == 6);
@@ -416,7 +416,7 @@ unification:
         vector<string> filenames;
         discovered_alleles dsals;
 
-        Status s = utils::merge_discovered_allele_files(console, filenames, contigs, dsals);
+        Status s = utils::merge_discovered_allele_files(console, 0, filenames, contigs, dsals);
         REQUIRE(s.bad());
     }
 
@@ -437,7 +437,7 @@ unification:
 
         vector<pair<string,size_t>> contigs3;
         discovered_alleles dsals;
-        Status s = utils::merge_discovered_allele_files(console, filenames, contigs3, dsals);
+        Status s = utils::merge_discovered_allele_files(console, 0, filenames, contigs3, dsals);
         REQUIRE(s.bad());
     }
 
@@ -478,7 +478,7 @@ unification:
         }
 
         discovered_alleles dsals;
-        Status s = utils::merge_discovered_allele_files(console, filenames, contigs, dsals);
+        Status s = utils::merge_discovered_allele_files(console, 0, filenames, contigs, dsals);
     }
 }
 


### PR DESCRIPTION
Implements parallel load of the discovered allele files, for the unify-allele stage. The number of parallel threads is, by default, the number of cores. You can set it from the command line, using the -t parameter. 