### PR TITLE
unifier: translate copy numbers to allele frequencies

### DIFF
--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -785,7 +785,7 @@ int main_unify_sites(int argc, char *argv[]) {
     }
 
     vector<GLnexus::unified_site> sites;
-    H("unify sites", GLnexus::unified_sites(unifier_cfg, dsals, sites));
+    H("unify sites", GLnexus::unified_sites(unifier_cfg, N, dsals, sites));
     // sanity check, sites are in-order and non-overlapping
     if (sites.size() > 1) {
         auto p = sites.begin();

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -675,7 +675,8 @@ int main_discover_alleles(int argc, char *argv[]) {
 
     console->info() << "discovering alleles in " << ranges.size() << " range(s)";
     vector<GLnexus::discovered_alleles> valleles;
-    H("discover alleles", svc->discover_alleles(sampleset, ranges, valleles));
+    unsigned N;
+    H("discover alleles", svc->discover_alleles(sampleset, ranges, N, valleles));
 
     GLnexus::discovered_alleles dsals;
     for (auto it = valleles.begin(); it != valleles.end(); ++it) {
@@ -684,7 +685,7 @@ int main_discover_alleles(int argc, char *argv[]) {
     console->info() << "discovered " << dsals.size() << " alleles";
 
     // Write the discovered alleles to stdout
-    H("write results as yaml", utils::yaml_stream_of_discovered_alleles(contigs, dsals, cout));
+    H("write results as yaml", utils::yaml_stream_of_discovered_alleles(N, contigs, dsals, cout));
     return 0;
 }
 
@@ -767,11 +768,12 @@ int main_unify_sites(int argc, char *argv[]) {
         H("load configuration preset", load_config_preset(config_preset, unifier_cfg, genotyper_cfg));
     }
 
+    unsigned N;
     vector<pair<string,size_t> > contigs;
     GLnexus::discovered_alleles dsals;
     H("merge discovered allele files",
-      utils::merge_discovered_allele_files(console, threads, discovered_allele_files, contigs, dsals));
-    console->info() << "consolidated to " << dsals.size() << " alleles for site unification";
+      utils::merge_discovered_allele_files(console, threads, discovered_allele_files, N, contigs, dsals));
+    console->info() << "consolidated to " << dsals.size() << " alleles for site unification; N = " << N;
 
     set<GLnexus::range> ranges;
     if (!bedfilename.empty()) {

--- a/include/cli_utils.h
+++ b/include/cli_utils.h
@@ -29,9 +29,8 @@ Status yaml_of_contigs(const std::vector<std::pair<std::string,size_t> > &contig
 Status contigs_of_yaml(const YAML::Node& yaml,
                        std::vector<std::pair<std::string,size_t> > &contigs);
 
-// Serialize the contigs and discovered alleles to YAML. This is
-// done in streaming fashion, so only part of the YAML document is held
-// in memory.
+// Serialize N (sample count), contigs, and discovered alleles to YAML, in a
+// streaming fashion.
 Status yaml_stream_of_discovered_alleles(unsigned N, const std::vector<std::pair<std::string,size_t> > &contigs,
                                          const discovered_alleles &dsals,
                                          std::ostream &os);
@@ -52,7 +51,7 @@ Status unified_sites_of_yaml_stream(std::istream &is,
                                     std::vector<unified_site> &sites);
 
 // Merge a bunch of discovered-allele files, all in YAML format.
-//
+// N is summed across the files, and the contigs must be the same in all.
 Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
                                      size_t nr_threads,
                                      const std::vector<std::string> &filenames,

--- a/include/cli_utils.h
+++ b/include/cli_utils.h
@@ -32,13 +32,13 @@ Status contigs_of_yaml(const YAML::Node& yaml,
 // Serialize the contigs and discovered alleles to YAML. This is
 // done in streaming fashion, so only part of the YAML document is held
 // in memory.
-Status yaml_stream_of_discovered_alleles(const std::vector<std::pair<std::string,size_t> > &contigs,
+Status yaml_stream_of_discovered_alleles(unsigned N, const std::vector<std::pair<std::string,size_t> > &contigs,
                                          const discovered_alleles &dsals,
                                          std::ostream &os);
 
 // Load a YAML file, previously created with the above function
 Status discovered_alleles_of_yaml_stream(std::istream &is,
-                                         std::vector<std::pair<std::string,size_t> > &contigs,
+                                         unsigned &N, std::vector<std::pair<std::string,size_t> > &contigs,
                                          discovered_alleles &dsals);
 
 // Serialize a vector of unified-alleles to YAML.
@@ -56,7 +56,7 @@ Status unified_sites_of_yaml_stream(std::istream &is,
 Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
                                      size_t nr_threads,
                                      const std::vector<std::string> &filenames,
-                                     std::vector<std::pair<std::string,size_t>> &contigs,
+                                     unsigned& N, std::vector<std::pair<std::string,size_t>> &contigs,
                                      discovered_alleles &dsals);
 
 

--- a/include/service.h
+++ b/include/service.h
@@ -39,6 +39,8 @@ public:
     /// overlapping; the set is generally used as input to allele
     /// "unification"
     ///
+    /// Sets N = sample count (size of sampleset)
+    ///
     /// If the abort flag is non-null, then from time to time the algorithm
     /// checks its contents; if it finds the flag set (presumably by some
     /// other thread), then it will cleanly shut down and return status
@@ -62,7 +64,9 @@ public:
                           const std::string& filename,
                           std::atomic<bool>* abort = nullptr);
 
-
+    // Report cumulative time (milliseconds) worker threads in the above
+    // operations have spent 'stalled' waiting on single-threaded processing
+    // steps (e.g. output serialization)
     unsigned threads_stalled_ms() const;
 };
 

--- a/include/service.h
+++ b/include/service.h
@@ -44,7 +44,7 @@ public:
     /// other thread), then it will cleanly shut down and return status
     /// ABORTED.
     Status discover_alleles(const std::string& sampleset, const range& pos,
-                            discovered_alleles& ans,
+                            unsigned& N, discovered_alleles& ans,
                             std::atomic<bool>* abort = nullptr);
 
     /// Discover all the alleles contained within each of the given disjoint
@@ -53,7 +53,7 @@ public:
     /// target capture regions). However, attention should be paid to the
     /// anticipated size of the results.
     Status discover_alleles(const std::string& sampleset, const std::vector<range>& ranges,
-                            std::vector<discovered_alleles>& ans,
+                            unsigned& N, std::vector<discovered_alleles>& ans,
                             std::atomic<bool>* abort = nullptr);
 
     /// Genotype a set of samples at the given sites, producing a BCF file.

--- a/include/types.h
+++ b/include/types.h
@@ -409,18 +409,33 @@ struct unified_site {
     /// DNA) onto the unified alleles (by index).
     std::map<allele,int> unification;
 
-    std::vector<float> copy_number;
+    std::vector<float> allele_frequencies;
     //std::vector<float> genotype_prior;
 
     bool operator==(const unified_site& rhs) const noexcept {
-        return pos == rhs.pos && alleles == rhs.alleles && unification == rhs.unification
-               && copy_number == rhs.copy_number;
+        if (!(pos == rhs.pos && alleles == rhs.alleles && unification == rhs.unification
+              && allele_frequencies.size() == rhs.allele_frequencies.size())) {
+            return false;
+        }
+        // nan-tolerant comparison of allele_frequencies
+        for (unsigned i = 0; i < allele_frequencies.size(); i++) {
+            if (allele_frequencies[i] == allele_frequencies[i]) {
+                if (allele_frequencies[i] != rhs.allele_frequencies[i]) {
+                    return false;
+                }
+            } else {
+                if (rhs.allele_frequencies[i] == rhs.allele_frequencies[i]) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
     bool operator<(const unified_site& rhs) const noexcept{
         if (pos != rhs.pos) return pos < rhs.pos;
         if (alleles != rhs.alleles) return alleles < rhs.alleles;
         if (unification != rhs.unification) return unification < rhs.unification;
-        return copy_number < rhs.copy_number;
+        return allele_frequencies < rhs.allele_frequencies;
     }
 
     unified_site(const range& pos_) noexcept : pos(pos_), containing_target(-1,-1,-1) {}

--- a/include/unifier.h
+++ b/include/unifier.h
@@ -9,7 +9,7 @@ namespace GLnexus {
 
 /// Compute unified sites from all discovered alleles in some genomic region
 Status unified_sites(const unifier_config& cfg,
-                     const discovered_alleles& alleles,
+                     unsigned N, const discovered_alleles& alleles,
                      std::vector<unified_site>& ans);
 }
 

--- a/include/unifier.h
+++ b/include/unifier.h
@@ -8,6 +8,7 @@ namespace GLnexus {
 // unification_config...
 
 /// Compute unified sites from all discovered alleles in some genomic region
+/// N = sample count (used to estimate allele frequencies)
 Status unified_sites(const unifier_config& cfg,
                      unsigned N, const discovered_alleles& alleles,
                      std::vector<unified_site>& ans);

--- a/src/service.cc
+++ b/src/service.cc
@@ -153,6 +153,7 @@ Status Service::discover_alleles(const string& sampleset, const vector<range>& r
             Status ls = discover_alleles(sampleset, range, tmpN, dsals, &abort);
             if (ls.ok()) {
                 if (i == 0) {
+                    // tmpN should be the same across all ranges
                     N = tmpN;
                 }
                 results[i] = move(dsals);

--- a/src/service.cc
+++ b/src/service.cc
@@ -56,11 +56,13 @@ Status Service::Start(const service_config& cfg, Metadata& metadata, BCFData& da
 }
 
 Status Service::discover_alleles(const string& sampleset, const range& pos,
-                                 discovered_alleles& ans, atomic<bool>* ext_abort) {
+                                 unsigned& N, discovered_alleles& ans,
+                                 atomic<bool>* ext_abort) {
     // Find the data sets containing the samples in the sample set.
     shared_ptr<const set<string>> samples, datasets;
     vector<unique_ptr<RangeBCFIterator>> iterators;
     Status s;
+    N = 0;
 
     // Query for (iterators to) records overlapping pos in all the data sets.
     // We query for variant records only (excluding reference confidence records
@@ -74,6 +76,7 @@ Status Service::discover_alleles(const string& sampleset, const range& pos,
     };
     S(body_->data_.sampleset_range(*(body_->metadata_), sampleset, pos, predicate,
                                    samples, datasets, iterators));
+    N = samples->size();
 
     // Enqueue processing of each dataset on the thread pool.
     // TODO: improve cache-friendliness for long ranges
@@ -131,10 +134,11 @@ Status Service::discover_alleles(const string& sampleset, const range& pos,
 }
 
 Status Service::discover_alleles(const string& sampleset, const vector<range>& ranges,
-                                 vector<discovered_alleles>& ans, atomic<bool>* ext_abort) {
+                                 unsigned& N, vector<discovered_alleles>& ans, atomic<bool>* ext_abort) {
     atomic<bool> abort(false);
     vector<future<Status>> statuses;
     vector<discovered_alleles> results(ranges.size());
+    N = 0;
 
     size_t i = 0;
     for (const auto& range : ranges) {
@@ -145,8 +149,14 @@ Status Service::discover_alleles(const string& sampleset, const vector<range>& r
             }
 
             discovered_alleles dsals;
-            Status ls = discover_alleles(sampleset, range, dsals, &abort);
-            results[i] = move(dsals);
+            unsigned tmpN;
+            Status ls = discover_alleles(sampleset, range, tmpN, dsals, &abort);
+            if (ls.ok()) {
+                if (i == 0) {
+                    N = tmpN;
+                }
+                results[i] = move(dsals);
+            }
             return ls;
         });
 

--- a/src/unifier.cc
+++ b/src/unifier.cc
@@ -383,7 +383,7 @@ Status unify_alleles(const unifier_config& cfg, unsigned N, const range& pos,
         assert(unified_alt.pos == ref.pos);
 
         us.alleles.push_back(unified_alt.dna);
-        // TODO: better source of ploidy count
+        // TODO: configurable ploidy setting
         float freq = float(alt_info.copy_number)/(N*zygosity_by_GQ::PLOIDY);
         us.allele_frequencies.push_back(roundf(freq*1e6f)/1e6f);
         for (const auto& original : alt_info.originals) {
@@ -392,9 +392,6 @@ Status unify_alleles(const unifier_config& cfg, unsigned N, const range& pos,
     }
     ans = std::move(us);
     return Status::OK();
-    // TODO: will need some representation for copy number of pruned
-    // alleles. but maybe counting samples (+ploidy config) in
-    // discovered_alleles will suffice.
 }
 
 Status unified_sites(const unifier_config& cfg,

--- a/src/unifier.cc
+++ b/src/unifier.cc
@@ -333,7 +333,7 @@ Status pad_alt_allele(const allele& ref, allele& alt) {
 }
 
 /// Unify the alleles at one site.
-Status unify_alleles(const unifier_config& cfg, const range& pos,
+Status unify_alleles(const unifier_config& cfg, unsigned N, const range& pos,
                      const discovered_alleles& refs, const minimized_alleles& alts,
                      unified_site& ans) {
     Status s;
@@ -368,10 +368,12 @@ Status unify_alleles(const unifier_config& cfg, const range& pos,
     // fill out the unification
     unified_site us(pos);
     us.alleles.push_back(ref.dna);
-    // We don't attempt to specify the ref copy number for now. It's
+    // We don't attempt to specify the ref allele frequency for now. It's
     // problematic because the copy numbers in discovered_alleles omit nearly
-    // all homozygous ref genotypes.
-    us.copy_number.push_back(0.0);
+    // all homozygous ref genotypes. We also shouldn't just do 1 - (sum of ALT
+    // frequencies) because we may have pruned some ALT alleles, and currently
+    // haven't preserved their frequency information (but in principle we could)
+    us.allele_frequencies.push_back(NAN);
     for (int i = 1; i <= valts.size(); i++) {
         const minimized_allele& p = valts[i-1];
         UNPAIR(p, alt, alt_info);
@@ -381,7 +383,9 @@ Status unify_alleles(const unifier_config& cfg, const range& pos,
         assert(unified_alt.pos == ref.pos);
 
         us.alleles.push_back(unified_alt.dna);
-        us.copy_number.push_back(alt_info.copy_number);
+        // TODO: better source of ploidy count
+        float freq = float(alt_info.copy_number)/(N*zygosity_by_GQ::PLOIDY);
+        us.allele_frequencies.push_back(roundf(freq*1e6f)/1e6f);
         for (const auto& original : alt_info.originals) {
             us.unification[original] = i;
         }
@@ -394,7 +398,7 @@ Status unify_alleles(const unifier_config& cfg, const range& pos,
 }
 
 Status unified_sites(const unifier_config& cfg,
-                     const discovered_alleles& alleles,
+                     unsigned N, const discovered_alleles& alleles,
                      vector<unified_site>& ans) {
     Status s;
 
@@ -406,7 +410,7 @@ Status unified_sites(const unifier_config& cfg,
         UNPAIR(site, pos, site_alleles);
         UNPAIR(site_alleles, ref_alleles, alt_alleles);
         unified_site us(pos);
-        S(unify_alleles(cfg, pos, ref_alleles, alt_alleles, us));
+        S(unify_alleles(cfg, N, pos, ref_alleles, alt_alleles, us));
         ans.push_back(us);
     }
     return Status::OK();

--- a/test/cli_utils.cc
+++ b/test/cli_utils.cc
@@ -227,7 +227,7 @@ alleles: yyy
     const char* snp = 1 + R"(
 range: {ref: '17', beg: 100, end: 100}
 alleles: [A, G]
-copy_number: [100, 51]
+allele_frequencies: [.nan, 0.51]
 unification:
   - range: {ref: '17', beg: 100, end: 100}
     dna: A
@@ -241,7 +241,7 @@ unification:
     const char* del = 1 + R"(
 range: {ref: '17', beg: 1000, end: 1001}
 alleles: [AG, AC, C]
-copy_number: [100, 50, 1]
+allele_frequencies: [.nan, 0.50, 0.1]
 unification:
   - range: {ref: '17', beg: 1000, end: 1001}
     dna: AG

--- a/test/data/gvcf_test_cases/DP0_noAD.yml
+++ b/test/data/gvcf_test_cases/DP0_noAD.yml
@@ -51,7 +51,7 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1000}
       alleles: [C, CG]
-      copy_number: [0, 2]
+      allele_frequencies: [.nan, 0.5]
       unification:
         - range: {beg: 1000, end: 1000}
           dna: CG

--- a/test/data/gvcf_test_cases/format_fields_AD_fallback.yml
+++ b/test/data/gvcf_test_cases/format_fields_AD_fallback.yml
@@ -53,7 +53,7 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1000}
       alleles: [C, CG]
-      copy_number: [0, 2]
+      allele_frequencies: [.nan, 0.5]
       unification:
         - range: {beg: 1000, end: 1000}
           dna: CG

--- a/test/data/gvcf_test_cases/format_fields_combi.yml
+++ b/test/data/gvcf_test_cases/format_fields_combi.yml
@@ -62,7 +62,7 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1001}
       alleles: [CC, T, TC]
-      copy_number: [0, 2, 1]
+      allele_frequencies: [.nan, 0.5, 0.25]
       unification:
         - range: {beg: 1000, end: 1001}
           dna: T

--- a/test/data/gvcf_test_cases/format_fields_default_missing.yml
+++ b/test/data/gvcf_test_cases/format_fields_default_missing.yml
@@ -70,7 +70,7 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1000}
       alleles: [C, CG]
-      copy_number: [0, 2]
+      allele_frequencies: [.nan, 0.5]
       unification:
         - range: {beg: 1000, end: 1000}
           dna: CG

--- a/test/data/gvcf_test_cases/format_fields_default_none.yml
+++ b/test/data/gvcf_test_cases/format_fields_default_none.yml
@@ -62,7 +62,7 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1000}
       alleles: [C, CG]
-      copy_number: [0, 2]
+      allele_frequencies: [.nan, 0.5]
       unification:
         - range: {beg: 1000, end: 1000}
           dna: CG

--- a/test/data/gvcf_test_cases/format_fields_ignore_non_variants.yml
+++ b/test/data/gvcf_test_cases/format_fields_ignore_non_variants.yml
@@ -76,7 +76,7 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1001}
       alleles: [GA, GAA, T]
-      copy_number: [0, 2, 1]
+      allele_frequencies: [.nan, 0.333333, 0.166667]
       unification:
         - range: {beg: 1000, end: 1000}
           dna: GA

--- a/test/data/gvcf_test_cases/format_fields_integrated.yml
+++ b/test/data/gvcf_test_cases/format_fields_integrated.yml
@@ -72,35 +72,35 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "21", beg: 10009461, end: 10009461}
       alleles: [T, A]
-      copy_number: [0, 2]
+      allele_frequencies: [.nan, 0.5]
       unification:
         - range: {beg: 10009461, end: 10009461}
           dna: A
           to: 1
     - range: {ref: "21", beg: 10009462, end: 10009462}
       alleles: [T, A]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009462, end: 10009462}
           dna: A
           to: 1
     - range: {ref: "21", beg: 10009463, end: 10009463}
       alleles: [C, G]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009463, end: 10009463}
           dna: G
           to: 1
     - range: {ref: "21", beg: 10009464, end: 10009465}
       alleles: [TA, T]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009464, end: 10009465}
           dna: T
           to: 1
     - range: {ref: "21", beg: 10009466, end: 10009467}
       alleles: [AA, GT]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009466, end: 10009467}
           dna: GT

--- a/test/data/gvcf_test_cases/gvcf_services.yml
+++ b/test/data/gvcf_test_cases/gvcf_services.yml
@@ -39,28 +39,28 @@ input:
 truth_unified_sites:
     - range: {ref: "21", beg: 10009462, end: 10009462}
       alleles: [T, A]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009462, end: 10009462}
           dna: A
           to: 1
     - range: {ref: "21", beg: 10009463, end: 10009463}
       alleles: [C, G]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009463, end: 10009463}
           dna: G
           to: 1
     - range: {ref: "21", beg: 10009464, end: 10009465}
       alleles: [TA, T]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009464, end: 10009465}
           dna: T
           to: 1
     - range: {ref: "21", beg: 10009466, end: 10009467}
       alleles: [AA, GT]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009466, end: 10009467}
           dna: GT

--- a/test/data/gvcf_test_cases/gvcf_services_depth12.yml
+++ b/test/data/gvcf_test_cases/gvcf_services_depth12.yml
@@ -42,21 +42,21 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "21", beg: 10009464, end: 10009465}
       alleles: [TA, T]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009464, end: 10009465}
           dna: T
           to: 1
     - range: {ref: "21", beg: 10009466, end: 10009466}
       alleles: [A, G]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009466, end: 10009466}
           dna: G
           to: 1
     - range: {ref: "21", beg: 10009467, end: 10009467}
       alleles: [A, C]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009467, end: 10009467}
           dna: C

--- a/test/data/gvcf_test_cases/gvcf_services_depth9.yml
+++ b/test/data/gvcf_test_cases/gvcf_services_depth9.yml
@@ -40,7 +40,7 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "21", beg: 10009464, end: 10009465}
       alleles: [TA, T]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009464, end: 10009465}
           dna: T

--- a/test/data/gvcf_test_cases/inconsistent_trim.yml
+++ b/test/data/gvcf_test_cases/inconsistent_trim.yml
@@ -43,7 +43,7 @@ input:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1001}
       alleles: [TA, TAA, TAAA, T]
-      copy_number: [0, 4, 1, 1]
+      allele_frequencies: [.nan, 0.5, 0.125, 0.125]
       unification:
         - range: {beg: 1000, end: 1001}
           dna: TAA

--- a/test/data/gvcf_test_cases/join_3_gvcfs.yml
+++ b/test/data/gvcf_test_cases/join_3_gvcfs.yml
@@ -46,7 +46,7 @@ input:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1002}
       alleles: [TTC, T]
-      copy_number: [0, 3]
+      allele_frequencies: [.nan, 0.375]
       unification:
         - range: {beg: 1000, end: 1002}
           dna: T

--- a/test/data/gvcf_test_cases/join_gvcf_vcf.yml
+++ b/test/data/gvcf_test_cases/join_gvcf_vcf.yml
@@ -49,7 +49,7 @@ input:
 truth_unified_sites:
     - range: {ref: "A", beg: 999, end: 1000}
       alleles: [AT, ATC, A]
-      copy_number: [0, 2, 1]
+      allele_frequencies: [.nan, 0.25, 0.125]
       unification:
         - range: {beg: 1000, end: 1000}
           dna: TC

--- a/test/data/gvcf_test_cases/join_gvcf_vcf_gvcf.yml
+++ b/test/data/gvcf_test_cases/join_gvcf_vcf_gvcf.yml
@@ -50,7 +50,7 @@ input:
 truth_unified_sites:
     - range: {ref: "A", beg: 999, end: 1001}
       alleles: [ATG, ATCG, A]
-      copy_number: [0, 2, 1]
+      allele_frequencies: [.nan, 0.25, 0.125]
       unification:
         - range: {beg: 1000, end: 1000}
           dna: TC

--- a/test/data/gvcf_test_cases/join_gvcfs.yml
+++ b/test/data/gvcf_test_cases/join_gvcfs.yml
@@ -45,7 +45,7 @@ input:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1002}
       alleles: [TTC, T]
-      copy_number: [0, 3]
+      allele_frequencies: [.nan, 0.375]
       unification:
         - range: {beg: 1000, end: 1002}
           dna: T

--- a/test/data/gvcf_test_cases/join_records_basic.yml
+++ b/test/data/gvcf_test_cases/join_records_basic.yml
@@ -43,7 +43,7 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1002}
       alleles: [TTC, T, TAC]
-      copy_number: [0, 2, 1]
+      allele_frequencies: [.nan, 0.25, 0.125]
       unification:
         - range: {beg: 1000, end: 1002}
           dna: T

--- a/test/data/gvcf_test_cases/join_records_incomplete_span.yml
+++ b/test/data/gvcf_test_cases/join_records_incomplete_span.yml
@@ -37,7 +37,7 @@ input:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1002}
       alleles: [TTC, T, ATC, TTG]
-      copy_number: [0, 2, 1, 1]
+      allele_frequencies: [.nan, 0.25, 0.125, 0.125]
       unification:
         - range: {beg: 1000, end: 1002}
           dna: T

--- a/test/data/gvcf_test_cases/join_records_insufficient_ref_depth.yml
+++ b/test/data/gvcf_test_cases/join_records_insufficient_ref_depth.yml
@@ -44,7 +44,7 @@ genotyper_config:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1002}
       alleles: [TTC, T, TAC]
-      copy_number: [0, 2, 1]
+      allele_frequencies: [.nan, 0.25, 0.125]
       unification:
         - range: {beg: 1000, end: 1002}
           dna: T

--- a/test/data/gvcf_test_cases/join_records_overlapping.yml
+++ b/test/data/gvcf_test_cases/join_records_overlapping.yml
@@ -42,7 +42,7 @@ input:
 truth_unified_sites:
     - range: {ref: A, beg: 907970, end: 907971}
       alleles: [AC, AA, A]
-      copy_number: [0, 3, 1]
+      allele_frequencies: [.nan, 0.375, 0.125]
       unification:
         - range: {beg: 907971, end: 907971}
           dna: A

--- a/test/data/gvcf_test_cases/join_records_prefer_small.yml
+++ b/test/data/gvcf_test_cases/join_records_prefer_small.yml
@@ -37,14 +37,14 @@ unifier_config:
 truth_unified_sites:
     - range: {ref: A, beg: 1000, end: 1000}
       alleles: [T, A]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.125]
       unification:
         - range: {beg: 1000, end: 1000}
           dna: A
           to: 1
     - range: {ref: A, beg: 1002, end: 1002}
       alleles: [C, G]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.125]
       unification:
         - range: {beg: 1002, end: 1002}
           dna: G

--- a/test/data/gvcf_test_cases/join_records_unjoinable.yml
+++ b/test/data/gvcf_test_cases/join_records_unjoinable.yml
@@ -40,7 +40,7 @@ input:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1002}
       alleles: [TTC, T, ATC, TTG]
-      copy_number: [0, 2, 1, 1]
+      allele_frequencies: [.nan, 0.25, 0.125, 0.125]
       unification:
         - range: {beg: 1000, end: 1002}
           dna: T

--- a/test/data/gvcf_test_cases/join_vcf_gvcf.yml
+++ b/test/data/gvcf_test_cases/join_vcf_gvcf.yml
@@ -45,7 +45,7 @@ input:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1001}
       alleles: [AT, ATT, A]
-      copy_number: [0, 2, 1]
+      allele_frequencies: [.nan, 0.25, 0.125]
       unification:
         - range: {beg: 1000, end: 1000}
           dna: AT

--- a/test/data/gvcf_test_cases/lost_deletion.yml
+++ b/test/data/gvcf_test_cases/lost_deletion.yml
@@ -53,7 +53,7 @@ input:
 truth_unified_sites:
     - range: {ref: A, beg: 608825, end: 608832}
       alleles: [TGGGGCCG, T, TGGAGCCG]
-      copy_number: [0, 4, 2]
+      allele_frequencies: [.nan, 0.5, 0.25]
       unification:
         - range: {beg: 608825, end: 608832}
           dna: T
@@ -63,7 +63,7 @@ truth_unified_sites:
           to: 2
     - range: {ref: A, beg: 608835, end: 608852}
       alleles: [ACCGGGACCGGGACTGGG, A]
-      copy_number: [0, 4]
+      allele_frequencies: [.nan, 0.5]
       unification:
         - range: {beg: 608835, end: 608852}
           dna: A

--- a/test/data/gvcf_test_cases/min_allele_copy_number.yml
+++ b/test/data/gvcf_test_cases/min_allele_copy_number.yml
@@ -45,14 +45,14 @@ unifier_config:
 truth_unified_sites:
     - range: {ref: "21", beg: 10009461, end: 10009461}
       alleles: [T, A]
-      copy_number: [0, 2]
+      allele_frequencies: [.nan, 0.5]
       unification:
         - range: {beg: 10009461, end: 10009461}
           dna: A
           to: 1
     - range: {ref: "21", beg: 10009465, end: 10009465}
       alleles: [A, C]
-      copy_number: [0, 2]
+      allele_frequencies: [.nan, 0.5]
       unification:
         - range: {beg: 10009464, end: 10009465}
           dna: TC
@@ -62,7 +62,7 @@ truth_unified_sites:
           to: 1
     - range: {ref: 21, beg: 10009466, end: 10009466}
       alleles: [T, A]
-      copy_number: [0, 2]
+      allele_frequencies: [.nan, 0.5]
       unification:
         - range: {beg: 10009466, end: 10009466}
           dna: A

--- a/test/data/gvcf_test_cases/min_quality.yml
+++ b/test/data/gvcf_test_cases/min_quality.yml
@@ -144,14 +144,14 @@ truth_discovered_alleles:
 truth_unified_sites:
     - range: {ref: "21", beg: 10009461, end: 10009461}
       alleles: [T, A]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009461, end: 10009461}
           dna: A
           to: 1
     - range: {ref: "21", beg: 10009465, end: 10009465}
       alleles: [A, C]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009464, end: 10009465}
           dna: TC
@@ -161,21 +161,21 @@ truth_unified_sites:
           to: 1
     - range: {ref: 21, beg: 10009466, end: 10009466}
       alleles: [T, A]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009466, end: 10009466}
           dna: A
           to: 1
     - range: {ref: 21, beg: 10009467, end: 10009467}
       alleles: [T, A]
-      copy_number: [0, 1]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 10009467, end: 10009467}
           dna: A
           to: 1
     - range: {ref: "21", beg: 10009468, end: 10009468}
       alleles: [T, A]
-      copy_number: [0, 2]
+      allele_frequencies: [.nan, 0.5]
       unification:
         - range: {beg: 10009468, end: 10009468}
           dna: A

--- a/test/data/gvcf_test_cases/rs11429009.yml
+++ b/test/data/gvcf_test_cases/rs11429009.yml
@@ -42,7 +42,7 @@ input:
 truth_unified_sites:
     - range: {ref: 17, beg: 15643381, end: 15643382}
       alleles: [CA, C, CAC, CAA]
-      copy_number: [0, 2, 1, 1]
+      allele_frequencies: [.nan, 0.25, 0.125, 0.125]
       unification:
       - range: {beg: 15643381, end: 15643382}
         dna: C

--- a/test/data/gvcf_test_cases/rs141305015.yml
+++ b/test/data/gvcf_test_cases/rs141305015.yml
@@ -81,7 +81,7 @@ truth_discovered_alleles:
 truth_unified_sites:
     - range: {ref: A, beg: 36643700, end: 36643703}
       alleles: [GAGA, G]
-      copy_number: [0, 3]
+      allele_frequencies: [.nan, 0.5]
       unification:
         - range: {beg: 36643700, end: 36643703}
           dna: G

--- a/test/data/gvcf_test_cases/trim_input.yml
+++ b/test/data/gvcf_test_cases/trim_input.yml
@@ -42,7 +42,7 @@ input:
 truth_unified_sites:
     - range: {ref: "A", beg: 1000, end: 1001}
       alleles: [AT, A]
-      copy_number: [0, 8]
+      allele_frequencies: [.nan, 1.0]
       unification:
         - range: {beg: 1000, end: 1001}
           dna: A

--- a/test/data/gvcf_test_cases/vcf_services.yml
+++ b/test/data/gvcf_test_cases/vcf_services.yml
@@ -36,14 +36,14 @@ input:
 truth_unified_sites:
     - range: {ref: "A", beg: 1001, end: 1001}
       alleles: [A, G]
-      copy_number: [0, 6]
+      allele_frequencies: [.nan, 0.5]
       unification:
         - range: {beg: 1001, end: 1001}
           dna: G
           to: 1
     - range: {ref: "A", beg: 1002, end: 1002}
       alleles: [C, A, G, T]
-      copy_number: [0, 6, 2, 2]
+      allele_frequencies: [.nan, 0.5, 0.166667, 0.166667]
       unification:
         - range: {beg: 1002, end: 1002}
           dna: A
@@ -56,7 +56,7 @@ truth_unified_sites:
           to: 3
     - range: {ref: "A", beg: 1011, end: 1013}
       alleles: [CCC, AGC, AGA]
-      copy_number: [0, 3, 2]
+      allele_frequencies: [.nan, 0.25, 0.166667]
       unification:
         - range: {beg: 1011, end: 1012}
           dna: AG
@@ -66,21 +66,21 @@ truth_unified_sites:
           to: 2
     - range: {ref: "A", beg: 1101, end: 1101}
       alleles: [C, A]
-      copy_number: [0, 3]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 1101, end: 1101}
           dna: A
           to: 1
     - range: {ref: "A", beg: 1103, end: 1103}
       alleles: [C, G]
-      copy_number: [0, 3]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 1103, end: 1103}
           dna: G
           to: 1
     - range: {ref: "A", beg: 1201, end: 1201}
       alleles: [C, A]
-      copy_number: [0, 3]
+      allele_frequencies: [.nan, 0.25]
       unification:
         - range: {beg: 1201, end: 1201}
           dna: A

--- a/test/gvcf_test_cases.cc
+++ b/test/gvcf_test_cases.cc
@@ -286,7 +286,7 @@ public:
         Status s = svc->discover_alleles("<ALL>", range(0, 0, 1000000000), N, als);
         REQUIRE(s.ok());
 
-        s = unified_sites(unifier_cfg, als, sites);
+        s = unified_sites(unifier_cfg, N, als, sites);
         REQUIRE(s.ok());
 
         REQUIRE(is_sorted(sites.begin(), sites.end()));

--- a/test/gvcf_test_cases.cc
+++ b/test/gvcf_test_cases.cc
@@ -241,7 +241,8 @@ public:
     }
 
     Status execute_discover_alleles(discovered_alleles& als, const string sampleset, range pos) {
-        return svc->discover_alleles(sampleset, pos, als);
+        unsigned N;
+        return svc->discover_alleles(sampleset, pos, N, als);
     }
 
     Status check_discovered_alleles(discovered_alleles& als, const string sampleset="<ALL>", range pos=range(0, 0, 1000000000)) {
@@ -281,7 +282,8 @@ public:
     // the expected "truth"
     Status check_unify_sites() {
         discovered_alleles als;
-        Status s = svc->discover_alleles("<ALL>", range(0, 0, 1000000000), als);
+        unsigned N;
+        Status s = svc->discover_alleles("<ALL>", range(0, 0, 1000000000), N, als);
         REQUIRE(s.ok());
 
         s = unified_sites(unifier_cfg, als, sites);

--- a/test/service.cc
+++ b/test/service.cc
@@ -212,7 +212,7 @@ TEST_CASE("unified_sites") {
         REQUIRE(N == 3);
 
         vector<unified_site> sites;
-        s = unified_sites(unifier_config(), als, sites);
+        s = unified_sites(unifier_config(), N, als, sites);
         REQUIRE(s.ok());
 
         vector<pair<string,size_t> > contigs;
@@ -226,9 +226,9 @@ TEST_CASE("unified_sites") {
         REQUIRE(sites[0].alleles[1] == "G");
         REQUIRE(sites[0].unification[allele(range(0,1000,1001),string("A"))] == 0);
         REQUIRE(sites[0].unification[allele(range(0,1000,1001),string("G"))] == 1);
-        REQUIRE(sites[0].copy_number.size() == 2);
-        REQUIRE(sites[0].copy_number[0] == 0);
-        REQUIRE(sites[0].copy_number[1] == 4);
+        REQUIRE(sites[0].allele_frequencies.size() == 2);
+        REQUIRE(sites[0].allele_frequencies[0] != sites[0].allele_frequencies[0]);
+        REQUIRE(sites[0].allele_frequencies[1] == 0.666667f);
 
         REQUIRE(sites[1].pos == range(0,1001,1002));
         REQUIRE(sites[1].alleles.size() == 3);
@@ -238,10 +238,10 @@ TEST_CASE("unified_sites") {
         REQUIRE(sites[1].unification[allele(range(0,1001,1002),string("C"))] == 0);
         REQUIRE(sites[1].unification[allele(range(0,1001,1002),string("G"))] == 1);
         REQUIRE(sites[1].unification[allele(range(0,1001,1002),string("T"))] == 2);
-        REQUIRE(sites[1].copy_number.size() == 3);
-        REQUIRE(sites[1].copy_number[0] == 0);
-        REQUIRE(sites[1].copy_number[1] == 2);
-        REQUIRE(sites[1].copy_number[2] == 2);
+        REQUIRE(sites[1].allele_frequencies.size() == 3);
+        REQUIRE(sites[1].allele_frequencies[0] != sites[1].allele_frequencies[0]);
+        REQUIRE(sites[1].allele_frequencies[1] == 0.333333f);
+        REQUIRE(sites[1].allele_frequencies[2] == 0.333333f);
 
         REQUIRE(sites[2].pos == range(0,1010,1012));
         REQUIRE(sites[2].alleles.size() == 2);
@@ -249,9 +249,9 @@ TEST_CASE("unified_sites") {
         REQUIRE(sites[2].alleles[1] == "AG");
         REQUIRE(sites[2].unification[allele(range(0,1010,1012),string("CC"))] == 0);
         REQUIRE(sites[2].unification[allele(range(0,1010,1012),string("AG"))] == 1);
-        REQUIRE(sites[2].copy_number.size() == 2);
-        REQUIRE(sites[2].copy_number[0] == 0);
-        REQUIRE(sites[2].copy_number[1] == 3);
+        REQUIRE(sites[2].allele_frequencies.size() == 2);
+        REQUIRE(sites[2].allele_frequencies[0] != sites[2].allele_frequencies[0]);
+        REQUIRE(sites[2].allele_frequencies[1] == 0.5f);
 
         REQUIRE(sites[3].pos == range(0,1100,1101));
         REQUIRE(sites[3].alleles.size() == 2);
@@ -259,9 +259,9 @@ TEST_CASE("unified_sites") {
         REQUIRE(sites[3].alleles[1] == "A");
         REQUIRE(sites[3].unification[allele(range(0,1100,1101),string("C"))] == 0);
         REQUIRE(sites[3].unification[allele(range(0,1100,1101),string("A"))] == 1);
-        REQUIRE(sites[3].copy_number.size() == 2);
-        REQUIRE(sites[3].copy_number[0] == 0);
-        REQUIRE(sites[3].copy_number[1] == 3);
+        REQUIRE(sites[3].allele_frequencies.size() == 2);
+        REQUIRE(sites[3].allele_frequencies[0] != sites[3].allele_frequencies[0]);
+        REQUIRE(sites[3].allele_frequencies[1] == 0.5f);
 
         REQUIRE(sites[4].pos == range(0,1102,1103));
         REQUIRE(sites[4].alleles.size() == 2);
@@ -269,9 +269,9 @@ TEST_CASE("unified_sites") {
         REQUIRE(sites[4].alleles[1] == "G");
         REQUIRE(sites[4].unification[allele(range(0,1102,1103),string("C"))] == 0);
         REQUIRE(sites[4].unification[allele(range(0,1102,1103),string("G"))] == 1);
-        REQUIRE(sites[4].copy_number.size() == 2);
-        REQUIRE(sites[4].copy_number[0] == 0);
-        REQUIRE(sites[4].copy_number[1] == 3);
+        REQUIRE(sites[4].allele_frequencies.size() == 2);
+        REQUIRE(sites[4].allele_frequencies[0] != sites[4].allele_frequencies[0]);
+        REQUIRE(sites[4].allele_frequencies[1] == 0.5f);
 
         REQUIRE(sites[5].pos == range(0,1200,1201));
         REQUIRE(sites[5].alleles.size() == 2);
@@ -279,9 +279,9 @@ TEST_CASE("unified_sites") {
         REQUIRE(sites[5].alleles[1] == "A");
         REQUIRE(sites[5].unification[allele(range(0,1200,1201),string("C"))] == 0);
         REQUIRE(sites[5].unification[allele(range(0,1200,1201),string("A"))] == 1);
-        REQUIRE(sites[5].copy_number.size() == 2);
-        REQUIRE(sites[5].copy_number[0] == 0);
-        REQUIRE(sites[5].copy_number[1] == 3);
+        REQUIRE(sites[5].allele_frequencies.size() == 2);
+        REQUIRE(sites[5].allele_frequencies[0] != sites[5].allele_frequencies[0]);
+        REQUIRE(sites[5].allele_frequencies[1] == 0.5f);
     }
 
     SECTION("2 trios") {
@@ -290,7 +290,7 @@ TEST_CASE("unified_sites") {
         REQUIRE(N == 6);
 
         vector<unified_site> sites;
-        s = unified_sites(unifier_config(), als, sites);
+        s = unified_sites(unifier_config(), N, als, sites);
         REQUIRE(s.ok());
 
         vector<pair<string,size_t> > contigs;
@@ -304,9 +304,9 @@ TEST_CASE("unified_sites") {
         REQUIRE(sites[0].alleles[1] == "G");
         REQUIRE(sites[0].unification[allele(range(0,1000,1001),string("A"))] == 0);
         REQUIRE(sites[0].unification[allele(range(0,1000,1001),string("G"))] == 1);
-        REQUIRE(sites[0].copy_number.size() == 2);
-        REQUIRE(sites[0].copy_number[0] == 0);
-        REQUIRE(sites[0].copy_number[1] == 6);
+        REQUIRE(sites[0].allele_frequencies.size() == 2);
+        REQUIRE(sites[0].allele_frequencies[0] != sites[0].allele_frequencies[0]);
+        REQUIRE(sites[0].allele_frequencies[1] == 0.5f);
 
         REQUIRE(sites[1].pos == range(0,1001,1002));
         REQUIRE(sites[1].alleles.size() == 4);
@@ -318,11 +318,11 @@ TEST_CASE("unified_sites") {
         REQUIRE(sites[1].unification[allele(range(0,1001,1002),string("A"))] == 1);
         REQUIRE(sites[1].unification[allele(range(0,1001,1002),string("G"))] == 2);
         REQUIRE(sites[1].unification[allele(range(0,1001,1002),string("T"))] == 3);
-        REQUIRE(sites[1].copy_number.size() == 4);
-        REQUIRE(sites[1].copy_number[0] == 0);
-        REQUIRE(sites[1].copy_number[1] == 6);
-        REQUIRE(sites[1].copy_number[2] == 2);
-        REQUIRE(sites[1].copy_number[3] == 2);
+        REQUIRE(sites[1].allele_frequencies.size() == 4);
+        REQUIRE(sites[1].allele_frequencies[0] != sites[1].allele_frequencies[0]);
+        REQUIRE(sites[1].allele_frequencies[1] == 0.5f);
+        REQUIRE(sites[1].allele_frequencies[2] == 0.166667f);
+        REQUIRE(sites[1].allele_frequencies[3] == 0.166667f);
 
         REQUIRE(sites[2].pos == range(0,1010,1013));
         REQUIRE(sites[2].alleles.size() == 3);
@@ -333,10 +333,10 @@ TEST_CASE("unified_sites") {
         REQUIRE(sites[2].unification[allele(range(0,1010,1013),string("CCC"))] == 0);
         REQUIRE(sites[2].unification[allele(range(0,1010,1012),string("AG"))] == 1);
         REQUIRE(sites[2].unification[allele(range(0,1010,1013),string("AGA"))] == 2);
-        REQUIRE(sites[2].copy_number.size() == 3);
-        REQUIRE(sites[2].copy_number[0] == 0);
-        REQUIRE(sites[2].copy_number[1] == 3);
-        REQUIRE(sites[2].copy_number[2] == 2);
+        REQUIRE(sites[2].allele_frequencies.size() == 3);
+        REQUIRE(sites[2].allele_frequencies[0] != sites[2].allele_frequencies[0]);
+        REQUIRE(sites[2].allele_frequencies[1] == 0.25f);
+        REQUIRE(sites[2].allele_frequencies[2] == 0.166667f);
 
         REQUIRE(sites[3].pos == range(0,1100,1101));
         REQUIRE(sites[3].alleles.size() == 2);
@@ -344,9 +344,9 @@ TEST_CASE("unified_sites") {
         REQUIRE(sites[3].alleles[1] == "A");
         REQUIRE(sites[3].unification[allele(range(0,1100,1101),string("C"))] == 0);
         REQUIRE(sites[3].unification[allele(range(0,1100,1101),string("A"))] == 1);
-        REQUIRE(sites[3].copy_number.size() == 2);
-        REQUIRE(sites[3].copy_number[0] == 0);
-        REQUIRE(sites[3].copy_number[1] == 3);
+        REQUIRE(sites[3].allele_frequencies.size() == 2);
+        REQUIRE(sites[3].allele_frequencies[0] != sites[3].allele_frequencies[0]);
+        REQUIRE(sites[3].allele_frequencies[1] == 0.25f);
 
         REQUIRE(sites[4].pos == range(0,1102,1103));
         REQUIRE(sites[4].alleles.size() == 2);
@@ -354,9 +354,9 @@ TEST_CASE("unified_sites") {
         REQUIRE(sites[4].alleles[1] == "G");
         REQUIRE(sites[4].unification[allele(range(0,1102,1103),string("C"))] == 0);
         REQUIRE(sites[4].unification[allele(range(0,1102,1103),string("G"))] == 1);
-        REQUIRE(sites[4].copy_number.size() == 2);
-        REQUIRE(sites[4].copy_number[0] == 0);
-        REQUIRE(sites[4].copy_number[1] == 3);
+        REQUIRE(sites[4].allele_frequencies.size() == 2);
+        REQUIRE(sites[4].allele_frequencies[0] != sites[4].allele_frequencies[0]);
+        REQUIRE(sites[4].allele_frequencies[1] == 0.25f);
 
         REQUIRE(sites[5].pos == range(0,1200,1201));
         REQUIRE(sites[5].alleles.size() == 2);
@@ -364,9 +364,9 @@ TEST_CASE("unified_sites") {
         REQUIRE(sites[5].alleles[1] == "A");
         REQUIRE(sites[5].unification[allele(range(0,1200,1201),string("C"))] == 0);
         REQUIRE(sites[5].unification[allele(range(0,1200,1201),string("A"))] == 1);
-        REQUIRE(sites[5].copy_number.size() == 2);
-        REQUIRE(sites[5].copy_number[0] == 0);
-        REQUIRE(sites[5].copy_number[1] == 3);
+        REQUIRE(sites[5].allele_frequencies.size() == 2);
+        REQUIRE(sites[5].allele_frequencies[0] != sites[5].allele_frequencies[0]);
+        REQUIRE(sites[5].allele_frequencies[1] == 0.25f);
 
         // An allele from trio2 that would collapse sites[3] and sites[4] was
         // pruned.
@@ -375,7 +375,7 @@ TEST_CASE("unified_sites") {
         for (const auto& site : sites) {
             cout << site.pos.str(contigs);
             for (unsigned i = 0; i < site.alleles.size(); i++) {
-                cout << ' ' << site.alleles[i] << '[' << site.copy_number[i] << ']';
+                cout << ' ' << site.alleles[i] << '[' << site.allele_frequencies[i] << ']';
             }
             for (const auto& u : site.unification) {
                 UNPAIR(u, p, i)
@@ -408,7 +408,7 @@ TEST_CASE("genotyper placeholder") {
         REQUIRE(s.ok());
         REQUIRE(N == 6);
         vector<unified_site> sites;
-        s = unified_sites(unifier_config(), als, sites);
+        s = unified_sites(unifier_config(), N, als, sites);
         REQUIRE(s.ok());
 
         unique_ptr<SimFailBCFData> faildata;
@@ -449,7 +449,7 @@ TEST_CASE("genotyper placeholder") {
         REQUIRE(merge_discovered_alleles(als1, als).ok());
 
         vector<unified_site> sites;
-        s = unified_sites(unifier_config(), als, sites);
+        s = unified_sites(unifier_config(), N, als, sites);
         cout << s.str() << endl;
         REQUIRE(s.ok());
 
@@ -479,7 +479,7 @@ TEST_CASE("gVCF genotyper") {
         us.alleles.push_back("A");
         us.unification[allele(range(0,10009461,10009462),"T")] = 0;
         us.unification[allele(range(0,10009461,10009462),"A")] = 1;
-        us.copy_number = { 1, 1 };
+        us.allele_frequencies = { NAN, 0.1 };
         sites.push_back(us);
 
         us.pos = range(0,10009462,10009463);
@@ -489,7 +489,7 @@ TEST_CASE("gVCF genotyper") {
         us.unification.clear();
         us.unification[allele(range(0,10009462,10009463),"C")] = 0;
         us.unification[allele(range(0,10009462,10009463),"G")] = 1;
-        us.copy_number = { 1, 1 };
+        us.allele_frequencies = { NAN, 0.1 };
         sites.push_back(us);
 
         // this site spans two gVCF records and will not be called by the current algorithm.
@@ -500,7 +500,7 @@ TEST_CASE("gVCF genotyper") {
         us.unification.clear();
         us.unification[allele(range(0,10009465,10009467),"AA")] = 0;
         us.unification[allele(range(0,10009465,10009467),"GT")] = 1;
-        us.copy_number = { 1, 1 };
+        us.allele_frequencies = { NAN, 0.1 };
         sites.push_back(us);
 
         s = svc->genotype_sites(genotyper_config(), string("NA12878D_HiSeqX.21.10009462-10009469"), sites, tfn);
@@ -515,7 +515,7 @@ TEST_CASE("gVCF genotyper") {
         us.alleles.push_back("T");
         us.unification[allele(range(0,10009463,10009465),"TA")] = 0;
         us.unification[allele(range(0,10009463,10009465),"T")] = 1;
-        us.copy_number = { 1, 1 };
+        us.allele_frequencies = { NAN, 0.1 };
         sites.push_back(us);
 
         us.pos = range(0,10009465,10009466);
@@ -525,7 +525,7 @@ TEST_CASE("gVCF genotyper") {
         us.unification.clear();
         us.unification[allele(range(0,10009465,10009466),"A")] = 0;
         us.unification[allele(range(0,10009465,10009466),"G")] = 1;
-        us.copy_number = { 1, 1 };
+        us.allele_frequencies = { NAN, 0.1 };
         sites.push_back(us);
 
         us.pos = range(0,10009466,10009467);
@@ -535,7 +535,7 @@ TEST_CASE("gVCF genotyper") {
         us.unification.clear();
         us.unification[allele(range(0,10009466,10009467),"A")] = 0;
         us.unification[allele(range(0,10009466,10009467),"C")] = 1;
-        us.copy_number = { 1, 1 };
+        us.allele_frequencies = { NAN, 0.1 };
         sites.push_back(us);
 
         genotyper_config cfg;
@@ -554,7 +554,7 @@ TEST_CASE("gVCF genotyper") {
         us.alleles.push_back("T");
         us.unification[allele(range(0,10009463,10009465),"TA")] = 0;
         us.unification[allele(range(0,10009463,10009465),"T")] = 1;
-        us.copy_number = { 1, 1 };
+        us.allele_frequencies = { NAN, 0.1 };
         sites.push_back(us);
 
         genotyper_config cfg;
@@ -578,7 +578,7 @@ TEST_CASE("genotype residuals") {
     REQUIRE(s.ok());
 
     vector<unified_site> sites;
-    s = unified_sites(unifier_config(), als, sites);
+    s = unified_sites(unifier_config(), N, als, sites);
     REQUIRE(s.ok());
 
     const string tfn("/tmp/GLnexus_unit_tests.bcf");

--- a/test/types.cc
+++ b/test/types.cc
@@ -260,7 +260,7 @@ TEST_CASE("unified_site::of_yaml") {
     const char* snp = 1 + R"(
 range: {ref: '17', beg: 100, end: 100}
 alleles: [A, G]
-copy_number: [100, 51]
+allele_frequencies: [.nan, 0.01]
 unification:
   - range: {ref: '17', beg: 100, end: 100}
     dna: A
@@ -279,15 +279,15 @@ unification:
         REQUIRE((us).unification.size() == 2);  \
         REQUIRE((us).unification[allele(range(1, 99, 100), "A")] == 0); \
         REQUIRE((us).unification[allele(range(1, 99, 100), "G")] == 1); \
-        REQUIRE((us).copy_number.size() == 2); \
-        REQUIRE((us).copy_number[0] == 100.0); \
-        REQUIRE((us).copy_number[1] == 51.0);
+        REQUIRE((us).allele_frequencies.size() == 2); \
+        REQUIRE((us).allele_frequencies[0] != (us).allele_frequencies[0]); \
+        REQUIRE((us).allele_frequencies[1] == 0.01f);
 
 
     const char* del = 1 + R"(
 range: {ref: '17', beg: 1000, end: 1001}
 alleles: [AG, AC, C]
-copy_number: [100, 50, 1]
+allele_frequencies: [.nan, 0.05, 0.001]
 unification:
   - range: {ref: '17', beg: 1000, end: 1001}
     dna: AG
@@ -320,6 +320,7 @@ unification:
 
         unified_site us(range(-1,-1,-1));
         Status s = unified_site::of_yaml(n, contigs, us);
+        cout << s.str() << endl;
         REQUIRE(s.ok());
         VERIFY_SNP(us);
     }
@@ -349,7 +350,7 @@ unification:
         const char* snp_opt = 1 + R"(
 range: {ref: '17', beg: 100, end: 100}
 alleles: [A, G]
-copy_number: [100, 51]
+allele_frequencies: [.nan, 0.01]
 unification:
   - range: {beg: 100, end: 100}
     dna: A
@@ -370,7 +371,7 @@ unification:
         const char* snp_bogus = 1 + R"(
 range: {ref: 'bogus', beg: 100, end: 100}
 alleles: [A, G]
-copy_number: [100, 51]
+allele_frequencies: [.nan, 0.01]
 unification:
   - range: {beg: 100, end: 100}
     dna: A
@@ -387,7 +388,7 @@ unification:
         snp_bogus = 1 + R"(
 range: 12345
 alleles: [A, G]
-copy_number: [100, 51]
+allele_frequencies: [.nan, 0.01]
 unification:
   - range: {beg: 100, end: 100}
     dna: A
@@ -404,7 +405,7 @@ unification:
         const char* snp_bogus = 1 + R"(
 range: {ref: '17', beg: 100, end: 100}
 alleles: [A]
-copy_number: [100, 51]
+allele_frequencies: [.nan, 0.01]
 unification:
   - range: {beg: 100, end: 100}
     dna: A
@@ -420,7 +421,7 @@ unification:
         const char* snp_bogus = 1 + R"(
 range: {ref: '17', beg: 100, end: 100}
 alleles: [A, G]
-copy_number: [100, 51]
+allele_frequencies: [.nan, 0.01]
 unification:
   - range: {ref: 'bogus', beg: 100, end: 100}
     dna: A
@@ -437,7 +438,7 @@ unification:
         snp_bogus = 1 + R"(
 range: {ref: '17', beg: 100, end: 100}
 alleles: [A, G]
-copy_number: [100, 51]
+allele_frequencies: [.nan, 0.01]
 unification:
 )";
         n = YAML::Load(snp_bogus);
@@ -455,7 +456,7 @@ TEST_CASE("unified_site::yaml") {
 range: {ref: '17', beg: 1000, end: 1001}
 containing_target: {ref: '17', beg: 1, end: 10000}
 alleles: [AG, AC, C]
-copy_number: [100, 50, 1]
+allele_frequencies: [.nan, 0.05, 0.001]
 unification:
   - range: {ref: '17', beg: 1000, end: 1001}
     dna: AG

--- a/test/unifier.cc
+++ b/test/unifier.cc
@@ -29,7 +29,7 @@ TEST_CASE("unifier max_alleles_per_site") {
 
     SECTION("0") {
         // No limit on # of max alleles
-        Status s = unified_sites(cfg, dal, sites);
+        Status s = unified_sites(cfg, 200, dal, sites);
         REQUIRE(s.ok());
         REQUIRE(sites.size() == 1);
         REQUIRE(sites[0].alleles.size() == 6);
@@ -38,7 +38,7 @@ TEST_CASE("unifier max_alleles_per_site") {
 
     SECTION("5") {
         cfg.max_alleles_per_site = 5;
-        Status s = unified_sites(cfg, dal, sites);
+        Status s = unified_sites(cfg, 200, dal, sites);
         REQUIRE(s.ok());
         REQUIRE(sites.size() == 1);
         REQUIRE(sites[0].alleles.size() == 5);
@@ -47,7 +47,7 @@ TEST_CASE("unifier max_alleles_per_site") {
 
     SECTION("4") {
         cfg.max_alleles_per_site = 4;
-        Status s = unified_sites(cfg, dal, sites);
+        Status s = unified_sites(cfg, 200, dal, sites);
         REQUIRE(s.ok());
         REQUIRE(sites.size() == 1);
         REQUIRE(sites[0].alleles.size() == 3);
@@ -57,7 +57,7 @@ TEST_CASE("unifier max_alleles_per_site") {
 
     SECTION("3") {
         cfg.max_alleles_per_site = 3;
-        Status s = unified_sites(cfg, dal, sites);
+        Status s = unified_sites(cfg, 200, dal, sites);
         REQUIRE(s.ok());
         REQUIRE(sites.size() == 1);
         REQUIRE(sites[0].alleles.size() == 3);
@@ -66,7 +66,7 @@ TEST_CASE("unifier max_alleles_per_site") {
 
     SECTION("2") {
         cfg.max_alleles_per_site = 2;
-        Status s = unified_sites(cfg, dal, sites);
+        Status s = unified_sites(cfg, 200, dal, sites);
         REQUIRE(s.ok());
         REQUIRE(sites.size() == 1);
         REQUIRE(sites[0].alleles.size() == 2);


### PR DESCRIPTION
- N (sample count) is tracked through allele discovery, and provided to the unifier
- unifier uses this to calculate allele frequencies from discovered allele counts
- reference allele frequency is reported as NaN for now