### PR TITLE
reduce unifier memory usage

### DIFF
--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -90,10 +90,21 @@ static int all_steps(const vector<string> &vcf_files,
           GLnexus::cli::utils::yaml_write_discovered_alleles_to_file(dsals, contigs, sample_count, filename));
     }
 
+    // partition dsals by contig to reduce peak memory usage in the unifier
+    std::vector<GLnexus::discovered_alleles> dsals_by_contig(contigs.size());
+    for (auto p = dsals.begin(); p != dsals.end(); dsals.erase(p++)) {
+        UNPAIR(*p, al, dai);
+        assert(al.pos.rid >= 0 && al.pos.rid < contigs.size());
+        dsals_by_contig[al.pos.rid][al] = dai;
+    }
+
     // unify sites
+    // we could parallelize over dsals_by_contig although this might increase memory usage.
     vector<GLnexus::unified_site> sites;
-    H("unify sites",
-      GLnexus::cli::utils::unify_sites(console, unifier_cfg, ranges, contigs, dsals, sample_count, sites));
+    for (auto& dsals_i : dsals_by_contig) {
+        H("unify sites",
+          GLnexus::cli::utils::unify_sites(console, unifier_cfg, ranges, contigs, dsals_i, sample_count, sites));
+    }
     if (debug) {
         string filename("/tmp/sites.yml");
         H("write unified sites to file",

--- a/include/cli_utils.h
+++ b/include/cli_utils.h
@@ -138,7 +138,7 @@ Status unify_sites(std::shared_ptr<spdlog::logger> logger,
                    const unifier_config &unifier_cfg,
                    const std::vector<range> &ranges,
                    const std::vector<std::pair<std::string,size_t> > &contigs,
-                   const discovered_alleles &dsals,
+                   /* const */ discovered_alleles &dsals, // input, cleared by side-effect to save memory
                    unsigned sample_count,
                    std::vector<unified_site> &sites);
 

--- a/include/cli_utils.h
+++ b/include/cli_utils.h
@@ -74,13 +74,14 @@ Status unified_sites_of_yaml_stream(std::istream &is,
                                     const std::vector<std::pair<std::string,size_t> > &contigs,
                                     std::vector<unified_site> &sites);
 
-// Merge a bunch of discovered-allele files, all in YAML format.
+// Merge a bunch of discovered-allele files, all in capnp format.
 // N is summed across the files, and the contigs must be the same in all.
+// Returns one discovered_alleles structures per contig, in order.
 Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
                                      size_t nr_threads,
                                      const std::vector<std::string> &filenames,
                                      unsigned& N, std::vector<std::pair<std::string,size_t>> &contigs,
-                                     discovered_alleles &dsals);
+                                     std::vector<discovered_alleles>& dsals);
 
 
 // Find which range contains [pos]. The ranges are assumed to be non-overlapping.
@@ -134,11 +135,14 @@ Status discover_alleles(std::shared_ptr<spdlog::logger> logger,
                         discovered_alleles &dsals,
                         unsigned &sample_count);
 
+// Run unifier on given discovered alleles.
+// input dsals is cleared by side-effect to save memory
+// output sites is appended to (not cleared!)
 Status unify_sites(std::shared_ptr<spdlog::logger> logger,
                    const unifier_config &unifier_cfg,
                    const std::vector<range> &ranges,
                    const std::vector<std::pair<std::string,size_t> > &contigs,
-                   /* const */ discovered_alleles &dsals, // input, cleared by side-effect to save memory
+                   discovered_alleles &dsals,
                    unsigned sample_count,
                    std::vector<unified_site> &sites);
 

--- a/include/types.h
+++ b/include/types.h
@@ -22,7 +22,7 @@
 #include "yaml-cpp/yaml.h"
 #pragma GCC diagnostic pop
 
-#define UNPAIR(p,nm1,nm2) auto nm1 = (p).first; auto nm2 = (p).second;
+#define UNPAIR(p,nm1,nm2) const auto& nm1 = (p).first; const auto& nm2 = (p).second;
 template<typename T> inline void ignore_retval(T) {}
 
 namespace GLnexus {

--- a/include/unifier.h
+++ b/include/unifier.h
@@ -9,8 +9,13 @@ namespace GLnexus {
 
 /// Compute unified sites from all discovered alleles in some genomic region
 /// N = sample count (used to estimate allele frequencies)
+// Important I/O notes:
+// (1) The input discovered_alleles structure is cleared as a
+//     side-effect, to save memory since it can be quite large.
+// (2) ans is NOT cleared, only appended to.
 Status unified_sites(const unifier_config& cfg,
-                     unsigned N, const discovered_alleles& alleles,
+                     unsigned N,
+                     /* const */ discovered_alleles& alleles,
                      std::vector<unified_site>& ans);
 }
 

--- a/src/cli_utils.cc
+++ b/src/cli_utils.cc
@@ -797,6 +797,7 @@ Status discover_alleles(std::shared_ptr<spdlog::logger> logger,
     Status s;
     unique_ptr<KeyValue::DB> db;
     unique_ptr<BCFKeyValueData> data;
+    dsals.clear();
 
     // open the database in read-only mode
     S(RocksKeyValue::Open(dbpath, db, GLnexus_prefix_spec(),
@@ -819,6 +820,7 @@ Status discover_alleles(std::shared_ptr<spdlog::logger> logger,
 
     for (auto it = valleles.begin(); it != valleles.end(); ++it) {
         S(merge_discovered_alleles(*it, dsals));
+        it->clear(); // free some memory
     }
     logger->info() << "discovered " << dsals.size() << " alleles";
     return Status::OK();
@@ -828,7 +830,7 @@ Status unify_sites(std::shared_ptr<spdlog::logger> logger,
                    const unifier_config &unifier_cfg,
                    const vector<range> &ranges,
                    const vector<pair<string,size_t> > &contigs,
-                   const discovered_alleles &dsals,
+                   discovered_alleles &dsals,
                    unsigned sample_count,
                    vector<unified_site> &sites) {
     Status s;

--- a/src/unifier.cc
+++ b/src/unifier.cc
@@ -120,26 +120,27 @@ Status minimize_alleles(const unifier_config& cfg, const discovered_alleles& src
     // go through each alt allele
     alts.clear();
     for (const auto& dal : dalts) {
-        allele alt = dal.first;
+        const allele& alt = dal.first;
 
         // find corresponding reference allele
         const auto rp = refs_by_range.find(alt.pos);
         if (rp == refs_by_range.end()) return Status::Invalid("minimize_alleles: missing REF allele for ", alt.pos.str());
 
         // minimize the alt allele
-        S(minimize_allele(rp->second.first, alt));
+        allele min_alt = alt;
+        S(minimize_allele(rp->second.first, min_alt));
 
         unsigned copy_number = dal.second.zGQ.copy_number(cfg.min_GQ);
 
         // add it to alts, combining originals, copy_number, and topAQ with any
         // previously observed occurrences of the same minimized alt allele.
-        auto ap = alts.find(alt);
+        auto ap = alts.find(min_alt);
         if (ap == alts.end()) {
             minimized_allele_info info;
             info.originals.insert(dal.first);
             info.topAQ = dal.second.topAQ;
             info.copy_number = copy_number;
-            alts[alt] = move(info);
+            alts[min_alt] = move(info);
         } else {
             ap->second.originals.insert(dal.first);
             ap->second.topAQ += dal.second.topAQ;
@@ -155,14 +156,16 @@ Status minimize_alleles(const unifier_config& cfg, const discovered_alleles& src
 // alleles in an active region are transitively connected through overlap.
 // (However, individual pairs of alleles within an active region might be non-
 // overlapping.)
+// The input is cleared by side-effect to save memory.
 template<class discovered_or_minimized_alleles>
-auto partition(const discovered_or_minimized_alleles& alleles) {
+auto partition(discovered_or_minimized_alleles& alleles) {
     map<range,discovered_or_minimized_alleles> ans;
 
     range rng(-1,-1,-1);
     discovered_or_minimized_alleles als;
 
-    for (const auto& it : alleles) {
+    for (auto pit = alleles.begin(); pit != alleles.end(); alleles.erase(pit++)) {
+        const auto& it = *pit;
         if (!rng.overlaps(it.first.pos)) {
             if (rng.rid != -1) {
                 assert(!als.empty());
@@ -267,23 +270,27 @@ auto prune_alleles(const unifier_config& cfg, const minimized_alleles& alleles, 
 // Delineate sites given all discovered alleles, potentially pruning some as
 // described above. The result maps the range of each site to a pair of the
 // discovered REF alleles and the minimized ALT alleles.
-Status delineate_sites(const unifier_config& cfg, const discovered_alleles& alleles,
+// The input alleles is cleared by side-effect to save memory.
+Status delineate_sites(const unifier_config& cfg, discovered_alleles& alleles,
                        map<range,tuple<discovered_alleles,minimized_alleles,minimized_alleles>>& ans) {
     Status s;
 
     // Start by coarsely partitioning "active regions" (allele clusters)
     auto active_regions = partition<discovered_alleles>(alleles);
+    // alleles has been cleared by side effect
 
     // Decompose each active region into sites
     ans.clear();
-    for (const auto& active_region : active_regions) {
+    for (auto par = active_regions.begin(); par != active_regions.end(); active_regions.erase(par++)) {
+        const auto& active_region = *par;
+
         // minimize the alt alleles
         discovered_alleles refs;
         minimized_alleles alts, pruned;
         S(minimize_alleles(cfg, active_region.second, refs, alts));
 
         // prune alt alleles as necessary to yield sites
-        auto sites = prune_alleles(cfg, alts, pruned);
+        const auto sites = prune_alleles(cfg, alts, pruned);
 
         for (const auto& site : sites) {
             // find the ref alleles overlapping this site
@@ -348,6 +355,8 @@ Status pad_alt_allele(const allele& ref, allele& alt) {
 }
 
 /// Unify the alleles at one site.
+/// pruned is in+out; we need to know which alleles were pruned in site delineation, and,
+/// we might prune more alleles in the process.
 Status unify_alleles(const unifier_config& cfg, unsigned N, const range& pos,
                      const discovered_alleles& refs, const minimized_alleles& alts,
                      minimized_alleles& pruned, unified_site& ans) {
@@ -432,19 +441,19 @@ Status unify_alleles(const unifier_config& cfg, unsigned N, const range& pos,
 }
 
 Status unified_sites(const unifier_config& cfg,
-                     unsigned N, const discovered_alleles& alleles,
+                     unsigned N, discovered_alleles& alleles,
                      vector<unified_site>& ans) {
     Status s;
 
     map<range,tuple<discovered_alleles,minimized_alleles,minimized_alleles>> sites;
     S(delineate_sites(cfg, alleles, sites));
+    // at this point, alleles has been cleared to save memory usage
 
-    ans.clear();
-    for (const auto& site : sites) {
-        UNPAIR(site, pos, site_alleles);
-        auto& ref_alleles = get<0>(site_alleles);
-        auto& alt_alleles = get<1>(site_alleles);
-        auto& pruned_alleles = get<2>(site_alleles);
+    for (auto psite = sites.begin(); psite != sites.end(); sites.erase(psite++)) {
+        UNPAIR(*psite, pos, site_alleles);
+        const auto& ref_alleles = get<0>(site_alleles);
+        const auto& alt_alleles = get<1>(site_alleles);
+        auto pruned_alleles = get<2>(site_alleles);
         unified_site us(pos);
         S(unify_alleles(cfg, N, pos, ref_alleles, alt_alleles, pruned_alleles, us));
         ans.push_back(us);

--- a/test/cli_utils.cc
+++ b/test/cli_utils.cc
@@ -372,11 +372,12 @@ unification:
         filenames.push_back(tmp_file_name1);
 
         vector<pair<string,size_t>> contigs2;
-        discovered_alleles dsals2;
+        vector<discovered_alleles> dsals2;
         Status s = utils::merge_discovered_allele_files(console, 0, filenames, N, contigs2, dsals2);
         REQUIRE(s.ok());
         REQUIRE(N == 1);
         REQUIRE(contigs2.size() == contigs.size());
+        REQUIRE(dsals2.size() == contigs.size());
     }
 
     SECTION("merging discovered allele files, 2 files") {
@@ -392,12 +393,14 @@ unification:
         filenames.push_back(tmp_file_name2);
 
         vector<pair<string,size_t>> contigs2;
-        discovered_alleles dsals;
+        vector<discovered_alleles> dsals;
         Status s = utils::merge_discovered_allele_files(console, 0, filenames, N, contigs2, dsals);
         REQUIRE(s.ok());
         REQUIRE(N == 3);
         REQUIRE(contigs2.size() == contigs.size());
-        REQUIRE(dsals.size() == 4);
+        REQUIRE(dsals.size() == contigs.size());
+        REQUIRE(dsals[0].size() == 2);
+        REQUIRE(dsals[1].size() == 2);
     }
 
     SECTION("merging discovered allele files, 3 files") {
@@ -411,17 +414,40 @@ unification:
         }
 
         vector<pair<string,size_t>> contigs2;
-        discovered_alleles dsals;
+        vector<discovered_alleles> dsals;
         Status s = utils::merge_discovered_allele_files(console, 0, filenames, N, contigs2, dsals);
         REQUIRE(s.ok());
         REQUIRE(N == 3);
         REQUIRE(contigs2.size() == contigs.size());
-        REQUIRE(dsals.size() == 6);
+        REQUIRE(dsals.size() == contigs.size());
+        REQUIRE(dsals[0].size() == 3);
+        REQUIRE(dsals[1].size() == 3);
+
+        discovered_alleles da1, da2, da3;
+        YAML::Node node = YAML::Load(da_yaml1);
+        s = discovered_alleles_of_yaml(node, contigs, da1); REQUIRE(s.ok());
+        node = YAML::Load(da_yaml2);
+        s = discovered_alleles_of_yaml(node, contigs, da2); REQUIRE(s.ok());
+        node = YAML::Load(da_yaml3);
+        s = discovered_alleles_of_yaml(node, contigs, da3); REQUIRE(s.ok());
+
+        vector<pair<allele,discovered_allele_info>> vdsals(dsals[0].begin(), dsals[0].end());
+        vector<pair<allele,discovered_allele_info>> vda(da1.begin(), da1.end());
+        REQUIRE(vdsals[0] == vda[0]);
+        REQUIRE(vdsals[2] == vda[1]);
+        vda.assign(da3.begin(), da3.end());
+        REQUIRE(vdsals[1] == vda[0]);
+
+        vdsals.assign(dsals[1].begin(), dsals[1].end());
+        REQUIRE(vdsals[2] == vda[1]);
+        vda.assign(da2.begin(), da2.end());
+        REQUIRE(vdsals[0] == vda[0]);
+        REQUIRE(vdsals[1] == vda[1]);
     }
 
     SECTION("merging discovered allele files, error, no files provided") {
         vector<string> filenames;
-        discovered_alleles dsals;
+        vector<discovered_alleles> dsals;
 
         Status s = utils::merge_discovered_allele_files(console, 0, filenames, N, contigs, dsals);
         REQUIRE(s.bad());
@@ -443,7 +469,7 @@ unification:
         filenames.push_back(tmp_file_name2);
 
         vector<pair<string,size_t>> contigs3;
-        discovered_alleles dsals;
+        vector<discovered_alleles> dsals;
         Status s = utils::merge_discovered_allele_files(console, 0, filenames, N, contigs3, dsals);
         REQUIRE(s.bad());
     }
@@ -484,7 +510,7 @@ unification:
             filenames.push_back(fname);
         }
 
-        discovered_alleles dsals;
+        vector<discovered_alleles> dsals;
         Status s = utils::merge_discovered_allele_files(console, 0, filenames, N, contigs, dsals);
     }
 }


### PR DESCRIPTION
Unifier memory usage is one of our scalability chokepoints. Here we change some functions in the unifier to free their inputs incrementally as they loop over them, reducing peak memory usage. Also when loading capnp files we partition the discovered alleles by contig, so that we can run the unifier over one contig at a time in the first place. The latter needs a synchronized change in the internal workflow code.