### PR TITLE
upgrade capnproto

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -9,10 +9,10 @@ sudo apt-get -qq update
 sudo apt-get -qq install -y liblz4-dev
 
 # Install GCC 4.9
-sudo apt-get -qq install -y gcc-4.9 g++-4.9 binutils
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 \
-                         --slave /usr/bin/g++ g++ /usr/bin/g++-4.9 \
-                         --slave /usr/bin/gcov gcov /usr/bin/gcov-4.9
+sudo apt-get -qq install -y gcc-5 g++-5 binutils
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 \
+                         --slave /usr/bin/g++ g++ /usr/bin/g++-5 \
+                         --slave /usr/bin/gcov gcov /usr/bin/gcov-5
 
 # Install boost for use in yaml-cpp
 sudo apt-get -qq install -y libboost1.55-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ set(SPDLOG_INCLUDE_DIR ${source_dir}/include)
 include_directories(${SPDLOG_INCLUDE_DIR})
 
 ExternalProject_Add(capnp
-    URL https://github.com/dnanexus-rnd/capnproto/archive/9f73e92944206107123c5e6fdde59abd7a4f8565.zip
+    URL https://github.com/sandstorm-io/capnproto/archive/9f73e92944206107123c5e6fdde59abd7a4f8565.zip
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external
     CONFIGURE_COMMAND cd c++ && cmake -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external .
     BUILD_IN_SOURCE 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,19 +162,15 @@ ExternalProject_Get_Property(spdlog source_dir)
 set(SPDLOG_INCLUDE_DIR ${source_dir}/include)
 include_directories(${SPDLOG_INCLUDE_DIR})
 
-# Note: installing the sources from git is significantly more
-# complicated. For example, you need to install the google-test
-# package (gtest).
 ExternalProject_Add(capnp
-    URL https://capnproto.org/capnproto-c++-0.5.3.tar.gz
+    URL https://github.com/sandstorm-io/capnproto/archive/6e1d23179980321a6dfd1ac7af0988014d73145f.zip
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external
-    CONFIGURE_COMMAND ./configure --prefix=${CMAKE_BINARY_DIR}/external
+    CONFIGURE_COMMAND cd c++ && cmake -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external .
     BUILD_IN_SOURCE 1
-    BUILD_COMMAND make -j6 check
-    INSTALL_COMMAND make install
+    BUILD_COMMAND make -C c++ -j4 check
+    INSTALL_COMMAND make -C c++ install
     LOG_DOWNLOAD ON
   )
-
 
 execute_process(COMMAND git describe --tags --long --dirty --always
                 OUTPUT_VARIABLE GIT_REVISION OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -193,7 +189,7 @@ include_directories(${COMMON_INCLUDES} capnp/serialize)
 # definitions.
 add_custom_command(
   OUTPUT  capnp/serialize/defs.capnp.c++ capnp/serialize/defs.capnp.h
-  COMMAND ${CMAKE_BINARY_DIR}/external/bin/capnp compile -oexternal/bin/capnpc-c++ capnp/serialize/defs.capnp
+  COMMAND ${CMAKE_BINARY_DIR}/external/bin/capnp compile -I${CMAKE_CURRENT_BINARY_DIR}/external/include -oexternal/bin/capnpc-c++ capnp/serialize/defs.capnp
   DEPENDS capnp/serialize/defs.capnp
   COMMENT "GLnexus: generating cap'n proto C++ and H files")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ set(SPDLOG_INCLUDE_DIR ${source_dir}/include)
 include_directories(${SPDLOG_INCLUDE_DIR})
 
 ExternalProject_Add(capnp
-    URL https://github.com/dnanexus-rnd/capnproto/archive/b97b6e72e676b9ddadabfe7ebfbbd756367466a9.zip
+    URL https://github.com/dnanexus-rnd/capnproto/archive/d223429881edc76aa8f3da392f91d726af3ca08f.zip
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external
     CONFIGURE_COMMAND cd c++ && cmake -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external .
     BUILD_IN_SOURCE 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ set(SPDLOG_INCLUDE_DIR ${source_dir}/include)
 include_directories(${SPDLOG_INCLUDE_DIR})
 
 ExternalProject_Add(capnp
-    URL https://github.com/dnanexus-rnd/capnproto/archive/d223429881edc76aa8f3da392f91d726af3ca08f.zip
+    URL https://github.com/dnanexus-rnd/capnproto/archive/9f73e92944206107123c5e6fdde59abd7a4f8565.zip
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external
     CONFIGURE_COMMAND cd c++ && cmake -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external .
     BUILD_IN_SOURCE 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ set(SPDLOG_INCLUDE_DIR ${source_dir}/include)
 include_directories(${SPDLOG_INCLUDE_DIR})
 
 ExternalProject_Add(capnp
-    URL https://github.com/sandstorm-io/capnproto/archive/6e1d23179980321a6dfd1ac7af0988014d73145f.zip
+    URL https://github.com/dnanexus-rnd/capnproto/archive/b97b6e72e676b9ddadabfe7ebfbbd756367466a9.zip
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external
     CONFIGURE_COMMAND cd c++ && cmake -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external .
     BUILD_IN_SOURCE 1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is an early-stage R&D project we're developing openly. The code doesn't yet
 
 <a href="https://travis-ci.org/dnanexus-rnd/GLnexus"><img src="https://travis-ci.org/dnanexus-rnd/GLnexus.svg?branch=master"/></a> [![Coverage Status](https://coveralls.io/repos/dnanexus-rnd/GLnexus/badge.svg?branch=master&service=github)](https://coveralls.io/github/dnanexus-rnd/GLnexus?branch=master)
 
-First install [gcc 4.9 or higher](http://askubuntu.com/a/581497), [CMake 3.2 or higher](http://askubuntu.com/questions/610291/how-to-install-cmake-3-2-on-ubuntu-14-04), and packages: `autoconf` `libjemalloc-dev` `libboost-dev` `libzip-dev` `libsnappy-dev` `liblz4-dev` `libbz2-dev` `python-pyvcf`. Then:
+First install [gcc 5+](http://askubuntu.com/a/581497), [CMake 3.2+](http://askubuntu.com/questions/610291/how-to-install-cmake-3-2-on-ubuntu-14-04), and packages: `autoconf` `libjemalloc-dev` `libboost-dev` `libzip-dev` `libsnappy-dev` `liblz4-dev` `libbz2-dev` `python-pyvcf`. Then:
 
 ```
 cmake -Dtest=ON . && make && ./unit_tests

--- a/src/genotyper.cc
+++ b/src/genotyper.cc
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <math.h>
 #include <algorithm>
 #include "genotyper.h"
 #include "diploid.h"

--- a/src/residuals.cc
+++ b/src/residuals.cc
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <algorithm>
+#include <numeric>
 #include <kstring.h>
 #include <vcf.h>
 #include "BCFSerialize.h"

--- a/src/types.cc
+++ b/src/types.cc
@@ -246,7 +246,7 @@ static Status capnp_write_discovered_alleles_fd(unsigned int sample_count,
                                                 const std::vector<std::pair<std::string,size_t> >& contigs,
                                                 const discovered_alleles &dsals,
                                                 int fd) {
-    ::capnp::MallocMessageBuilder message(::capnp::SUGGESTED_FIRST_SEGMENT_WORDS, ::capnp::AllocationStrategy::FIXED_SIZE);
+    ::capnp::MallocMessageBuilder message;
     capnp::DiscoveredAlleles::Builder dsals_pk = message.initRoot<capnp::DiscoveredAlleles>();
     dsals_pk.setSampleCount(sample_count);
 

--- a/src/types.cc
+++ b/src/types.cc
@@ -246,7 +246,7 @@ static Status capnp_write_discovered_alleles_fd(unsigned int sample_count,
                                                 const std::vector<std::pair<std::string,size_t> >& contigs,
                                                 const discovered_alleles &dsals,
                                                 int fd) {
-    ::capnp::MallocMessageBuilder message;
+    ::capnp::MallocMessageBuilder message(::capnp::SUGGESTED_FIRST_SEGMENT_WORDS, ::capnp::AllocationStrategy::FIXED_SIZE);
     capnp::DiscoveredAlleles::Builder dsals_pk = message.initRoot<capnp::DiscoveredAlleles>();
     dsals_pk.setSampleCount(sample_count);
 

--- a/src/unifier.cc
+++ b/src/unifier.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <assert.h>
+#include <math.h>
 #include "unifier.h"
 #include <iostream>
 


### PR DESCRIPTION
in particular pull in https://github.com/sandstorm-io/capnproto/pull/444

Necessitates gcc 5 in Travis environment, in turn necessitating a few includes.