### PR TITLE
capnp de/serialization of unified sites

### DIFF
--- a/capnp/serialize/defs.capnp
+++ b/capnp/serialize/defs.capnp
@@ -3,6 +3,8 @@
 using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("GLnexus::capnp");
 
+### discovered alleles
+
 struct DiscoveredAlleleInfo {
     isRef @0 :Bool = false;
 
@@ -37,4 +39,30 @@ struct DiscoveredAlleles {
     sampleCount @0 : UInt64;
     contigs @1 : List(Contig);
     aips @2 :List(AlleleInfoPair);
+}
+
+### unified sites
+
+struct OriginalAllele {
+    pos @0 :Range;
+    dna @1 :Text;
+    unifiedAllele @2 :Int64;
+}
+
+struct UnifiedSite {
+    pos @0 :Range;
+    containingTargetOption :union {
+        noContainingTarget @1 :Void;
+        containingTarget @2 :Range;
+    }
+    alleles @3 :List(Text);
+    unification @4 :List(OriginalAllele);
+    alleleFrequencies @5 :List(Float32);
+    lostAlleleFrequency @6 :Float32;
+    qual @7 :Int64;
+    monoallelic @8 :Bool;
+}
+
+struct UnifiedSites {
+    sites @0 :List(UnifiedSite);
 }

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -120,6 +120,12 @@ static int all_steps(const vector<string> &vcf_files,
         console->info() << "Writing unified sites as YAML to " << filename;
         H("write unified sites to file",
           GLnexus::cli::utils::write_unified_sites_to_file(sites, contigs, filename));
+
+        string filename_cflat("/tmp/sites.cflat");
+        console->info() << "Writing unified sites in serialized capnproto to " << filename
+                        << ", verifying that it is readable";
+        H("Verify that the cflat file is readable",
+          GLnexus::capnp_unified_sites_verify(sites, filename_cflat));
     }
 
     // genotype

--- a/include/types.h
+++ b/include/types.h
@@ -520,6 +520,21 @@ struct unified_site {
                           unified_site& ans);
 };
 
+// write vector<unified_site> structure to a file, with cap'n proto serialization
+Status capnp_of_unified_sites(const std::vector<unified_site> &sites, const std::string &filename);
+
+// write unified sites capnp to a file descriptor.
+Status capnp_of_unified_sites_fd(const std::vector<unified_site> &sites, int fd);
+
+// read unified sites from a capnp file
+Status unified_sites_of_capnp(const std::string &filename, std::vector<unified_site>& sites);
+
+// Verify that we can serialize and deserialize unified sites
+//
+// Note: this is a debugging function
+Status capnp_unified_sites_verify(const std::vector<unified_site> &sites, const std::string &filename);
+
+
 // Statistics collected during range queries
 struct StatsRangeQuery {
     int64_t nBCFRecordsRead;    // how many BCF records were read from the DB

--- a/test/gvcf_test_cases.cc
+++ b/test/gvcf_test_cases.cc
@@ -231,6 +231,7 @@ public:
             const auto n_unified_sites = yaml["truth_unified_sites"];
             REQUIRE(n_unified_sites);
             S(parse_unified_sites(n_unified_sites, contigs));
+            REQUIRE(GLnexus::capnp_unified_sites_verify(truth_sites, "/tmp/unified_sites_capnp_check").ok());
         }
 
         // write truth gvcf if test_genotypes is set to true

--- a/test/types.cc
+++ b/test/types.cc
@@ -345,13 +345,14 @@ unification:
     SECTION("snp+del") {
         vector<YAML::Node> ns = YAML::LoadAll("---\n" + string(snp) + "\n---\n" + string(del) + "\n...");
         REQUIRE(ns.size() == 2);
-        unified_site us(range(-1,-1,-1));
+        unified_site us(range(-1,-1,-1)), us2(range(-1,-1,-1));
         Status s = unified_site::of_yaml(ns[0], contigs, us);
         REQUIRE(s.ok());
         VERIFY_SNP(us);
-        s = unified_site::of_yaml(ns[1], contigs, us);
+        s = unified_site::of_yaml(ns[1], contigs, us2);
         REQUIRE(s.ok());
-        VERIFY_DEL(us);
+        VERIFY_DEL(us2);
+        REQUIRE(GLnexus::capnp_unified_sites_verify({us, us2}, "/tmp/unified_sites.capnp").ok());
     }
 
     SECTION("optional ref") {
@@ -497,6 +498,8 @@ unification:
         unified_site us2(range(-1,-1,-1));
         REQUIRE(unified_site::of_yaml(n, contigs, us2).ok());
         REQUIRE(us == us2);
+
+        REQUIRE(GLnexus::capnp_unified_sites_verify({us}, "/tmp/unified_sites.capnp").ok());
     }
 }
 


### PR DESCRIPTION
The slowness of de/serializing unified sites in YAML has become an issue for WGS. Here is plumbing for doing so with capnp instead, while (as with discovered alleles) we still keep the YAML representation for tests and debugging.