### PR TITLE
Track the discovery target range in which alleles are found

### DIFF
--- a/capnp/serialize/defs.capnp
+++ b/capnp/serialize/defs.capnp
@@ -3,6 +3,12 @@
 using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("GLnexus::capnp");
 
+struct Range {
+    rid @0 :Int64;
+    beg @1 :Int64;
+    end @2 :Int64;
+}
+
 ### discovered alleles
 
 struct DiscoveredAlleleInfo {
@@ -17,12 +23,11 @@ struct DiscoveredAlleleInfo {
      # zygosity_by_GQ statistics are used to estimate allele copy number
     zGQ0 @2 :List(UInt64);
     zGQ1 @3 :List(UInt64);
-}
 
-struct Range {
-    rid @0 :Int64;
-    beg @1 :Int64;
-    end @2 :Int64;
+    inTargetOption : union {
+        noInTarget @5 :Void;
+        inTarget @6 :Range;
+    }
 }
 
 # This is really a mapping from allele to information.

--- a/capnp/serialize/defs.capnp
+++ b/capnp/serialize/defs.capnp
@@ -59,9 +59,9 @@ struct OriginalAllele {
 
 struct UnifiedSite {
     pos @0 :Range;
-    containingTargetOption :union {
-        noContainingTarget @1 :Void;
-        containingTarget @2 :Range;
+    inTargetOption :union {
+        noInTarget @1 :Void;
+        inTarget @2 :Range;
     }
     alleles @3 :List(Text);
     unification @4 :List(OriginalAllele);

--- a/capnp/serialize/defs.capnp
+++ b/capnp/serialize/defs.capnp
@@ -11,30 +11,26 @@ struct Range {
 
 ### discovered alleles
 
-struct DiscoveredAlleleInfo {
-    isRef @0 :Bool = false;
-
-    # indicates whether all observations of this allele failed some VCF FILTER
-    allFiltered @4 :Bool = false;
-
-    # top_AQ statistics are used to adjudicate allele existence
-    topAQ @1 :List(Int64);
-
-     # zygosity_by_GQ statistics are used to estimate allele copy number
-    zGQ0 @2 :List(UInt64);
-    zGQ1 @3 :List(UInt64);
-
-    inTargetOption : union {
-        noInTarget @5 :Void;
-        inTarget @6 :Range;
-    }
-}
-
-# This is really a mapping from allele to information.
-struct AlleleInfoPair {
+struct DiscoveredAllele {
     range @0 :Range;
     dna @1 :Text;
-    dai @2 :DiscoveredAlleleInfo;
+    isRef @2 :Bool = false;
+
+    # optional: discovery target range in which this allele was found
+    inTargetOption : union {
+        noInTarget @3 :Void;
+        inTarget @4 :Range;
+    }
+
+    # indicates whether all observations of this allele failed some VCF FILTER
+    allFiltered @5 :Bool = false;
+
+    # top_AQ statistics are used to adjudicate allele existence
+    topAQ @6 :List(Int64);
+
+     # zygosity_by_GQ statistics are used to estimate allele copy number
+    zGQ0 @7 :List(UInt64);
+    zGQ1 @8 :List(UInt64);
 }
 
 struct Contig {
@@ -46,7 +42,7 @@ struct Contig {
 struct DiscoveredAlleles {
     sampleCount @0 : UInt64;
     contigs @1 : List(Contig);
-    aips @2 :List(AlleleInfoPair);
+    alleles @2 :List(DiscoveredAllele);
 }
 
 ### unified sites

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -113,7 +113,7 @@ static int all_steps(const vector<string> &vcf_files,
     for (auto& dsals_i : dsals_by_contig) {
         GLnexus::unifier_stats stats1;
         H("unify sites",
-          GLnexus::cli::utils::unify_sites(console, unifier_cfg, ranges, contigs, dsals_i, sample_count, sites, stats1));
+          GLnexus::cli::utils::unify_sites(console, unifier_cfg, contigs, dsals_i, sample_count, sites, stats1));
         stats += stats1;
     }
     console->info() << "unified to " << sites.size() << " sites cleanly with " << stats.unified_alleles << " ALT alleles. "

--- a/include/cli_utils.h
+++ b/include/cli_utils.h
@@ -133,7 +133,6 @@ Status discover_alleles(std::shared_ptr<spdlog::logger> logger,
 // output sites is appended to (not cleared!)
 Status unify_sites(std::shared_ptr<spdlog::logger> logger,
                    const unifier_config &unifier_cfg,
-                   const std::vector<range> &ranges,
                    const std::vector<std::pair<std::string,size_t> > &contigs,
                    discovered_alleles &dsals,
                    unsigned sample_count,

--- a/include/cli_utils.h
+++ b/include/cli_utils.h
@@ -77,12 +77,11 @@ Status unified_sites_of_yaml_stream(std::istream &is,
 
 // Merge a bunch of discovered-allele files, all in capnp format.
 // N is summed across the files, and the contigs must be the same in all.
-// Returns one discovered_alleles structures per contig, in order.
 Status merge_discovered_allele_files(std::shared_ptr<spdlog::logger> logger,
                                      size_t nr_threads,
                                      const std::vector<std::string> &filenames,
                                      unsigned& N, std::vector<std::pair<std::string,size_t>> &contigs,
-                                     std::vector<discovered_alleles>& dsals);
+                                     discovered_alleles& dsals);
 
 // Check if a file exists
 bool check_file_exists(const std::string &path);

--- a/include/types.h
+++ b/include/types.h
@@ -533,7 +533,6 @@ Status capnp_of_unified_sites(const std::vector<unified_site> &sites, const std:
 
 // write unified sites capnp to a file descriptor.
 Status capnp_of_unified_sites_fd(const std::vector<unified_site> &sites, int fd);
-Status capnp_of_unified_sites_fd(const std::vector<const std::vector<unified_site>*> &sites, int fd); // the 2D vector is flattened
 
 // read unified sites from a capnp file
 Status unified_sites_of_capnp(const std::string &filename, std::vector<unified_site>& sites);

--- a/include/types.h
+++ b/include/types.h
@@ -388,6 +388,9 @@ struct discovered_allele_info {
     // zygosity_by_GQ statsitics are used to estimate allele copy number
     zygosity_by_GQ zGQ;
 
+    /// Optional: the target range (e.g. exon) in which this allele was discovered
+    range in_target = range(-1,-1,-1);
+
     bool operator==(const discovered_allele_info& rhs) const noexcept {
         return is_ref == rhs.is_ref && all_filtered == rhs.all_filtered && topAQ == rhs.topAQ && zGQ == rhs.zGQ;
     }

--- a/include/unifier.h
+++ b/include/unifier.h
@@ -38,7 +38,6 @@ struct unifier_stats {
 Status unified_sites(const unifier_config& cfg,
                      unsigned N,
                      /* const */ discovered_alleles& alleles,
-                     const std::set<range>& target_ranges,
                      std::vector<unified_site>& ans,
                      unifier_stats& stats);
 

--- a/src/cli_utils.cc
+++ b/src/cli_utils.cc
@@ -987,19 +987,13 @@ Status discover_alleles(std::shared_ptr<spdlog::logger> logger,
 
 Status unify_sites(std::shared_ptr<spdlog::logger> logger,
                    const unifier_config &unifier_cfg,
-                   const vector<range> &ranges,
                    const vector<pair<string,size_t> > &contigs,
                    discovered_alleles &dsals,
                    unsigned sample_count,
                    vector<unified_site> &sites,
                    unifier_stats& stats) {
     Status s;
-
-    set<range> ranges_set;
-    for (auto& r : ranges) {
-        ranges_set.insert(r);
-    }
-    S(unified_sites(unifier_cfg, sample_count, dsals, ranges_set, sites, stats));
+    S(unified_sites(unifier_cfg, sample_count, dsals, sites, stats));
 
     // sanity check, sites are in-order
     if (sites.size() > 1) {

--- a/src/discovery.cc
+++ b/src/discovery.cc
@@ -60,6 +60,7 @@ Status discover_alleles_from_iterator(const set<string>& samples,
                     ai.all_filtered = filtered;
                     ai.topAQ = topAQ[i];
                     ai.zGQ = zGQ[i];
+                    ai.in_target = pos;
                     dsals.insert(make_pair(allele(rng, aldna), ai));
                     any_alt = true;
                 }
@@ -75,6 +76,7 @@ Status discover_alleles_from_iterator(const set<string>& samples,
                     ai.all_filtered = filtered;
                     ai.topAQ = topAQ[0];
                     ai.zGQ = zGQ[0];
+                    ai.in_target = pos;
                     dsals.insert(make_pair(allele(rng, refdna), ai));
                 }
             } else {

--- a/src/types.cc
+++ b/src/types.cc
@@ -717,12 +717,12 @@ static Status capnp_write_unified_sites_fd(const vector<const vector<unified_sit
             pos_b.setEnd(site.pos.end);
 
             if (site.in_target.rid > -1) {
-                auto ct_b = site_b.getContainingTargetOption().initContainingTarget();
-                ct_b.setRid(site.in_target.rid);
-                ct_b.setBeg(site.in_target.beg);
-                ct_b.setEnd(site.in_target.end);
+                auto it_b = site_b.getInTargetOption().initInTarget();
+                it_b.setRid(site.in_target.rid);
+                it_b.setBeg(site.in_target.beg);
+                it_b.setEnd(site.in_target.end);
             } else {
-                site_b.getContainingTargetOption().setNoContainingTarget(::capnp::VOID);
+                site_b.getInTargetOption().setNoInTarget(::capnp::VOID);
             }
 
             auto alleles_b = site_b.initAlleles(site.alleles.size());
@@ -801,12 +801,12 @@ static Status _capnp_read_unified_sites_fd(int fd, vector<unified_site>& sites) 
 
         unified_site site(pos);
 
-        const auto cto_r = site_r.getContainingTargetOption();
-        if (cto_r.hasContainingTarget()) {
-            const auto ct_r = cto_r.getContainingTarget();
-            site.in_target.rid = ct_r.getRid();
-            site.in_target.beg = ct_r.getBeg();
-            site.in_target.end = ct_r.getEnd();
+        const auto ito_r = site_r.getInTargetOption();
+        if (ito_r.hasInTarget()) {
+            const auto it_r = ito_r.getInTarget();
+            site.in_target.rid = it_r.getRid();
+            site.in_target.beg = it_r.getBeg();
+            site.in_target.end = it_r.getEnd();
         }
 
         for (const auto& al : site_r.getAlleles()) {

--- a/test/cli.cc
+++ b/test/cli.cc
@@ -72,7 +72,7 @@ TEST_CASE("cli") {
         // unify sites
         vector<GLnexus::unified_site> sites;
         unifier_stats stats;
-        s = cli::utils::unify_sites(console, unifier_cfg, ranges,
+        s = cli::utils::unify_sites(console, unifier_cfg,
                                     contigs, dsals, sample_count, sites, stats);
         filename = DB_DIR + "/sites.yml";
         s = cli::utils::write_unified_sites_to_file(sites, contigs, filename);

--- a/test/gvcf_test_cases.cc
+++ b/test/gvcf_test_cases.cc
@@ -296,11 +296,7 @@ public:
         REQUIRE(s.ok());
 
         unifier_stats stats;
-        set<range> pos_set;
-        if (pos != range(0, 0, 1000000000)) {
-            pos_set.insert(pos);
-        }
-        s = unified_sites(unifier_cfg, N, als, pos_set, sites, stats);
+        s = unified_sites(unifier_cfg, N, als, sites, stats);
         REQUIRE(s.ok());
 
         REQUIRE(is_sorted(sites.begin(), sites.end()));

--- a/test/service.cc
+++ b/test/service.cc
@@ -223,7 +223,7 @@ TEST_CASE("unified_sites") {
 
         vector<unified_site> sites;
         unifier_stats stats;
-        s = unified_sites(unifier_config(), N, als, {}, sites, stats);
+        s = unified_sites(unifier_config(), N, als, sites, stats);
         REQUIRE(s.ok());
 
         vector<pair<string,size_t> > contigs;
@@ -302,7 +302,7 @@ TEST_CASE("unified_sites") {
 
         vector<unified_site> sites;
         unifier_stats stats;
-        s = unified_sites(unifier_config(), N, als, {}, sites, stats);
+        s = unified_sites(unifier_config(), N, als, sites, stats);
         REQUIRE(s.ok());
 
         vector<pair<string,size_t> > contigs;
@@ -421,7 +421,7 @@ TEST_CASE("genotyper placeholder") {
         REQUIRE(N == 6);
         vector<unified_site> sites;
         unifier_stats stats;
-        s = unified_sites(unifier_config(), N, als, {}, sites, stats);
+        s = unified_sites(unifier_config(), N, als, sites, stats);
         REQUIRE(s.ok());
 
         unique_ptr<SimFailBCFData> faildata;
@@ -463,7 +463,7 @@ TEST_CASE("genotyper placeholder") {
 
         vector<unified_site> sites;
         unifier_stats stats;
-        s = unified_sites(unifier_config(), N, als, {}, sites, stats);
+        s = unified_sites(unifier_config(), N, als, sites, stats);
         cout << s.str() << endl;
         REQUIRE(s.ok());
 
@@ -593,7 +593,7 @@ TEST_CASE("genotype residuals") {
 
     vector<unified_site> sites;
     unifier_stats stats;
-    s = unified_sites(unifier_config(), N, als, {}, sites, stats);
+    s = unified_sites(unifier_config(), N, als, sites, stats);
     REQUIRE(s.ok());
 
     const string tfn("/tmp/GLnexus_unit_tests.bcf");

--- a/test/service.cc
+++ b/test/service.cc
@@ -74,6 +74,8 @@ TEST_CASE("service::discover_alleles") {
         REQUIRE(mals[0].size() == 2);
         REQUIRE(mals[0].find(allele(range(0, 1000, 1001), "A"))->second.zGQ.copy_number() == 6);
         REQUIRE(mals[0].find(allele(range(0, 1000, 1001), "G"))->second.zGQ.copy_number() == 6);
+        REQUIRE(mals[0].find(allele(range(0, 1000, 1001), "A"))->second.in_target == range(0, 1000, 1001));
+        REQUIRE(mals[0].find(allele(range(0, 1000, 1001), "G"))->second.in_target == range(0, 1000, 1001));
 
         REQUIRE(mals[1].size() == 4);
         REQUIRE(mals[1].find(allele(range(0, 1001, 1002), "A"))->second.zGQ.copy_number() == 6);
@@ -94,6 +96,8 @@ TEST_CASE("service::discover_alleles") {
         REQUIRE(mals[4].size() == 4);
         REQUIRE(mals[4].find(allele(range(1, 1010, 1012), "AG"))->second.zGQ.copy_number() == 3);
         REQUIRE(mals[4].find(allele(range(1, 1010, 1012), "CC"))->second.zGQ.copy_number() == 3);
+        REQUIRE(mals[4].find(allele(range(1, 1010, 1012), "AG"))->second.in_target == range(1, 1010, 1012));
+        REQUIRE(mals[4].find(allele(range(1, 1010, 1012), "CC"))->second.in_target == range(1, 1010, 1012));
         REQUIRE(mals[2].find(allele(range(0, 1010, 1013), "AGA"))->second.zGQ.copy_number() == 2);
         REQUIRE(mals[2].find(allele(range(0, 1010, 1013), "CCC"))->second.zGQ.copy_number() == 4);
 
@@ -181,6 +185,7 @@ TEST_CASE("service::discover_alleles gVCF") {
         p = als.find(allele(range(0, 10009463, 10009465), "T"));
         REQUIRE(p != als.end());
         REQUIRE(p->second.zGQ.copy_number() == 1);
+        REQUIRE(p->second.in_target == range(0, 10000000, 10010000));
     }
 
     SECTION("exclusion/detection of bogus alleles") {

--- a/test/unifier.cc
+++ b/test/unifier.cc
@@ -9,7 +9,7 @@ TEST_CASE("unifier max_alleles_per_site") {
     discovered_alleles dal;
     discovered_allele_info dai;
 
-    dai.is_ref = true; dai.topAQ = top_AQ(99); dai.zGQ = zygosity_by_GQ(1,0,100);
+    dai.is_ref = true; dai.topAQ = top_AQ(99); dai.zGQ = zygosity_by_GQ(1,0,100); dai.in_target=range(0,90,110);
     dal[allele(range(0, 100, 101), "A")] = dai;
     dai.is_ref = false; dai.topAQ = top_AQ(99); dai.zGQ = zygosity_by_GQ(1,0,101);
     dal[allele(range(0, 100, 101), "G")] = dai;
@@ -30,17 +30,18 @@ TEST_CASE("unifier max_alleles_per_site") {
     SECTION("0") {
         // No limit on # of max alleles
         unifier_stats stats;
-        Status s = unified_sites(cfg, 200, dal, {}, sites, stats);
+        Status s = unified_sites(cfg, 200, dal, sites, stats);
         REQUIRE(s.ok());
         REQUIRE(sites.size() == 1);
         REQUIRE(sites[0].alleles.size() == 6);
         REQUIRE(sites[0].alleles[5] == "GC");
+        REQUIRE(sites[0].in_target == range(0,90,110));
     }
 
     SECTION("5") {
         cfg.max_alleles_per_site = 5;
         unifier_stats stats;
-        Status s = unified_sites(cfg, 200, dal, {}, sites, stats);
+        Status s = unified_sites(cfg, 200, dal, sites, stats);
         REQUIRE(s.ok());
         REQUIRE(sites.size() == 1);
         REQUIRE(sites[0].alleles.size() == 5);
@@ -50,7 +51,7 @@ TEST_CASE("unifier max_alleles_per_site") {
     SECTION("4") {
         cfg.max_alleles_per_site = 4;
         unifier_stats stats;
-        Status s = unified_sites(cfg, 200, dal, {}, sites, stats);
+        Status s = unified_sites(cfg, 200, dal, sites, stats);
         REQUIRE(s.ok());
         REQUIRE(sites.size() == 1);
         REQUIRE(sites[0].alleles.size() == 4);
@@ -60,7 +61,7 @@ TEST_CASE("unifier max_alleles_per_site") {
     SECTION("3") {
         cfg.max_alleles_per_site = 3;
         unifier_stats stats;
-        Status s = unified_sites(cfg, 200, dal, {}, sites, stats);
+        Status s = unified_sites(cfg, 200, dal, sites, stats);
         REQUIRE(s.ok());
         REQUIRE(sites.size() == 1);
         REQUIRE(sites[0].alleles.size() == 3);
@@ -70,7 +71,7 @@ TEST_CASE("unifier max_alleles_per_site") {
     SECTION("2") {
         cfg.max_alleles_per_site = 2;
         unifier_stats stats;
-        Status s = unified_sites(cfg, 200, dal, {}, sites, stats);
+        Status s = unified_sites(cfg, 200, dal, sites, stats);
         REQUIRE(s.ok());
         REQUIRE(sites.size() == 1);
         REQUIRE(sites[0].alleles.size() == 2);


### PR DESCRIPTION
By keeping track of this from the start, we don't need awkward logic currently in the unifier to figure out the target range for each site