### PR TITLE
Unify some non-left-aligned indels

### DIFF
--- a/src/types.cc
+++ b/src/types.cc
@@ -635,6 +635,7 @@ Status unified_site::of_yaml(const YAML::Node& yaml, const vector<pair<string,si
         const auto n_urange = (*p)["range"];
         VR(n_urange, "missing 'range' field in unification entry");
         S(range_of_yaml(n_urange, contigs, urange, ans.pos.rid));
+        VR(ans.pos.rid == urange.rid, "unification entry is on different contig than site");
 
         const auto n_udna = (*p)["dna"];
         VR(n_udna && n_udna.IsScalar(), "missing/invalid 'dna' field in unification entry");

--- a/src/types.cc
+++ b/src/types.cc
@@ -635,7 +635,6 @@ Status unified_site::of_yaml(const YAML::Node& yaml, const vector<pair<string,si
         const auto n_urange = (*p)["range"];
         VR(n_urange, "missing 'range' field in unification entry");
         S(range_of_yaml(n_urange, contigs, urange, ans.pos.rid));
-        VR(ans.pos.overlaps(urange), "unification entry range does not overlap site range");
 
         const auto n_udna = (*p)["dna"];
         VR(n_udna && n_udna.IsScalar(), "missing/invalid 'dna' field in unification entry");

--- a/src/unifier.cc
+++ b/src/unifier.cc
@@ -193,9 +193,9 @@ Status find_target_range(const std::set<range>& ranges, const range& pos, range&
 
 
 // Partition alleles into non-overlapping "active regions" where all the
-// alleles in an active region are transitively connected through overlap.
-// (However, individual pairs of alleles within an active region might be non-
-// overlapping.)
+// alleles in an active region are transitively connected through overlap
+// or adjacency. (However, individual pairs of alleles within an active
+// region might be separated.)
 // The input is cleared by side-effect to save memory.
 template<class discovered_or_minimized_alleles>
 auto partition(discovered_or_minimized_alleles& alleles) {
@@ -206,7 +206,8 @@ auto partition(discovered_or_minimized_alleles& alleles) {
 
     for (auto pit = alleles.begin(); pit != alleles.end(); alleles.erase(pit++)) {
         const auto& it = *pit;
-        if (!rng.overlaps(it.first.pos)) {
+        assert(rng <= it.first.pos);
+        if (rng.rid != it.first.pos.rid || rng.end < it.first.pos.beg) {
             if (rng.rid != -1) {
                 assert(!als.empty());
                 ans[rng] = als;
@@ -215,7 +216,7 @@ auto partition(discovered_or_minimized_alleles& alleles) {
             als.clear();
         }
 
-        assert(rng.overlaps(it.first.pos));
+        assert(rng.end >= it.first.pos.beg);
         assert(rng <= it.first.pos);
         rng.end = max(rng.end, it.first.pos.end);
         assert(it.first.pos.within(rng));
@@ -242,9 +243,8 @@ bool check_copy_number(const unifier_config& cfg, const minimized_allele& al) {
     return al.second.copy_number >= cfg.min_allele_copy_number;
 }
 
-// Given a cluster of related/overlapping ALT alleles, decompose it into
-// "sites" by heuristically pruning rare or lengthy alleles to avoid excessive
-// collapsing
+// Given an active region, decompose it into "sites" by heuristically pruning
+// rare or lengthy alleles to avoid excessive collapsing
 auto prune_alleles(const unifier_config& cfg, const minimized_alleles& alleles, minimized_alleles& pruned) {
     vector<minimized_allele> valleles;
     valleles.reserve(alleles.size());
@@ -270,6 +270,7 @@ auto prune_alleles(const unifier_config& cfg, const minimized_alleles& alleles, 
     }
 
     // sort the alt alleles by decreasing copy number (+ some tiebreakers)
+    // or possibly by increasing range size, according to configuration
     sort(valleles.begin(), valleles.end(), minimized_allele_lt(cfg.preference));
 
     // Build the sites by considering each alt allele in that order, and
@@ -324,6 +325,77 @@ auto prune_alleles(const unifier_config& cfg, const minimized_alleles& alleles, 
     return sites;
 }
 
+// Given reference alleles covering pos, reconstruct the reference allele for
+// pos exactly.
+Status unify_ref(const range& pos, const discovered_alleles& refs, allele& ref) {
+    ref.pos = pos;
+    ref.dna.assign(pos.size(), char(0));
+
+    for (const auto& ref1 : refs) {
+        UNPAIR(ref1, al, info);
+        assert(pos.overlaps(al.pos));
+        assert(info.is_ref);
+        assert(al.pos.size() == al.dna.size());
+        for (int i = 0, j = (al.pos.beg-pos.beg); i < al.dna.size(); i++, j++) {
+            if (j >= 0 && j < ref.dna.size()) {
+                if (ref.dna[j] && ref.dna[j] != al.dna[i]) {
+                    return Status::Invalid("detected inconsistent REF alleles", al.pos.str());
+                }
+                ref.dna[j] = al.dna[i];
+            }
+        }
+    }
+    if (any_of(ref.dna.begin(), ref.dna.end(), [] (const char c) { return c == 0; })) {
+        return Status::Invalid("Incomplete REF allele coverage in unification (this should not happen!)", pos.str());
+    }
+
+    return Status::OK();
+}
+
+// Given an ALT allele and a unified REF allele containing it, pad the ALT
+// allele as needed with reference bases so that it covers exactly the
+// same range as the ref allele.
+Status pad_alt_allele(const allele& ref, allele& alt) {
+    if (!ref.pos.contains(alt.pos)) return Status::Invalid("BUG: unified REF allele doesn't contain all ALT alleles");
+    size_t l = alt.pos.beg - ref.pos.beg;
+    size_t r = ref.pos.end - alt.pos.end;
+
+    alt.pos = ref.pos;
+    alt.dna = ref.dna.substr(0, l) + alt.dna + ref.dna.substr(ref.dna.size()-r, r);
+    return Status::OK();
+}
+
+// Given minimized alleles in an active region, detect equivalent ALT alleles
+// with different positions (i.e. indels with some non-left-aligned
+// representation) and collapse them together. This effectively realigns the
+// indels, but only in the limited case where they fall in the same active
+// region as so far defined. A non-left-aligned indel could be distant from
+// its left-aligned position e.g. in lengthy tandem repeats, and this will
+// not deal with those.
+Status unify_nonaligned_alts(const allele& ref, const minimized_alleles& alts,
+                             minimized_alleles& aligned_alts) {
+    Status s;
+    map<allele,minimized_allele> unified_alts;
+    for (const auto& p : alts) {
+        UNPAIR(p, alt, alt_info);
+        allele unified_alt(alt);
+        S(pad_alt_allele(ref, unified_alt));
+        assert(unified_alt.pos == ref.pos);
+
+        auto q = unified_alts.find(unified_alt);
+        if (q == unified_alts.end()) {
+            unified_alts.insert(make_pair(unified_alt,p));
+        } else {
+            q->second.second += alt_info;
+        }
+    }
+    aligned_alts.clear();
+    for (const auto& p : unified_alts) {
+        aligned_alts.insert(move(p.second));
+    }
+    return Status::OK();
+}
+
 // Delineate sites given all discovered alleles, potentially pruning some as
 // described above. The result maps the range of each site to a tuple of the
 // discovered REF alleles, the minimized ALT alleles, and any pruned alleles
@@ -348,9 +420,9 @@ Status delineate_sites(const unifier_config& cfg, discovered_alleles& alleles,
         const auto& active_region = *par;
 
         // minimize the alt alleles
-        map<range,discovered_allele> refs;
+        map<range,discovered_allele> refs_by_range;
         minimized_alleles alts, pruned;
-        S(minimize_alleles(cfg, active_region.second, refs, alts));
+        S(minimize_alleles(cfg, active_region.second, refs_by_range, alts));
 
         // exclude alleles not overlapping the discovery target range, if any,
         // after minimization.
@@ -363,6 +435,19 @@ Status delineate_sites(const unifier_config& cfg, discovered_alleles& alleles,
             }
         }
 
+        // reconstruct the active region's reference allele
+        discovered_alleles refs;
+        for (const auto& p : refs_by_range) {
+            refs.insert(p.second);
+        }
+        allele active_region_ref(active_region.first,"A");
+        S(unify_ref(active_region.first, refs, active_region_ref));
+
+        // detect equivalent alt alleles at different positions, and collapse them
+        minimized_alleles aligned_alts;
+        S(unify_nonaligned_alts(active_region_ref, alts, aligned_alts));
+        alts = move(aligned_alts);
+
         // prune alt alleles as necessary to yield sites
         const auto sites = prune_alleles(cfg, alts, pruned);
 
@@ -370,8 +455,8 @@ Status delineate_sites(const unifier_config& cfg, discovered_alleles& alleles,
             // find the ref alleles overlapping this site
             discovered_alleles site_refs;
             for (const auto& ref : refs) {
-                if (ref.first.overlaps(site.first)) {
-                    site_refs.insert(ref.second);
+                if (ref.first.pos.overlaps(site.first)) {
+                    site_refs.insert(ref);
                 }
             }
 
@@ -390,8 +475,8 @@ Status delineate_sites(const unifier_config& cfg, discovered_alleles& alleles,
         for (const auto& pa : pruned) {
             discovered_allele *longest_original_ref = nullptr;
             for (const auto& al : pa.second.originals) {
-                const auto r = refs.find(al.pos);
-                if (r == refs.end()) {
+                const auto r = refs_by_range.find(al.pos);
+                if (r == refs_by_range.end()) {
                     return Status::Invalid("delineate_sites: missing REF allele for ", al.pos.str());
                 }
                 if (!longest_original_ref || longest_original_ref->first.dna.size() < r->second.first.dna.size()) {
@@ -400,67 +485,6 @@ Status delineate_sites(const unifier_config& cfg, discovered_alleles& alleles,
             }
             assert(longest_original_ref);
             all_pruned_alleles.push_back(make_pair(pa, *longest_original_ref));
-        }
-    }
-    return Status::OK();
-}
-
-// Given the alleles at a site, collapse the discovered REF alleles to get one
-// reference allele covering the site's range.
-Status unify_ref(const range& pos, const discovered_alleles& refs, allele& ref) {
-    ref.pos = pos;
-    ref.dna.assign(pos.size(), char(0));
-
-    for (const auto& ref1 : refs) {
-        UNPAIR(ref1, al, info);
-        assert(pos.overlaps(al.pos));
-        assert(al.pos.size() == al.dna.size());
-        for (int i = 0, j = (al.pos.beg-pos.beg); i < al.dna.size(); i++, j++) {
-            if (j >= 0 && j < ref.dna.size()) {
-                if (ref.dna[j] && ref.dna[j] != al.dna[i]) {
-                    return Status::Invalid("detected inconsistent REF alleles", al.pos.str());
-                }
-                ref.dna[j] = al.dna[i];
-            }
-        }
-    }
-    if (any_of(ref.dna.begin(), ref.dna.end(), [] (const char c) { return c == 0; })) {
-        return Status::Invalid("Incomplete REF allele coverage in unification (this should not happen!)", pos.str());
-    }
-
-    return Status::OK();
-}
-
-// Given the unified REF allele and an ALT allele in the same site, pad the
-// ALT allele with reference bases so that it covers exactly the site's range.
-Status pad_alt_allele(const allele& ref, allele& alt) {
-    if (!ref.pos.contains(alt.pos)) return Status::Invalid("BUG: unified REF allele doesn't contain all ALT alleles");
-    size_t l = alt.pos.beg - ref.pos.beg;
-    size_t r = ref.pos.end - alt.pos.end;
-
-    alt.pos = ref.pos;
-    alt.dna = ref.dna.substr(0, l) + alt.dna + ref.dna.substr(ref.dna.size()-r, r);
-    return Status::OK();
-}
-
-// Given the alleles at one site, detect equivalent alt alleles with slightly
-// different positions (i.e. at least one version isn't left-aligned) and
-// collapse them. This effectively realigns indels, but only in the limited
-// case where delineate_sites put them together in the first place.
-Status unify_nonaligned_alts(const allele& ref, const minimized_alleles& alts, minimized_alleles& aligned_alts) {
-    Status s;
-    aligned_alts.clear();
-    for (const auto& p : alts) {
-        UNPAIR(p, alt, alt_info);
-        allele unified_alt(alt);
-        S(pad_alt_allele(ref, unified_alt));
-        assert(unified_alt.pos == ref.pos);
-
-        auto q = aligned_alts.find(unified_alt);
-        if (q == aligned_alts.end()) {
-            aligned_alts[unified_alt] = alt_info;
-        } else {
-            q->second += alt_info;
         }
     }
     return Status::OK();
@@ -476,16 +500,12 @@ Status unify_alleles(const unifier_config& cfg, unsigned N, const range& pos,
     allele ref(pos, "A");
     S(unify_ref(pos, refs, ref));
 
-    // detect equivalent alt alleles at different positions, and collapse them
-    minimized_alleles aligned_alts;
-    S(unify_nonaligned_alts(ref, alts, aligned_alts));
-
     // For presentation in the unified site, sort the alt alleles by
     // decreasing copy number count (+ some tiebreakers). Note, this may be a
     // different sort order than used in prune_allele earlier.
-    assert(aligned_alts.size() > 0);
-    assert(cfg.max_alleles_per_site < 2 || aligned_alts.size() < cfg.max_alleles_per_site);
-    vector<minimized_allele> valts(aligned_alts.begin(), aligned_alts.end());
+    assert(alts.size() > 0);
+    assert(cfg.max_alleles_per_site < 2 || alts.size() < cfg.max_alleles_per_site);
+    vector<minimized_allele> valts(alts.begin(), alts.end());
     sort(valts.begin(), valts.end(), minimized_allele_common_lt);
 
     // fill out the unification

--- a/test/data/gvcf_test_cases/xAtlas.yml
+++ b/test/data/gvcf_test_cases/xAtlas.yml
@@ -71,6 +71,10 @@ input:
         1	1087556	.	G	.	.	PASS	END=1087656;BLOCKAVG_min30p3a	GT:VR:RR:DP:GQ:PL:VRX:RRX:DPX	0/0:0:4:4:.:0,42,177:0,0,0,0:4,7,5.125,1.31022:4,7,5.125,1.31022
         1	131211614	.	AG	A	10	PASS	P=0.905149	GT:VR:RR:DP:GQ:PL	0/1:6:14:21:.:85,0,344
         1	131211615	.	GGA	G	2	low_qual	P=0.366185	GT:VR:RR:DP:GQ:PL	0/0:2:16:19:.:0,24,432
+    - Third.gvcf: |
+        ythird
+    - Fourth.gvcf: |
+        zfourth
 
 unifier_config:
     drop_filtered: true
@@ -283,7 +287,7 @@ truth_discovered_alleles:
 truth_unified_sites:
     - range: {ref: 1, beg: 15956, end: 15956}
       alleles: [G, A]
-      allele_frequencies: [.nan, 0.25]
+      allele_frequencies: [.nan, 0.125]
       quality: 257
       unification:
         - range: {beg: 15956, end: 15956}
@@ -291,7 +295,7 @@ truth_unified_sites:
           to: 1
     - range: {ref: 1, beg: 15983, end: 15983}
       alleles: [C, T, G]
-      allele_frequencies: [.nan, 0.5, 0.25]
+      allele_frequencies: [.nan, 0.25, 0.125]
       quality: 257
       unification:
         - range: {beg: 15983, end: 15983}
@@ -302,7 +306,7 @@ truth_unified_sites:
           to: 2
     - range: {ref: 1, beg: 15985, end: 15985}
       alleles: [A, T]
-      allele_frequencies: [.nan, 0.5]
+      allele_frequencies: [.nan, 0.25]
       quality: 257
       unification:
         - range: {beg: 15985, end: 15985}
@@ -310,7 +314,7 @@ truth_unified_sites:
           to: 1
     - range: {ref: 1, beg: 15987, end: 15987}
       alleles: [M, C]
-      allele_frequencies: [.nan, 0.5]
+      allele_frequencies: [.nan, 0.25]
       quality: 716
       unification:
         - range: {beg: 15987, end: 15987}
@@ -318,7 +322,7 @@ truth_unified_sites:
           to: 1
     - range: {ref: 1, beg: 15989, end: 15990}
       alleles: [AG, A]
-      allele_frequencies: [.nan, 0.5]
+      allele_frequencies: [.nan, 0.25]
       quality: 659
       unification:
         - range: {beg: 15989, end: 15990}
@@ -326,7 +330,7 @@ truth_unified_sites:
           to: 1
     - range: {ref: 1, beg: 1087454, end: 1087456}
       alleles: [TAA, TA, T]
-      allele_frequencies: [.nan, 0.25, 0.25]
+      allele_frequencies: [.nan, 0.125, 0.125]
       quality: 9
       unification:
         - range: {beg: 1087454, end: 1087455}
@@ -337,7 +341,7 @@ truth_unified_sites:
           to: 2
     - range: {ref: 1, beg: 1087554, end: 1087556}
       alleles: [TAA, TA, T]
-      allele_frequencies: [.nan, 0.25, 0.25]
+      allele_frequencies: [.nan, 0.125, 0.125]
       quality: 9
       unification:
         - range: {beg: 1087554, end: 1087555}
@@ -348,7 +352,7 @@ truth_unified_sites:
           to: 2
     - range: {ref: 1, beg: 131211614, end: 131211615}
       alleles: [AG, A]
-      allele_frequencies: [.nan, 0.25]
+      allele_frequencies: [.nan, 0.125]
       quality: 85
       unification:
         - range: {beg: 131211614, end: 131211615}
@@ -368,12 +372,12 @@ truth_output_vcf:
       ##FORMAT=<ID=VR,Number=1,Type=Integer,Description="Major Variant Read Depth">
       ##FORMAT=<ID=FT,Number=1,Type=String,Description="FILTER field from sample gVCF">
       ##contig=<ID=21,length=48129895>
-      #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG002 xAtlasTester
-      1	15956	.	G	A	257	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/1:.:257,0,172:20:8:12:.:..	0/0:.:0,42,177:4:4:0:.:..
-      1	15983	.	C	T,G	257	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/2:.:257,.,.,0,.,172:20:8:12:.:..	1/1:.:257,172,0,.,.,.:20:1:19:.:..
-      1	15985	.	A	T	257	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/1:.:257,0,172:20:8:12:.:..	0/1:.:257,0,172:4:0:4:low_coverage:..
-      1	15987	.	M	C	716	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	./.:.:.:.:.:.:.:MM	1/1:.:716,75,0:26:0:26:.:..
-      1	15989	.	AG	A	659	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	./.:.:.:.:.:.:.:MM	1/1:.:659,47,0:26:1:25:.:..
-      1	1087454	.	TAA	TA,T	9	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/2:.:9,.,.,0,.,125:8:5:2:.:..	0/1:.:9,0,125,.,.,.:8:5:2:.:..
-      1	1087554	.	TAA	TA,T	9	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/2:.:9,.,.,0,.,125:8:5:2:.:..	0/1:.:9,0,125,.,.,.:8:5:2:.:..
-      1	131211614	.	AG	A	85	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	./.:.:.:.:.:.:.:MM	0/1:.:.:19:14:6:low_qual:..
+      #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG002	xAtlasTester	ythird	zfourth
+      1	15956	.	G	A	257	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/1:.:257,0,172:20:8:12:.:..	0/0:.:0,42,177:4:4:0:.:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM
+      1	15983	.	C	T,G	257	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/2:.:257,.,.,0,.,172:20:8:12:.:..	1/1:.:257,172,0,.,.,.:20:1:19:.:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM
+      1	15985	.	A	T	257	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/1:.:257,0,172:20:8:12:.:..	0/1:.:257,0,172:4:0:4:low_coverage:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM
+      1	15987	.	M	C	716	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	./.:.:.:.:.:.:.:MM	1/1:.:716,75,0:26:0:26:.:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM
+      1	15989	.	AG	A	659	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	./.:.:.:.:.:.:.:MM	1/1:.:659,47,0:26:1:25:.:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM
+      1	1087454	.	TAA	TA,T	9	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/2:.:9,.,.,0,.,125:8:5:2:.:..	0/1:.:9,0,125,.,.,.:8:5:2:.:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM
+      1	1087554	.	TAA	TA,T	9	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/2:.:9,.,.,0,.,125:8:5:2:.:..	0/1:.:9,0,125,.,.,.:8:5:2:.:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM
+      1	131211614	.	AG	A	85	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	./.:.:.:.:.:.:.:MM	0/1:.:.:19:14:6:low_qual:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM

--- a/test/data/gvcf_test_cases/xAtlas.yml
+++ b/test/data/gvcf_test_cases/xAtlas.yml
@@ -58,6 +58,7 @@ input:
         1	1087454	.	TAA	T	8	PASS	P=0.848623	GT:VR:RR:DP:GQ:PL	0/1:2:5:8:.:9,0,125
         1	1087554	.	TAA	T	8	PASS	P=0.848623	GT:VR:RR:DP:GQ:PL	0/1:2:5:8:.:9,0,125
         1	1689669	.	C	CGGCCCT	.	PASS	P=0.999618	GT:VR:RR:DP:GQ:PL	0/1:4:2:6:.:85,0,9
+        1	1689769	.	C	CC	.	PASS	P=0.999618	GT:VR:RR:DP:GQ:PL	0/1:4:2:6:.:85,0,9
     - xAtlasTester.gvcf: |
         xAtlasTester
         1	15890	.	G	.	.	PASS	END=15982;BLOCKAVG_min30p3a	GT:VR:RR:DP:GQ:PL:VRX:RRX:DPX	0/0:0:4:4:.:0,42,177:0,0,0,0:4,7,5.125,1.31022:4,7,5.125,1.31022
@@ -78,6 +79,8 @@ input:
         1	1689669	.	CGGCCCT	C	.	PASS	P=0.999618	GT:VR:RR:DP:GQ:PL	0/1:4:2:6:.:85,0,9
     - Fourth.gvcf: |
         zfourth
+        1	1689700	.	G	.	.	PASS	END=1689769;BLOCKAVG_min30p3a	GT:VR:RR:DP:GQ:PL:VRX:RRX:DPX	0/0:0:4:4:.:0,42,177:0,0,0,0:4,7,5.125,1.31022:4,7,5.125,1.31022
+        1	1689770	.	C	CC	.	PASS	P=0.999618	GT:VR:RR:DP:GQ:PL	0/1:4:2:6:.:85,0,9
 
 unifier_config:
     drop_filtered: true
@@ -310,6 +313,30 @@ truth_discovered_alleles:
       all_filtered: false
       top_AQ: [85]
       zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: "1", beg: 1689769, end: 1689769}
+      dna: 'C'
+      is_ref: true
+      all_filtered: false
+      top_AQ: [9]
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: "1", beg: 1689769, end: 1689769}
+      dna: 'CC'
+      is_ref: false
+      all_filtered: false
+      top_AQ: [85]
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: "1", beg: 1689770, end: 1689770}
+      dna: 'C'
+      is_ref: true
+      all_filtered: false
+      top_AQ: [9]
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: "1", beg: 1689770, end: 1689770}
+      dna: 'CC'
+      is_ref: false
+      all_filtered: false
+      top_AQ: [85]
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "1", beg: 131211614, end: 131211615}
       dna: 'AG'
       is_ref: true
@@ -411,6 +438,18 @@ truth_unified_sites:
         - range: {beg: 1689669, end: 1689675}
           dna: C
           to: 2
+    - range: {ref: 1, beg: 1689769, end: 1689769}
+      in_target: {ref: 1, beg: 1, end: 1000000000}
+      alleles: [C, CC]
+      allele_frequencies: [.nan, 0.25]
+      quality: 85
+      unification:
+        - range: {beg: 1689769, end: 1689769}
+          dna: CC
+          to: 1
+        - range: {beg: 1689770, end: 1689770}
+          dna: CC
+          to: 1
 
 truth_output_vcf:
   - truth.vcf: |
@@ -433,5 +472,6 @@ truth_output_vcf:
       1	15989	.	AG	A	659	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	./.:.:.:.:.:.:.:MM	1/1:.:659,47,0:26:1:25:.:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM
       1	1087454	.	TAA	TA,T	9	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/2:.:9,.,.,0,.,125:8:5:2:.:..	0/1:.:9,0,125,.,.,.:8:5:2:.:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM
       1	1087554	.	TAA	TA,T	9	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/2:.:9,.,.,0,.,125:8:5:2:.:..	0/1:.:9,0,125,.,.,.:8:5:2:.:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM
-      1	131211614	.	AG	A	85	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	./.:.:.:.:.:.:.:MM	0/1:.:.:19:14:6:low_qual:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM
       1	1689669	.	CGGCCCT	CGGCCCTGGCCCT,C	85	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/1:.:85,0,9,.,.,.:6:2:4:.:..	0/1:.:85,0,9,.,.,.:6:2:4:.:..	0/2:.:85,.,.,0,.,9:6:2:4:.:..	./.:.:.:.:.:.:.:MM
+      1	1689769	.	C	CC	85	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/1:.:85,0,9:6:2:4:.:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM	0/1:.:85,0,9:6:2:4:.:..
+      1	131211614	.	AG	A	85	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	./.:.:.:.:.:.:.:MM	0/1:.:.:19:14:6:low_qual:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM

--- a/test/data/gvcf_test_cases/xAtlas.yml
+++ b/test/data/gvcf_test_cases/xAtlas.yml
@@ -57,6 +57,7 @@ input:
         1	69216	.	G	.	.	PASS	END=69259;BLOCKAVG_min30p3a	GT:VR:RR:DP:GQ:PL:VRX:RRX:DPX	0/0:0:5:5:.:0,45,208:0,0,0,0:5,7,6.22727,0.522233:5,7,6.22727,0.522233
         1	1087454	.	TAA	T	8	PASS	P=0.848623	GT:VR:RR:DP:GQ:PL	0/1:2:5:8:.:9,0,125
         1	1087554	.	TAA	T	8	PASS	P=0.848623	GT:VR:RR:DP:GQ:PL	0/1:2:5:8:.:9,0,125
+        1	1689669	.	C	CGGCCCT	.	PASS	P=0.999618	GT:VR:RR:DP:GQ:PL	0/1:4:2:6:.:85,0,9
     - xAtlasTester.gvcf: |
         xAtlasTester
         1	15890	.	G	.	.	PASS	END=15982;BLOCKAVG_min30p3a	GT:VR:RR:DP:GQ:PL:VRX:RRX:DPX	0/0:0:4:4:.:0,42,177:0,0,0,0:4,7,5.125,1.31022:4,7,5.125,1.31022
@@ -69,10 +70,12 @@ input:
         1	1087454	.	TA	T	8	PASS	P=0.848623	GT:VR:RR:DP:GQ:PL	0/1:2:5:8:.:9,0,125
         1	1087554	.	TA	T	8	PASS	P=0.848623	GT:VR:RR:DP:GQ:PL	0/1:2:5:8:.:9,0,125
         1	1087556	.	G	.	.	PASS	END=1087656;BLOCKAVG_min30p3a	GT:VR:RR:DP:GQ:PL:VRX:RRX:DPX	0/0:0:4:4:.:0,42,177:0,0,0,0:4,7,5.125,1.31022:4,7,5.125,1.31022
+        1	1689675	.	T	TGGCCCT	.	PASS	P=0.999618	GT:VR:RR:DP:GQ:PL	0/1:4:2:6:.:85,0,9
         1	131211614	.	AG	A	10	PASS	P=0.905149	GT:VR:RR:DP:GQ:PL	0/1:6:14:21:.:85,0,344
         1	131211615	.	GGA	G	2	low_qual	P=0.366185	GT:VR:RR:DP:GQ:PL	0/0:2:16:19:.:0,24,432
     - Third.gvcf: |
         ythird
+        1	1689669	.	CGGCCCT	C	.	PASS	P=0.999618	GT:VR:RR:DP:GQ:PL	0/1:4:2:6:.:85,0,9
     - Fourth.gvcf: |
         zfourth
 
@@ -271,6 +274,42 @@ truth_discovered_alleles:
       all_filtered: false
       top_AQ: [9]
       zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: "1", beg: 1689669, end: 1689669}
+      dna: 'C'
+      is_ref: true
+      all_filtered: false
+      top_AQ: [9]
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: "1", beg: 1689669, end: 1689669}
+      dna: 'CGGCCCT'
+      is_ref: false
+      all_filtered: false
+      top_AQ: [85]
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: "1", beg: 1689669, end: 1689675}
+      dna: 'CGGCCCT'
+      is_ref: true
+      all_filtered: false
+      top_AQ: [9]
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: "1", beg: 1689669, end: 1689675}
+      dna: 'C'
+      is_ref: false
+      all_filtered: false
+      top_AQ: [85]
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: "1", beg: 1689675, end: 1689675}
+      dna: 'T'
+      is_ref: true
+      all_filtered: false
+      top_AQ: [9]
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
+    - range: {ref: "1", beg: 1689675, end: 1689675}
+      dna: 'TGGCCCT'
+      is_ref: false
+      all_filtered: false
+      top_AQ: [85]
+      zygosity_by_GQ: [[1,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]
     - range: {ref: "1", beg: 131211614, end: 131211615}
       dna: 'AG'
       is_ref: true
@@ -358,6 +397,20 @@ truth_unified_sites:
         - range: {beg: 131211614, end: 131211615}
           dna: A
           to: 1
+    - range: {ref: 1, beg: 1689669, end: 1689675}
+      alleles: [CGGCCCT, CGGCCCTGGCCCT, C]
+      allele_frequencies: [.nan, 0.25, 0.125]
+      quality: 85
+      unification:
+        - range: {beg: 1689669, end: 1689669}
+          dna: CGGCCCT
+          to: 1
+        - range: {beg: 1689675, end: 1689675}
+          dna: TGGCCCT
+          to: 1
+        - range: {beg: 1689669, end: 1689675}
+          dna: C
+          to: 2
 
 truth_output_vcf:
   - truth.vcf: |
@@ -381,3 +434,4 @@ truth_output_vcf:
       1	1087454	.	TAA	TA,T	9	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/2:.:9,.,.,0,.,125:8:5:2:.:..	0/1:.:9,0,125,.,.,.:8:5:2:.:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM
       1	1087554	.	TAA	TA,T	9	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/2:.:9,.,.,0,.,125:8:5:2:.:..	0/1:.:9,0,125,.,.,.:8:5:2:.:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM
       1	131211614	.	AG	A	85	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	./.:.:.:.:.:.:.:MM	0/1:.:.:19:14:6:low_qual:..	./.:.:.:.:.:.:.:MM	./.:.:.:.:.:.:.:MM
+      1	1689669	.	CGGCCCT	CGGCCCTGGCCCT,C	85	.	.	GT:GQ:PL:DP:RR:VR:FT:RNC	0/1:.:85,0,9,.,.,.:6:2:4:.:..	0/1:.:85,0,9,.,.,.:6:2:4:.:..	0/2:.:85,.,.,0,.,9:6:2:4:.:..	./.:.:.:.:.:.:.:MM

--- a/testOutputVcf.py
+++ b/testOutputVcf.py
@@ -136,7 +136,7 @@ def compare_vcf_row(i_row, t_row, info_fs, format_fs):
     assert(range(i_row) == range(t_row))
 
     # Expect comparison for identical samples
-    assert([x.sample for x in i_row.samples] == [x.sample for x in t_row.samples])
+    assert [x.sample for x in i_row.samples] == [x.sample for x in t_row.samples], (str(i_row.samples) + ' / ' + str(t_row.samples))
     if (i_row.REF != t_row.REF):
         WARNING("Found differing ref! {0} {1}".format(i_row.REF, t_row.REF))
         return (i_row, t_row)


### PR DESCRIPTION
Unifier recognizes equivalent indels represented with different positions (e.g. affecting tandem repeats), in those cases where the representations are either overlapping, abutting, or spanned by some third allele. They are collapsed into the leftmost representation observed. The genotyper is adjusted slightly to ensure it gets such non-aligned indel records from the database, as their positions might not even overlap the unified site.

Limitations:

1. Doesn't recognize non-left-aligned indels other than the aforementioned cases. Equivalent representations can theoretically be far apart (in homopolymer or tandem repeats) which is difficult to handle at this stage.  
2. Doesn't necessarily produce the most left-aligned possible representation; rather, collapses into the most left-aligned version actually present in the gVCF corpus.

So, we still must strongly recommend the upstream gVCF caller left-align discovered indels.