### PR TITLE
capnproto 0.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ set(SPDLOG_INCLUDE_DIR ${source_dir}/include)
 include_directories(${SPDLOG_INCLUDE_DIR})
 
 ExternalProject_Add(capnp
-    URL https://capnproto.org/capnproto-c++-0.6.1.tar.gz
+    URL https://capnproto.org/capnproto-c++-0.7.0.tar.gz
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external
     CONFIGURE_COMMAND ./configure --prefix=${CMAKE_BINARY_DIR}/external
     BUILD_IN_SOURCE 1

--- a/src/BCFKeyValueData.cc
+++ b/src/BCFKeyValueData.cc
@@ -467,13 +467,14 @@ static Status ScanBCFBucket(const range& bucket, const string& dataset,
     //             https://github.com/capnproto/capnproto/issues/313
     //             https://lemire.me/blog/2012/05/31/data-alignment-for-speed-myth-or-reality/
     //             http://pzemtsov.github.io/2016/11/06/bug-story-alignment-on-x86.html
+    //             https://github.com/capnproto/capnproto/commit/3aa2b2aa02edb1c160b154ad74c08c929a02512a
     #ifndef __x86_64__
     if (uint64_t(data.data) % sizeof(::capnp::word)) {
          return Status::Failure("BCFBucketReader: input buffer isn't word-aligned");
     }
     #endif
     try {
-        ::capnp::FlatArrayMessageReader message(kj::ArrayPtr<const ::capnp::word>((::capnp::word*)data.data, data.size / sizeof(::capnp::word)));
+        ::capnp::UnalignedFlatArrayMessageReader message(kj::ArrayPtr<const ::capnp::word>((::capnp::word*)data.data, data.size / sizeof(::capnp::word)));
         capnp::BCFBucket::Reader bucket_reader = message.getRoot<capnp::BCFBucket>();
 
         // Scan: begin at a position informed by the 'skip index'

--- a/src/BCFKeyValueData_utils.h
+++ b/src/BCFKeyValueData_utils.h
@@ -229,7 +229,7 @@ public:
                 for (int ofs = 0; ofs < alignments_to_test; ofs++) {
                     auto buf = (uint8_t*) calloc(ans.size() + ofs, 1);
                     memcpy(buf+ofs, ans.data(), ans.size());
-                    ::capnp::FlatArrayMessageReader message(kj::ArrayPtr<const ::capnp::word>((::capnp::word*)(buf+ofs), ans.size() / sizeof(::capnp::word)));
+                    ::capnp::UnalignedFlatArrayMessageReader message(kj::ArrayPtr<const ::capnp::word>((::capnp::word*)(buf+ofs), ans.size() / sizeof(::capnp::word)));
                     capnp::BCFBucket::Reader bucket_reader = message.getRoot<capnp::BCFBucket>();
                     auto records = bucket_reader.getRecords();
                     assert(records.size() == records_.size());


### PR DESCRIPTION
capnproto added its own memory-alignment check, and a way around it, which we now use since we have our own checks.