### PR TITLE
check symbolic allele without std::regex_match

### DIFF
--- a/src/BCFKeyValueData_utils.h
+++ b/src/BCFKeyValueData_utils.h
@@ -365,15 +365,17 @@ static Status validate_bcf(BCFBucketRange& rangeHelper,
 
     // check that alleles are all distinct, and that all alleles are valid strings
     // of IUPAC nucleotides, except the last ALT allele which may be symbolic.
+    set<string> alleles;
     for (int i=0; i < bcf->n_allele; i++) {
-        const char* allele_i = bcf->d.allele[i];
+        const string allele_i(bcf->d.allele[i]);
         if (!(is_iupac_nucleotides(allele_i) ||
-              (i == bcf->n_allele-1 && is_symbolic_allele(allele_i)))) {
+              (i == bcf->n_allele-1 && is_symbolic_allele(allele_i.c_str())))) {
             return Status::Invalid("allele is not a DNA sequence ",
                                 filename + " " + allele_i +  " " + range(bcf).str(contigs));
         }
+        alleles.insert(allele_i);
     }
-    if (bcf->n_allele<1) {
+    if (bcf->n_allele<1 || alleles.size() != bcf->n_allele) {
         return Status::Invalid("alleles are not distinct ", filename + " " + range(bcf).str(contigs));
     }
 

--- a/src/BCFKeyValueData_utils.h
+++ b/src/BCFKeyValueData_utils.h
@@ -365,17 +365,15 @@ static Status validate_bcf(BCFBucketRange& rangeHelper,
 
     // check that alleles are all distinct, and that all alleles are valid strings
     // of IUPAC nucleotides, except the last ALT allele which may be symbolic.
-    set<string> alleles;
     for (int i=0; i < bcf->n_allele; i++) {
-        const string allele_i(bcf->d.allele[i]);
+        const char* allele_i = bcf->d.allele[i];
         if (!(is_iupac_nucleotides(allele_i) ||
-              (i == bcf->n_allele-1 && is_symbolic_allele(allele_i.c_str())))) {
+              (i == bcf->n_allele-1 && is_symbolic_allele(allele_i)))) {
             return Status::Invalid("allele is not a DNA sequence ",
                                 filename + " " + allele_i +  " " + range(bcf).str(contigs));
         }
-        alleles.insert(allele_i);
     }
-    if (bcf->n_allele<1 || alleles.size() != bcf->n_allele) {
+    if (bcf->n_allele<1) {
         return Status::Invalid("alleles are not distinct ", filename + " " + range(bcf).str(contigs));
     }
 

--- a/src/types.cc
+++ b/src/types.cc
@@ -923,9 +923,8 @@ Status genotyper_config::of_yaml(const YAML::Node& yaml, genotyper_config& ans) 
 }
 
 // regex for a VCF symbolic allele
-static std::regex regex_symbolic_allele("<.*>");
 bool is_symbolic_allele(const char* allele) {
-    return regex_match(allele, regex_symbolic_allele);
+    return allele[0] == '<' && allele[strlen(allele) - 1] == '>';
 }
 
 // gVCF reference confidence records recognized as having either:

--- a/src/types.cc
+++ b/src/types.cc
@@ -924,7 +924,8 @@ Status genotyper_config::of_yaml(const YAML::Node& yaml, genotyper_config& ans) 
 
 // regex for a VCF symbolic allele
 bool is_symbolic_allele(const char* allele) {
-    return allele[0] == '<' && allele[strlen(allele) - 1] == '>';
+  size_t len = strlen(allele);
+  return len > 1 && allele[0] == '<' && allele[len - 1] == '>';
 }
 
 // gVCF reference confidence records recognized as having either:


### PR DESCRIPTION
Implementations of std::regex_match can be slow and memory inefficient. We can use character comparisons for is_symbolic_allele(). This speeds up GLnexus's bulk import stage in my local development setup.