### PR TITLE
Bug Fix - min_AQ1 is ignored when min_AQ2 is set to zero

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -289,7 +289,7 @@ struct top_AQ {
     }
 
     void clear() {
-        memset(&V, 0, sizeof(int)*COUNT);
+        memset(&V, -1, sizeof(int)*COUNT);
         addbuf.clear();
     }
 

--- a/src/unifier.cc
+++ b/src/unifier.cc
@@ -236,7 +236,7 @@ bool check_filtered(const unifier_config& cfg, const minimized_allele& al) {
 }
 
 bool check_AQ(const unifier_config& cfg, const minimized_allele& al) {
-    return (al.second.topAQ.V[0] >= cfg.min_AQ1 || (al.second.copy_number > 1U && al.second.topAQ.V[1] >= cfg.min_AQ2));
+    return (al.second.topAQ.V[0] >= cfg.min_AQ1 || al.second.topAQ.V[1] >= cfg.min_AQ2);
 }
 
 bool check_copy_number(const unifier_config& cfg, const minimized_allele& al) {

--- a/src/unifier.cc
+++ b/src/unifier.cc
@@ -236,7 +236,7 @@ bool check_filtered(const unifier_config& cfg, const minimized_allele& al) {
 }
 
 bool check_AQ(const unifier_config& cfg, const minimized_allele& al) {
-    return (al.second.topAQ.V[0] >= cfg.min_AQ1 || al.second.topAQ.V[1] >= cfg.min_AQ2);
+    return (al.second.topAQ.V[0] >= cfg.min_AQ1 || (al.second.copy_number > 1U && al.second.topAQ.V[1] >= cfg.min_AQ2));
 }
 
 bool check_copy_number(const unifier_config& cfg, const minimized_allele& al) {


### PR DESCRIPTION
My name is Ted Yun and I'm in Genomics team at Google. My coworkers and I have found that when GLnexus is run with the two different set of parameters: `min_AQ1 = 30, min_AQ2 = 0` and `min_AQ1 = 0, min_AQ2 = 0`, it produces identical results.

I believe the issue is coming from this part of the code where `check_AQ` always returns true when `cfg.min_AQ2 = 0` (regardless of the `cfg.min_AQ1` value), because `al.second.topAQ.V[1]` value is initialized to zero. The suggested changes here check the second inequality only if the copy number of the allele is at least two, which I believe is the definition of the min_AQ2 config.

Please take a look. Thank you!

Regards,
Ted