### PR TITLE
Dockerfile: use source tree in build context instead of cloning from GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
       if [ "$effective_build_type" == "Valgrind" ]; then
         effective_build_type="Release"
       fi
-      cat Dockerfile | docker build --no-cache -t glnexus_tests --build-arg git_revision=$TRAVIS_COMMIT --build-arg build_type=$effective_build_type -
+      docker build --no-cache -t glnexus_tests --build-arg build_type=$effective_build_type .
       # copy the /GLnexus folder out of the image to mount for subsequent use
       docker run --rm -v /:/io glnexus_tests cp -r /GLnexus/ /io
       # Run the tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@
 # executable which can be copied out.
 FROM ubuntu:18.04
 MAINTAINER DNAnexus
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
-ARG git_revision=master
 ARG build_type=Release
 
 # dependencies
@@ -15,11 +16,9 @@ RUN apt-get -qq update && \
      libjemalloc-dev libzip-dev libsnappy-dev libbz2-dev zlib1g-dev liblzma-dev libzstd-dev \
      python-pyvcf
 
-# clone GLnexus repo on the desired git revision
-WORKDIR /
-RUN git clone https://github.com/dnanexus-rnd/GLnexus.git
+# Copy in the local source tree / build context
+ADD . /GLnexus
 WORKDIR /GLnexus
-RUN git fetch --tags origin && git checkout "$git_revision" && git submodule update --init --recursive
 
 # compile GLnexus
 RUN cmake -DCMAKE_BUILD_TYPE=$build_type . && make -j4

--- a/README.md
+++ b/README.md
@@ -21,10 +21,13 @@ For each tagged revision, the [Releases](https://github.com/dnanexus-rnd/GLnexus
 The GLnexus build process has a number of dependencies, but produces a standalone, statically-linked executable `glnexus_cli`. The easiest way to build it is to use our Dockerfile to control all the compile-time dependencies, then simply copy the static executable out of the resting Docker container and put it anywhere you like. 
 
 ```
-# Build GLnexus using its Dockerfile.
-# You can set a specific git revision by adding --build-arg=git_revision=xxxx
-curl -s https://raw.githubusercontent.com/dnanexus-rnd/GLnexus/master/Dockerfile \
-    | docker build --no-cache -t glnexus_tests -
+# Clone repo
+git clone https://github.com/dnanexus-rnd/GLnexus.git
+cd GLnexus
+git checkout vX.Y.Z  # optional, check out desired revision
+
+# Build GLnexus in docker
+docker build --no-cache -t glnexus_tests .
 
 # Run GLnexus unit tests.
 docker run --rm glnexus_tests
@@ -41,7 +44,7 @@ docker run --rm -v $(pwd):/io glnexus_tests cp glnexus_cli /io
 Then,
 
 ```
-git clone --recursive https://github.com/dnanexus-rnd/GLnexus.git
+git clone https://github.com/dnanexus-rnd/GLnexus.git
 cd GLnexus
 cmake -Dtest=ON . && make -j$(nproc) && ctest -V
 ```


### PR DESCRIPTION
to fix travis build for pull requests (#149)