### PR TITLE
Use const std::shared_ptr<const bcf_hdr_t>& in BCFData::dataset_range

### DIFF
--- a/include/BCFKeyValueData.h
+++ b/include/BCFKeyValueData.h
@@ -51,7 +51,8 @@ public:
     // BCFData
     Status dataset_header(const std::string& dataset,
                               std::shared_ptr<const bcf_hdr_t>& hdr) override;
-    Status dataset_range(const std::string& dataset, const bcf_hdr_t* hdr,
+    Status dataset_range(const std::string& dataset,
+                         const std::shared_ptr<const bcf_hdr_t>& hdr,
                          const range& pos, bcf_predicate predicate,
                          std::vector<std::shared_ptr<bcf1_t> >& records) override;
 

--- a/include/data.h
+++ b/include/data.h
@@ -126,7 +126,8 @@ public:
     /// unpacked again by the dataset_range function.
     ///
     /// The provided header must match the data set, otherwise the behavior is undefined!
-    virtual Status dataset_range(const std::string& dataset, const bcf_hdr_t* hdr,
+    virtual Status dataset_range(const std::string& dataset,
+                                 const std::shared_ptr<const bcf_hdr_t>& hdr,
                                  const range& pos, bcf_predicate predicate,
                                  std::vector<std::shared_ptr<bcf1_t> >& records) = 0;
 

--- a/src/BCFKeyValueData.cc
+++ b/src/BCFKeyValueData.cc
@@ -522,7 +522,7 @@ static Status ScanBCFBucket(const range& bucket, const string& dataset,
 // found. If an invalid rid is requested, the return value will be an
 // empty list.
 Status BCFKeyValueData::dataset_range(const string& dataset,
-                                      const bcf_hdr_t* hdr,
+                                      const std::shared_ptr<bcf_hdr_t>& hdr,
                                       const range& query,
                                       bcf_predicate predicate,
                                       vector<shared_ptr<bcf1_t> >& records) {

--- a/src/data.cc
+++ b/src/data.cc
@@ -117,7 +117,7 @@ Status BCFData::dataset_range_and_header(const string& dataset, const range& pos
                                          vector<shared_ptr<bcf1_t> >& records) {
     Status s;
     S(dataset_header(dataset, hdr));
-    return dataset_range(dataset, hdr.get(), pos, predicate, records);
+    return dataset_range(dataset, hdr, pos, predicate, records);
 }
 
 // default sampleset_range implementation:

--- a/test/BCFKeyValueData.cc
+++ b/test/BCFKeyValueData.cc
@@ -559,7 +559,7 @@ TEST_CASE("BCFKeyValueData BCF retrieval") {
         s = data->dataset_header("NA12878D", hdr);
         REQUIRE(s.ok());
         vector<shared_ptr<bcf1_t>> records;
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000000000), nullptr, records);
+        s = data->dataset_range("NA12878D", hdr, range(0, 0, 1000000000), nullptr, records);
         REQUIRE(s.ok());
 
         REQUIRE(records.size() == 5);
@@ -587,7 +587,7 @@ TEST_CASE("BCFKeyValueData BCF retrieval") {
         REQUIRE(bcf_get_info(hdr.get(), records[4].get(), "END")->v1.i == 10009471); // nb END stays 1-based!
 
         // subset of records
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 10009463, 10009466), nullptr, records);
+        s = data->dataset_range("NA12878D", hdr, range(0, 10009463, 10009466), nullptr, records);
         REQUIRE(s.ok());
 
         REQUIRE(records.size() == 2);
@@ -608,7 +608,7 @@ TEST_CASE("BCFKeyValueData BCF retrieval") {
             retval = (bcf->n_allele >= 3);
             return Status::OK();
         };
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000000000), predicate, records);
+        s = data->dataset_range("NA12878D", hdr, range(0, 0, 1000000000), predicate, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 1);
 
@@ -619,15 +619,15 @@ TEST_CASE("BCFKeyValueData BCF retrieval") {
         REQUIRE(string(records[0]->d.allele[2]) == "<NON_REF>");
 
         // empty results
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000), nullptr, records);
+        s = data->dataset_range("NA12878D", hdr, range(0, 0, 1000), nullptr, records);
         REQUIRE((records.size() == 0));
 
-        s = data->dataset_range("NA12878D", hdr.get(), range(1, 10009463, 10009466), nullptr, records);
+        s = data->dataset_range("NA12878D", hdr, range(1, 10009463, 10009466), nullptr, records);
         //REQUIRE(s == StatusCode::NOT_FOUND);
         REQUIRE((records.size() == 0));
 
         // bogus dataset
-        s = data->dataset_range("bogus", hdr.get(), range(1, 10009463, 10009466), nullptr, records);
+        s = data->dataset_range("bogus", hdr, range(1, 10009463, 10009466), nullptr, records);
         //REQUIRE(s == StatusCode::NOT_FOUND);
         REQUIRE((records.size() == 0));
     }
@@ -668,7 +668,7 @@ TEST_CASE("BCFKeyValueData range overlap with a single dataset") {
            |<-A1->)       |<-A2->)
            Expected result: empty set
         */
-        s = data->dataset_range("synth_A", hdr.get(), range(0, 1005, 1010), nullptr, records);
+        s = data->dataset_range("synth_A", hdr, range(0, 1005, 1010), nullptr, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 0);
 
@@ -678,7 +678,7 @@ TEST_CASE("BCFKeyValueData range overlap with a single dataset") {
            |<-A2->)  |<-A4->)
            Expected result: {A1, A2, A3}
         */
-        s = data->dataset_range("synth_A", hdr.get(), range(0, 2003, 2006), nullptr, records);
+        s = data->dataset_range("synth_A", hdr, range(0, 2003, 2006), nullptr, records);
         REQUIRE(s.ok());
 //        for (auto r : records) {
 //            cout << "r= " << r->rid << "," << r->pos << "," << r->rlen << "," << r->shared.s  << endl;
@@ -693,7 +693,7 @@ TEST_CASE("BCFKeyValueData range overlap with a single dataset") {
           |<-A3->)
           Expected result: {A1, A2, A3}
         */
-        s = data->dataset_range("synth_A", hdr.get(), range(0, 3004, 3006), nullptr, records);
+        s = data->dataset_range("synth_A", hdr, range(0, 3004, 3006), nullptr, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 3);
 
@@ -737,7 +737,7 @@ TEST_CASE("BCFKeyValueData long_confidence_intervals") {
 
         // only reference confidence records are supposed to show up in these queries
         vector<shared_ptr<bcf1_t>> records;
-        s = data->dataset_range("long_ref", hdr.get(), range(0, 1020, 1030), nullptr, records);
+        s = data->dataset_range("long_ref", hdr, range(0, 1020, 1030), nullptr, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 1);
         REQUIRE(records[0]->pos == 1016);
@@ -745,23 +745,23 @@ TEST_CASE("BCFKeyValueData long_confidence_intervals") {
         REQUIRE(string(records[0]->d.allele[0]) == "A");
         REQUIRE(string(records[0]->d.allele[1]) == "<NON_REF>");
 
-        s = data->dataset_range("long_ref", hdr.get(), range(0, 2100, 2900), nullptr, records);
+        s = data->dataset_range("long_ref", hdr, range(0, 2100, 2900), nullptr, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 1);
         REQUIRE(records[0]->pos == 2009);
         REQUIRE(string(records[0]->d.allele[0]) == "C");
 
         // Several records are supposed to appear
-        s = data->dataset_range("long_ref", hdr.get(), range(0, 2800, 3010), nullptr, records);
+        s = data->dataset_range("long_ref", hdr, range(0, 2800, 3010), nullptr, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 5);
 
-        s = data->dataset_range("long_ref", hdr.get(), range(0, 1004, 3000), nullptr, records);
+        s = data->dataset_range("long_ref", hdr, range(0, 1004, 3000), nullptr, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 8);
 
         // long record is last
-        s = data->dataset_range("long_ref", hdr.get(), range(0, 3000, 4000), nullptr, records);
+        s = data->dataset_range("long_ref", hdr, range(0, 3000, 4000), nullptr, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 5);
     }
@@ -807,27 +807,27 @@ TEST_CASE("BCFKeyValueData long_confidence_intervals 2") {
         REQUIRE(s.ok());
 
         vector<shared_ptr<bcf1_t>> records;
-        s = data->dataset_range("B", hdr.get(), range(0, 1000, 1108), nullptr, records);
+        s = data->dataset_range("B", hdr, range(0, 1000, 1108), nullptr, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 1);
 
-        s = data->dataset_range("B", hdr.get(), range(0, 3000, 4000), nullptr, records);
+        s = data->dataset_range("B", hdr, range(0, 3000, 4000), nullptr, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 5);
 
-        s = data->dataset_range("B", hdr.get(), range(0, 5000, 5010), nullptr, records);
+        s = data->dataset_range("B", hdr, range(0, 5000, 5010), nullptr, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 2);
         REQUIRE(records[0]->pos == 3198);
         REQUIRE(string(records[0]->d.allele[0]) == "C");
 
-        s = data->dataset_range("B", hdr.get(), range(0, 6000, 6005), nullptr, records);
+        s = data->dataset_range("B", hdr, range(0, 6000, 6005), nullptr, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 1);
         REQUIRE(records[0]->pos == 4002);
         REQUIRE(string(records[0]->d.allele[0]) == "C");
 
-        s = data->dataset_range("B", hdr.get(), range(0, 8000, 10000), nullptr, records);
+        s = data->dataset_range("B", hdr, range(0, 8000, 10000), nullptr, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 0);
     }
@@ -910,7 +910,7 @@ TEST_CASE("BCFData::sampleset_range") {
     vector<shared_ptr<bcf1_t>> records, all_records;
     s = iterators[0]->next(dataset, hdr, records);
     REQUIRE(s.ok());
-    #define check() s = data->dataset_range(dataset, hdr.get(), range(0,0,1000000), nullptr, all_records); \
+    #define check() s = data->dataset_range(dataset, hdr, range(0,0,1000000), nullptr, all_records); \
                     REQUIRE(s.ok()); \
                     REQUIRE(records.size() <= count_if(all_records.begin(), all_records.end(), [&](shared_ptr<bcf1_t>& r){return rng.overlaps(r.get());})); \
                     REQUIRE(all_of(records.begin(), records.end(), [&](shared_ptr<bcf1_t>& r){return rng.overlaps(r.get());}))
@@ -1115,7 +1115,7 @@ TEST_CASE("BCFKeyValueData::sampleset_range") {
     shared_ptr<const bcf_hdr_t> hdr;
     vector<shared_ptr<bcf1_t>> records, all_records;
 
-     #define check() s = data->dataset_range(dataset, hdr.get(), range(0,0,10000000), nullptr, all_records); \
+     #define check() s = data->dataset_range(dataset, hdr, range(0,0,10000000), nullptr, all_records); \
                     REQUIRE(s.ok()); \
                     REQUIRE(records.size() <= count_if(all_records.begin(), all_records.end(), [&](shared_ptr<bcf1_t>& r){return rng.overlaps(r.get());})); \
                     REQUIRE(all_of(records.begin(), records.end(), [&](shared_ptr<bcf1_t>& r){return rng.overlaps(r.get());}))

--- a/test/rocks_integration.cc
+++ b/test/rocks_integration.cc
@@ -280,7 +280,7 @@ TEST_CASE("RocksDB BCF retrieval") {
         s = data->dataset_header("NA12878D", hdr);
         REQUIRE(s.ok());
         vector<shared_ptr<bcf1_t>> records;
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000000000), 0, records);
+        s = data->dataset_range("NA12878D", hdr, range(0, 0, 1000000000), 0, records);
         REQUIRE(s.ok());
 
         REQUIRE(records.size() == 5);
@@ -308,7 +308,7 @@ TEST_CASE("RocksDB BCF retrieval") {
         REQUIRE(bcf_get_info(hdr.get(), records[4].get(), "END")->v1.i == 10009471); // nb END stays 1-based!
 
         // subset of records
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 10009463, 10009466), 0, records);
+        s = data->dataset_range("NA12878D", hdr, range(0, 10009463, 10009466), 0, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 2);
         std::shared_ptr<StatsRangeQuery> srq = data->getRangeStats();
@@ -328,15 +328,15 @@ TEST_CASE("RocksDB BCF retrieval") {
         REQUIRE(string(records[1]->d.allele[1]) == "<NON_REF>");
 
         // empty results
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000), 0, records);
+        s = data->dataset_range("NA12878D", hdr, range(0, 0, 1000), 0, records);
         REQUIRE(records.size() == 0);
 
-        s = data->dataset_range("NA12878D", hdr.get(), range(1, 10009463, 10009466), 0, records);
+        s = data->dataset_range("NA12878D", hdr, range(1, 10009463, 10009466), 0, records);
         //REQUIRE(s == StatusCode::NOT_FOUND);
         REQUIRE(records.size() == 0);
 
         // bogus dataset
-        s = data->dataset_range("bogus", hdr.get(), range(1, 10009463, 10009466), 0, records);
+        s = data->dataset_range("bogus", hdr, range(1, 10009463, 10009466), 0, records);
         //REQUIRE(s == StatusCode::NOT_FOUND);
         REQUIRE(records.size() == 0);
 
@@ -373,7 +373,7 @@ TEST_CASE("RocksKeyValue prefix mode") {
         vector<shared_ptr<bcf1_t>> records;
 
         // subset of records
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 10009463, 10009466), 0, records);
+        s = data->dataset_range("NA12878D", hdr, range(0, 10009463, 10009466), 0, records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 2);
 
@@ -389,14 +389,14 @@ TEST_CASE("RocksKeyValue prefix mode") {
         REQUIRE(string(records[1]->d.allele[1]) == "<NON_REF>");
 
         // empty results
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000), 0, records);
+        s = data->dataset_range("NA12878D", hdr, range(0, 0, 1000), 0, records);
         REQUIRE(records.size() == 0);
 
-        s = data->dataset_range("NA12878D", hdr.get(), range(1, 10009463, 10009466), 0, records);
+        s = data->dataset_range("NA12878D", hdr, range(1, 10009463, 10009466), 0, records);
         REQUIRE(records.size() == 0);
 
         // bogus dataset
-        s = data->dataset_range("bogus", hdr.get(), range(1, 10009463, 10009466), 0, records);
+        s = data->dataset_range("bogus", hdr, range(1, 10009463, 10009466), 0, records);
         REQUIRE(records.size() == 0);
 
     }
@@ -442,12 +442,12 @@ static void queryDataset(T *data, const std::string &dataset) {
     Status s = data->dataset_header(dataset, hdr);
 
     vector<shared_ptr<bcf1_t>> records;
-    s = data->dataset_range(dataset, hdr.get(), range(0, 1005, 1010), 0,
+    s = data->dataset_range(dataset, hdr, range(0, 1005, 1010), 0,
                             records);
     assert(s.ok());
     assert(records.size() == 0);
 
-    s = data->dataset_range(dataset, hdr.get(), range(0, 2003, 2006), 0,
+    s = data->dataset_range(dataset, hdr, range(0, 2003, 2006), 0,
                             records);
     assert(s.ok());
     assert(records.size() == 3);

--- a/test/service.cc
+++ b/test/service.cc
@@ -33,8 +33,11 @@ public:
         return inner_.dataset_header(dataset, hdr);
     }
 
-    Status dataset_range(const string& dataset, const bcf_hdr_t *hdr, const range& pos,
-                         bcf_predicate predicate, vector<shared_ptr<bcf1_t> >& records) override {
+    Status dataset_range(const string& dataset,
+                         const std::shared_ptr<const bcf_hdr_t>& hdr,
+                         const range& pos,
+                         bcf_predicate predicate,
+                         vector<shared_ptr<bcf1_t> >& records) override {
         if (i_++ % fail_every_ == 0) {
             failed_once_ = true;
             return Status::IOError("SIM");

--- a/test/utils.cc
+++ b/test/utils.cc
@@ -180,7 +180,8 @@ public:
         return Status::OK();
     }
 
-    Status dataset_range(const string& dataset, const bcf_hdr_t *hdr,
+    Status dataset_range(const string& dataset,
+                         const std::shared_ptr<const bcf_hdr_t>& hdr,
                          const range& pos, bcf_predicate predicate,
                          vector<shared_ptr<bcf1_t> >& records) override {
         Status s;


### PR DESCRIPTION
Pass hdr as a const std::shared_ptr reference will allow implementation
to retain a ref count to the hdr pointer.