### PR TITLE
Avoid using non-const function params in a few places

### DIFF
--- a/include/BCFKeyValueData.h
+++ b/include/BCFKeyValueData.h
@@ -50,10 +50,10 @@ public:
 
     // BCFData
     Status dataset_header(const std::string& dataset,
-                              std::shared_ptr<const bcf_hdr_t>& hdr) override;
+                          std::shared_ptr<const bcf_hdr_t>* hdr) override;
     Status dataset_range(const std::string& dataset, const bcf_hdr_t* hdr,
                          const range& pos, bcf_predicate predicate,
-                         std::vector<std::shared_ptr<bcf1_t> >& records) override;
+                         std::vector<std::shared_ptr<bcf1_t>>* records) override;
 
     Status sampleset_range(const MetadataCache& metadata, const std::string& sampleset,
                            const range& pos, bcf_predicate predicate,

--- a/include/data.h
+++ b/include/data.h
@@ -101,7 +101,7 @@ public:
 
     /// Retrieve the BCF header for a data set.
     virtual Status dataset_header(const std::string& dataset,
-                                  std::shared_ptr<const bcf_hdr_t>& hdr) = 0;
+                                  std::shared_ptr<const bcf_hdr_t>* hdr) = 0;
 
     /// Retrieve all BCF records in the data set overlapping a range.
     ///
@@ -128,14 +128,14 @@ public:
     /// The provided header must match the data set, otherwise the behavior is undefined!
     virtual Status dataset_range(const std::string& dataset, const bcf_hdr_t* hdr,
                                  const range& pos, bcf_predicate predicate,
-                                 std::vector<std::shared_ptr<bcf1_t> >& records) = 0;
+                                 std::vector<std::shared_ptr<bcf1_t>>* records) = 0;
 
     /// Wrapper for dataset_range which first fetches the appropriate header
     /// (useful if the caller doesn't already have the header in hand)
     virtual Status dataset_range_and_header(const std::string& dataset,
                                             const range& pos, bcf_predicate predicate,
-                                            std::shared_ptr<const bcf_hdr_t>& hdr,
-                                            std::vector<std::shared_ptr<bcf1_t> >& records);
+                                            std::shared_ptr<const bcf_hdr_t>* hdr,
+                                            std::vector<std::shared_ptr<bcf1_t>>* records);
 
     /// Get iterators for BCF records overlapping the given range in all
     /// datasets containing at least one sample in the designated sample set.

--- a/src/data.cc
+++ b/src/data.cc
@@ -113,11 +113,11 @@ Status MetadataCache::sampleset_datasets(const string& sampleset,
 }
 
 Status BCFData::dataset_range_and_header(const string& dataset, const range& pos, bcf_predicate predicate,
-                                         shared_ptr<const bcf_hdr_t>& hdr,
-                                         vector<shared_ptr<bcf1_t> >& records) {
+                                         shared_ptr<const bcf_hdr_t>* hdr,
+                                         vector<shared_ptr<bcf1_t>>* records) {
     Status s;
     S(dataset_header(dataset, hdr));
-    return dataset_range(dataset, hdr.get(), pos, predicate, records);
+    return dataset_range(dataset, hdr->get(), pos, predicate, records);
 }
 
 // default sampleset_range implementation:
@@ -147,7 +147,7 @@ public:
         dataset = *it_++;
 
         vector<shared_ptr<bcf1_t>> all_records;
-        Status s = data_.dataset_range_and_header(dataset, range_, predicate_, hdr, all_records);
+        Status s = data_.dataset_range_and_header(dataset, range_, predicate_, &hdr, &all_records);
         if (s.bad()) {
              if (s == StatusCode::NOT_FOUND) {
                 // censor this error so caller doesn't think this is the normal

--- a/test/BCFKeyValueData.cc
+++ b/test/BCFKeyValueData.cc
@@ -541,7 +541,7 @@ TEST_CASE("BCFKeyValueData BCF retrieval") {
 
     SECTION("dataset_header") {
         shared_ptr<const bcf_hdr_t> hdr;
-        s = data->dataset_header("NA12878D", hdr);
+        s = data->dataset_header("NA12878D", &hdr);
         REQUIRE(s.ok());
 
         vector<string> samples;
@@ -556,10 +556,10 @@ TEST_CASE("BCFKeyValueData BCF retrieval") {
     SECTION("dataset_range") {
         // get all records
         shared_ptr<const bcf_hdr_t> hdr;
-        s = data->dataset_header("NA12878D", hdr);
+        s = data->dataset_header("NA12878D", &hdr);
         REQUIRE(s.ok());
         vector<shared_ptr<bcf1_t>> records;
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000000000), nullptr, records);
+        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000000000), nullptr, &records);
         REQUIRE(s.ok());
 
         REQUIRE(records.size() == 5);
@@ -587,7 +587,7 @@ TEST_CASE("BCFKeyValueData BCF retrieval") {
         REQUIRE(bcf_get_info(hdr.get(), records[4].get(), "END")->v1.i == 10009471); // nb END stays 1-based!
 
         // subset of records
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 10009463, 10009466), nullptr, records);
+        s = data->dataset_range("NA12878D", hdr.get(), range(0, 10009463, 10009466), nullptr, &records);
         REQUIRE(s.ok());
 
         REQUIRE(records.size() == 2);
@@ -608,7 +608,7 @@ TEST_CASE("BCFKeyValueData BCF retrieval") {
             retval = (bcf->n_allele >= 3);
             return Status::OK();
         };
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000000000), predicate, records);
+        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000000000), predicate, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 1);
 
@@ -619,15 +619,15 @@ TEST_CASE("BCFKeyValueData BCF retrieval") {
         REQUIRE(string(records[0]->d.allele[2]) == "<NON_REF>");
 
         // empty results
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000), nullptr, records);
+        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000), nullptr, &records);
         REQUIRE((records.size() == 0));
 
-        s = data->dataset_range("NA12878D", hdr.get(), range(1, 10009463, 10009466), nullptr, records);
+        s = data->dataset_range("NA12878D", hdr.get(), range(1, 10009463, 10009466), nullptr, &records);
         //REQUIRE(s == StatusCode::NOT_FOUND);
         REQUIRE((records.size() == 0));
 
         // bogus dataset
-        s = data->dataset_range("bogus", hdr.get(), range(1, 10009463, 10009466), nullptr, records);
+        s = data->dataset_range("bogus", hdr.get(), range(1, 10009463, 10009466), nullptr, &records);
         //REQUIRE(s == StatusCode::NOT_FOUND);
         REQUIRE((records.size() == 0));
     }
@@ -659,7 +659,7 @@ TEST_CASE("BCFKeyValueData range overlap with a single dataset") {
         }
         REQUIRE(s.ok());
         shared_ptr<const bcf_hdr_t> hdr;
-        s = data->dataset_header("synth_A", hdr);
+        s = data->dataset_header("synth_A", &hdr);
         REQUIRE(s.ok());
 
         vector<shared_ptr<bcf1_t>> records;
@@ -668,7 +668,7 @@ TEST_CASE("BCFKeyValueData range overlap with a single dataset") {
            |<-A1->)       |<-A2->)
            Expected result: empty set
         */
-        s = data->dataset_range("synth_A", hdr.get(), range(0, 1005, 1010), nullptr, records);
+        s = data->dataset_range("synth_A", hdr.get(), range(0, 1005, 1010), nullptr, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 0);
 
@@ -678,7 +678,7 @@ TEST_CASE("BCFKeyValueData range overlap with a single dataset") {
            |<-A2->)  |<-A4->)
            Expected result: {A1, A2, A3}
         */
-        s = data->dataset_range("synth_A", hdr.get(), range(0, 2003, 2006), nullptr, records);
+        s = data->dataset_range("synth_A", hdr.get(), range(0, 2003, 2006), nullptr, &records);
         REQUIRE(s.ok());
 //        for (auto r : records) {
 //            cout << "r= " << r->rid << "," << r->pos << "," << r->rlen << "," << r->shared.s  << endl;
@@ -693,7 +693,7 @@ TEST_CASE("BCFKeyValueData range overlap with a single dataset") {
           |<-A3->)
           Expected result: {A1, A2, A3}
         */
-        s = data->dataset_range("synth_A", hdr.get(), range(0, 3004, 3006), nullptr, records);
+        s = data->dataset_range("synth_A", hdr.get(), range(0, 3004, 3006), nullptr, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 3);
 
@@ -732,12 +732,12 @@ TEST_CASE("BCFKeyValueData long_confidence_intervals") {
         }
         REQUIRE(s.ok());
         shared_ptr<const bcf_hdr_t> hdr;
-        s = data->dataset_header("long_ref", hdr);
+        s = data->dataset_header("long_ref", &hdr);
         REQUIRE(s.ok());
 
         // only reference confidence records are supposed to show up in these queries
         vector<shared_ptr<bcf1_t>> records;
-        s = data->dataset_range("long_ref", hdr.get(), range(0, 1020, 1030), nullptr, records);
+        s = data->dataset_range("long_ref", hdr.get(), range(0, 1020, 1030), nullptr, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 1);
         REQUIRE(records[0]->pos == 1016);
@@ -745,23 +745,23 @@ TEST_CASE("BCFKeyValueData long_confidence_intervals") {
         REQUIRE(string(records[0]->d.allele[0]) == "A");
         REQUIRE(string(records[0]->d.allele[1]) == "<NON_REF>");
 
-        s = data->dataset_range("long_ref", hdr.get(), range(0, 2100, 2900), nullptr, records);
+        s = data->dataset_range("long_ref", hdr.get(), range(0, 2100, 2900), nullptr, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 1);
         REQUIRE(records[0]->pos == 2009);
         REQUIRE(string(records[0]->d.allele[0]) == "C");
 
         // Several records are supposed to appear
-        s = data->dataset_range("long_ref", hdr.get(), range(0, 2800, 3010), nullptr, records);
+        s = data->dataset_range("long_ref", hdr.get(), range(0, 2800, 3010), nullptr, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 5);
 
-        s = data->dataset_range("long_ref", hdr.get(), range(0, 1004, 3000), nullptr, records);
+        s = data->dataset_range("long_ref", hdr.get(), range(0, 1004, 3000), nullptr, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 8);
 
         // long record is last
-        s = data->dataset_range("long_ref", hdr.get(), range(0, 3000, 4000), nullptr, records);
+        s = data->dataset_range("long_ref", hdr.get(), range(0, 3000, 4000), nullptr, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 5);
     }
@@ -803,31 +803,31 @@ TEST_CASE("BCFKeyValueData long_confidence_intervals 2") {
         REQUIRE(s.ok());
 
         shared_ptr<const bcf_hdr_t> hdr;
-        s = data->dataset_header("B", hdr);
+        s = data->dataset_header("B", &hdr);
         REQUIRE(s.ok());
 
         vector<shared_ptr<bcf1_t>> records;
-        s = data->dataset_range("B", hdr.get(), range(0, 1000, 1108), nullptr, records);
+        s = data->dataset_range("B", hdr.get(), range(0, 1000, 1108), nullptr, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 1);
 
-        s = data->dataset_range("B", hdr.get(), range(0, 3000, 4000), nullptr, records);
+        s = data->dataset_range("B", hdr.get(), range(0, 3000, 4000), nullptr, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 5);
 
-        s = data->dataset_range("B", hdr.get(), range(0, 5000, 5010), nullptr, records);
+        s = data->dataset_range("B", hdr.get(), range(0, 5000, 5010), nullptr, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 2);
         REQUIRE(records[0]->pos == 3198);
         REQUIRE(string(records[0]->d.allele[0]) == "C");
 
-        s = data->dataset_range("B", hdr.get(), range(0, 6000, 6005), nullptr, records);
+        s = data->dataset_range("B", hdr.get(), range(0, 6000, 6005), nullptr, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 1);
         REQUIRE(records[0]->pos == 4002);
         REQUIRE(string(records[0]->d.allele[0]) == "C");
 
-        s = data->dataset_range("B", hdr.get(), range(0, 8000, 10000), nullptr, records);
+        s = data->dataset_range("B", hdr.get(), range(0, 8000, 10000), nullptr, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 0);
     }
@@ -910,7 +910,7 @@ TEST_CASE("BCFData::sampleset_range") {
     vector<shared_ptr<bcf1_t>> records, all_records;
     s = iterators[0]->next(dataset, hdr, records);
     REQUIRE(s.ok());
-    #define check() s = data->dataset_range(dataset, hdr.get(), range(0,0,1000000), nullptr, all_records); \
+    #define check() s = data->dataset_range(dataset, hdr.get(), range(0,0,1000000), nullptr, &all_records); \
                     REQUIRE(s.ok()); \
                     REQUIRE(records.size() <= count_if(all_records.begin(), all_records.end(), [&](shared_ptr<bcf1_t>& r){return rng.overlaps(r.get());})); \
                     REQUIRE(all_of(records.begin(), records.end(), [&](shared_ptr<bcf1_t>& r){return rng.overlaps(r.get());}))
@@ -1115,7 +1115,7 @@ TEST_CASE("BCFKeyValueData::sampleset_range") {
     shared_ptr<const bcf_hdr_t> hdr;
     vector<shared_ptr<bcf1_t>> records, all_records;
 
-     #define check() s = data->dataset_range(dataset, hdr.get(), range(0,0,10000000), nullptr, all_records); \
+    #define check() s = data->dataset_range(dataset, hdr.get(), range(0,0,10000000), nullptr, &all_records); \
                     REQUIRE(s.ok()); \
                     REQUIRE(records.size() <= count_if(all_records.begin(), all_records.end(), [&](shared_ptr<bcf1_t>& r){return rng.overlaps(r.get());})); \
                     REQUIRE(all_of(records.begin(), records.end(), [&](shared_ptr<bcf1_t>& r){return rng.overlaps(r.get());}))
@@ -1532,7 +1532,7 @@ TEST_CASE("BCFKeyValueData NA12878 import and query") {
             range q(16, lo, hi);
 
             std::vector<std::shared_ptr<bcf1_t> > resultset, truthset;
-            ls = data->dataset_range("NA12878", hdr.get(), q, nullptr, resultset);
+            ls = data->dataset_range("NA12878", hdr.get(), q, nullptr, &resultset);
             if (ls.bad()) {
                 return ls;
             }

--- a/test/rocks_integration.cc
+++ b/test/rocks_integration.cc
@@ -262,7 +262,7 @@ TEST_CASE("RocksDB BCF retrieval") {
 
     SECTION("dataset_header") {
         shared_ptr<const bcf_hdr_t> hdr;
-        s = data->dataset_header("NA12878D", hdr);
+        s = data->dataset_header("NA12878D", &hdr);
         REQUIRE(s.ok());
 
         vector<string> samples;
@@ -277,10 +277,10 @@ TEST_CASE("RocksDB BCF retrieval") {
     SECTION("dataset_range") {
         // get all records
         shared_ptr<const bcf_hdr_t> hdr;
-        s = data->dataset_header("NA12878D", hdr);
+        s = data->dataset_header("NA12878D", &hdr);
         REQUIRE(s.ok());
         vector<shared_ptr<bcf1_t>> records;
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000000000), 0, records);
+        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000000000), 0, &records);
         REQUIRE(s.ok());
 
         REQUIRE(records.size() == 5);
@@ -308,7 +308,7 @@ TEST_CASE("RocksDB BCF retrieval") {
         REQUIRE(bcf_get_info(hdr.get(), records[4].get(), "END")->v1.i == 10009471); // nb END stays 1-based!
 
         // subset of records
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 10009463, 10009466), 0, records);
+        s = data->dataset_range("NA12878D", hdr.get(), range(0, 10009463, 10009466), 0, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 2);
         std::shared_ptr<StatsRangeQuery> srq = data->getRangeStats();
@@ -328,15 +328,15 @@ TEST_CASE("RocksDB BCF retrieval") {
         REQUIRE(string(records[1]->d.allele[1]) == "<NON_REF>");
 
         // empty results
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000), 0, records);
+        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000), 0, &records);
         REQUIRE(records.size() == 0);
 
-        s = data->dataset_range("NA12878D", hdr.get(), range(1, 10009463, 10009466), 0, records);
+        s = data->dataset_range("NA12878D", hdr.get(), range(1, 10009463, 10009466), 0, &records);
         //REQUIRE(s == StatusCode::NOT_FOUND);
         REQUIRE(records.size() == 0);
 
         // bogus dataset
-        s = data->dataset_range("bogus", hdr.get(), range(1, 10009463, 10009466), 0, records);
+        s = data->dataset_range("bogus", hdr.get(), range(1, 10009463, 10009466), 0, &records);
         //REQUIRE(s == StatusCode::NOT_FOUND);
         REQUIRE(records.size() == 0);
 
@@ -368,12 +368,12 @@ TEST_CASE("RocksKeyValue prefix mode") {
     SECTION("dataset_range") {
         // get all records
         shared_ptr<const bcf_hdr_t> hdr;
-        s = data->dataset_header("NA12878D", hdr);
+        s = data->dataset_header("NA12878D", &hdr);
         REQUIRE(s.ok());
         vector<shared_ptr<bcf1_t>> records;
 
         // subset of records
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 10009463, 10009466), 0, records);
+        s = data->dataset_range("NA12878D", hdr.get(), range(0, 10009463, 10009466), 0, &records);
         REQUIRE(s.ok());
         REQUIRE(records.size() == 2);
 
@@ -389,14 +389,14 @@ TEST_CASE("RocksKeyValue prefix mode") {
         REQUIRE(string(records[1]->d.allele[1]) == "<NON_REF>");
 
         // empty results
-        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000), 0, records);
+        s = data->dataset_range("NA12878D", hdr.get(), range(0, 0, 1000), 0, &records);
         REQUIRE(records.size() == 0);
 
-        s = data->dataset_range("NA12878D", hdr.get(), range(1, 10009463, 10009466), 0, records);
+        s = data->dataset_range("NA12878D", hdr.get(), range(1, 10009463, 10009466), 0, &records);
         REQUIRE(records.size() == 0);
 
         // bogus dataset
-        s = data->dataset_range("bogus", hdr.get(), range(1, 10009463, 10009466), 0, records);
+        s = data->dataset_range("bogus", hdr.get(), range(1, 10009463, 10009466), 0, &records);
         REQUIRE(records.size() == 0);
 
     }
@@ -439,16 +439,16 @@ static void importGVCF(T *data,
 // it will never be removed.
 static void queryDataset(T *data, const std::string &dataset) {
     shared_ptr<const bcf_hdr_t> hdr;
-    Status s = data->dataset_header(dataset, hdr);
+    Status s = data->dataset_header(dataset, &hdr);
 
     vector<shared_ptr<bcf1_t>> records;
     s = data->dataset_range(dataset, hdr.get(), range(0, 1005, 1010), 0,
-                            records);
+                            &records);
     assert(s.ok());
     assert(records.size() == 0);
 
     s = data->dataset_range(dataset, hdr.get(), range(0, 2003, 2006), 0,
-                            records);
+                            &records);
     assert(s.ok());
     assert(records.size() == 3);
 }

--- a/test/service.cc
+++ b/test/service.cc
@@ -25,7 +25,7 @@ public:
         return Status::OK();
     }
 
-    Status dataset_header(const string& dataset, shared_ptr<const bcf_hdr_t>& hdr) override {
+    Status dataset_header(const string& dataset, shared_ptr<const bcf_hdr_t>* hdr) override {
         if (i_++ % fail_every_ == 0) {
             failed_once_ = true;
             return Status::IOError("SIM");
@@ -34,7 +34,7 @@ public:
     }
 
     Status dataset_range(const string& dataset, const bcf_hdr_t *hdr, const range& pos,
-                         bcf_predicate predicate, vector<shared_ptr<bcf1_t> >& records) override {
+                         bcf_predicate predicate, vector<shared_ptr<bcf1_t>>* records) override {
         if (i_++ % fail_every_ == 0) {
             failed_once_ = true;
             return Status::IOError("SIM");

--- a/test/utils.cc
+++ b/test/utils.cc
@@ -171,24 +171,24 @@ public:
         return Status::OK();
     }
 
-    Status dataset_header(const string& dataset, shared_ptr<const bcf_hdr_t>& hdr) override {
+    Status dataset_header(const string& dataset, shared_ptr<const bcf_hdr_t>* hdr) override {
         auto p = datasets_.find(dataset);
         if (p == datasets_.end()) {
             return Status::NotFound("unknown data set", dataset);
         }
-        hdr = p->second.header;
+        *hdr = p->second.header;
         return Status::OK();
     }
 
     Status dataset_range(const string& dataset, const bcf_hdr_t *hdr,
                          const range& pos, bcf_predicate predicate,
-                         vector<shared_ptr<bcf1_t> >& records) override {
+                         vector<shared_ptr<bcf1_t>>* records) override {
         Status s;
         auto p = datasets_.find(dataset);
         if (p == datasets_.end()) {
             return Status::NotFound("unknown data set", dataset);
         }
-        records.clear();
+        records->clear();
         for (const auto& bcf : p->second.records) {
             if (!range(bcf).overlaps(pos))
                 continue;
@@ -200,7 +200,7 @@ public:
                 S(predicate(hdr, bcf.get(), rec_ok));
             }
             if (rec_ok)
-                records.push_back(bcf);
+                records->push_back(bcf);
         }
         return Status::OK();
     }


### PR DESCRIPTION
Non-const function params are not allowed in Google cpp style guide, see
below:
https://google.github.io/styleguide/cppguide.html
"In fact it is a very strong convention in Google code that input arguments are
values or const references while output arguments are pointers. Input parameters
may be const pointers, but we never allow non-const reference parameters except
when required by convention, e.g., swap()."

This fixes a few places to use non-const pointers instead of non-const
refs as function out params.