### PR TITLE
add max_alleles_per_site to 32 for deep variant

### DIFF
--- a/src/cli_utils.cc
+++ b/src/cli_utils.cc
@@ -767,6 +767,7 @@ DeepVariant:
         min_AQ2: 0
         min_GQ: 0
         monoallelic_sites_for_lost_alleles: true
+        max_alleles_per_site: 32
     genotyper_config:
         required_dp: 0
         revise_genotypes: false


### PR DESCRIPTION
setting add_max_alleles_per_site for DV for version 1.1.12