### PR TITLE
Update OS version to supported release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for building GLnexus. The resulting container image runs the unit tests
 # by default. It has in its working directory the statically linked glnexus_cli
 # executable which can be copied out.
-FROM ubuntu:18.04 AS builder
+FROM ubuntu:22.04 AS builder
 MAINTAINER DNAnexus
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
@@ -28,7 +28,7 @@ CMD ctest -V
 
 # Second stage: copy glnexus_cli into a slimmer image
 # use ubuntu 20.04+ to get multi-threaded bgzip with libdeflate
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
 - End of Standard Support and security patches for Ubuntu 18.04 was May, 2023. In order to continue enabling containers running securely, the OS needs to be updated.
 - Note, that the HEAD of the current branch compiles but fails a test, and the container build does not complete. While this patch does nothing to address that issue, pending a subsequent fix, there is no difference in the result between Ubuntu 18.04 and 22.04.