### PR TITLE
Updating the required depth to 2 in config.

### DIFF
--- a/src/cli_utils.cc
+++ b/src/cli_utils.cc
@@ -830,7 +830,7 @@ DeepVariant:
         monoallelic_sites_for_lost_alleles: true
         max_alleles_per_site: 32
     genotyper_config:
-        required_dp: 0
+        required_dp: 2
         revise_genotypes: true
         snv_prior_calibration: 0.6
         indel_prior_calibration: 0.45


### PR DESCRIPTION
Hello,

Requesting this change because the `required_dp: 0` in the config creates a lot of `0/0` calls in the gVCF files. Updating this to 2 removes the redundant lines.