### PR TITLE
Replace fcmm with TBB and add explicit checkpointing (RocksDB)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ ExternalProject_Add(capnp
 
 execute_process(COMMAND git describe --tags --long --dirty --always
                 OUTPUT_VARIABLE GIT_REVISION OUTPUT_STRIP_TRAILING_WHITESPACE)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_REVISION=\"\\\"${GIT_REVISION}\"\" -pthread -std=c++14 -Wall -Werror=return-type -Werror=unused-result -Wno-sign-compare -Wno-write-strings -Wno-terminate -fdiagnostics-color=auto -march=ivybridge")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_REVISION=${GIT_REVISION} -pthread -std=c++14 -Wall -Werror=return-type -Werror=unused-result -Wno-sign-compare -Wno-write-strings -Wno-terminate -fdiagnostics-color=auto -march=ivybridge")
 set(CMAKE_CXX_FLAGS_RELEASE "-gdwarf -DNDEBUG -O3")
 
 ################################
@@ -267,7 +267,7 @@ add_executable(unit_tests
                 test/cli.cc)
 add_dependencies(unit_tests catch)
 add_dependencies(unit_tests libglnexus)
-target_link_libraries(unit_tests glnexus libhts librocksdb libyaml-cpp libz.a libsnappy.a libbz2.a libzstd.a liblzma.a librt.a libcapnp.a libkj.a)
+target_link_libraries(unit_tests glnexus libhts librocksdb libyaml-cpp libtbb libz.a libsnappy.a libbz2.a libzstd.a liblzma.a librt.a libcapnp.a libkj.a)
 
 include(CTest)
 add_test(NAME unit_tests COMMAND ./unit_tests -d yes)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,18 +136,22 @@ ExternalProject_Get_Property(CTPL source_dir)
 set(CTPL_INCLUDE_DIR ${source_dir})
 include_directories(${CTPL_INCLUDE_DIR})
 
-ExternalProject_Add(fcmm
-    URL https://github.com/giacomodrago/fcmm/archive/v1.0.1.zip
+# TBB
+ExternalProject_Add(tbb
+    URL https://github.com/uxlfoundation/oneTBB/archive/refs/tags/v2022.2.0.tar.gz
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external
-    CONFIGURE_COMMAND ""
-    BUILD_IN_SOURCE 1
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
+    # Configure TBB's cmake build. We want a static library, and we don't need the tests.
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external -DTBB_TEST=OFF -DBUILD_SHARED_LIBS=OFF
+    # After build, install it to the prefix.
+    INSTALL_COMMAND make install
     LOG_DOWNLOAD ON
-  )
-ExternalProject_Get_Property(fcmm source_dir)
-set(FCMM_INCLUDE_DIR ${source_dir})
-include_directories(${FCMM_INCLUDE_DIR})
+    LOG_BUILD ON
+)
+# Define the imported library target for TBB
+add_library(libtbb STATIC IMPORTED)
+set(LIBTBB_A ${CMAKE_BINARY_DIR}/external/lib/libtbb.a)
+set_property(TARGET libtbb PROPERTY IMPORTED_LOCATION ${LIBTBB_A})
+include_directories(${CMAKE_BINARY_DIR}/external/include)
 
 ExternalProject_Add(spdlog
     URL https://github.com/gabime/spdlog/archive/v1.8.2.tar.gz
@@ -174,7 +178,7 @@ ExternalProject_Add(capnp
 
 execute_process(COMMAND git describe --tags --long --dirty --always
                 OUTPUT_VARIABLE GIT_REVISION OUTPUT_STRIP_TRAILING_WHITESPACE)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_REVISION=\"\\\"${GIT_REVISION}\\\"\" -pthread -std=c++14 -Wall -Werror=return-type -Werror=unused-result -Wno-sign-compare -Wno-write-strings -Wno-terminate -fdiagnostics-color=auto -march=ivybridge")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_REVISION=\"\\\"${GIT_REVISION}\"\" -pthread -std=c++14 -Wall -Werror=return-type -Werror=unused-result -Wno-sign-compare -Wno-write-strings -Wno-terminate -fdiagnostics-color=auto -march=ivybridge")
 set(CMAKE_CXX_FLAGS_RELEASE "-gdwarf -DNDEBUG -O3")
 
 ################################
@@ -217,7 +221,7 @@ add_dependencies(glnexus htslib)
 add_dependencies(glnexus rocksdb)
 add_dependencies(glnexus yaml-cpp)
 add_dependencies(glnexus CTPL)
-add_dependencies(glnexus fcmm)
+add_dependencies(glnexus tbb)
 add_dependencies(glnexus spdlog)
 add_dependencies(glnexus capnp)
 add_library(libglnexus ALIAS glnexus)
@@ -226,7 +230,8 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -march=ivybridge -static-l
 
 add_executable(glnexus_cli cli/glnexus_cli.cc)
 add_dependencies(glnexus_cli libglnexus)
-target_link_libraries(glnexus_cli glnexus libhts librocksdb libyaml-cpp libz.a libsnappy.a libbz2.a libzstd.a liblzma.a librt.a libcapnp.a libkj.a)
+target_link_libraries(glnexus_cli glnexus libhts librocksdb libyaml-cpp libtbb libz.a libsnappy.a libbz2.a libzstd.a liblzma.a librt.a libcapnp.a libkj.a)
+
 
 install(TARGETS glnexus_cli DESTINATION bin)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ADD . /GLnexus
 WORKDIR /GLnexus
 
 # compile GLnexus
-RUN cmake -DCMAKE_BUILD_TYPE=$build_type . && make -j4
+RUN cmake -DCMAKE_BUILD_TYPE=$build_type . && make
 
 # set up default container start to run tests
 CMD ctest -V
@@ -40,3 +40,33 @@ ADD https://github.com/mlin/spVCF/releases/download/v1.0.0/spvcf /usr/local/bin/
 RUN chmod +x /usr/local/bin/spvcf
 
 CMD glnexus_cli
+
+# Third stage: add in gcloud cli
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get -qqy update --fix-missing && \
+    apt-get -qqy dist-upgrade && \
+    apt-get -qqy install --no-install-recommends \
+                 apt-transport-https \
+                 ca-certificates \
+                 gnupg \
+                 curl \
+                 wget \
+                 bc \
+                 bedtools \
+                 datamash \
+                 gawk \
+                 less \
+                 pigz \
+                 tabix \
+                 tree \
+                 vcftools \
+                 zlib1g-dev && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get -qqy update && \
+    apt-get -qqy install --no-install-recommends google-cloud-cli && \
+    gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment github_docker_image && \
+    apt-get -qqy purge gnupg && \
+    apt-get -qqy clean

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -6,6 +6,7 @@
 #include <getopt.h>
 #include <sstream>
 #include <cstdlib>
+#include <sys/stat.h>
 #include "vcf.h"
 #include "hfile.h"
 #include "service.h"
@@ -45,13 +46,34 @@ static int all_steps(const vector<string> &vcf_files,
                      size_t mem_budget, size_t nr_threads,
                      bool debug,
                      bool iter_compare,
-                     size_t bucket_size) {
+                     size_t bucket_size,
+                     const string &checkpoint_out_path,
+                     const string &checkpoint_in_path,
+                     bool checkpoint_only,
+                     const string &output_filename) {
     GLnexus::Status s;
     GLnexus::unifier_config unifier_cfg;
     GLnexus::genotyper_config genotyper_cfg;
     string cfg_txt, cfg_crc32c;
+    bool is_loaded_from_checkpoint = false;
 
-    if (vcf_files.empty()) {
+    if (!checkpoint_in_path.empty()) {
+        struct stat info;
+        if (stat(dbpath.c_str(), &info) == 0 && (info.st_mode & S_IFDIR)) {
+            console->error("Database directory {} already exists. Please remove it before loading from a checkpoint.", dbpath);
+            return 1;
+        }
+
+        string cmd = "ln -s " + checkpoint_in_path + " " + dbpath;
+        console->info("Loading database from checkpoint by creating a symbolic link: {}", cmd);
+        if (system(cmd.c_str()) != 0) {
+            console->error("Failed to create symbolic link from {} to {}.", checkpoint_in_path, dbpath);
+            return 1;
+        }
+        is_loaded_from_checkpoint = true;
+    }
+
+    if (vcf_files.empty() && !is_loaded_from_checkpoint) {
         console->error("No source GVCF files specified");
         return 1;
     }
@@ -62,16 +84,20 @@ static int all_steps(const vector<string> &vcf_files,
 
     // initilize empty database
     vector<pair<string,size_t> > contigs;
-    H("initialize database", GLnexus::cli::utils::db_init(console, dbpath, vcf_files[0], contigs,
-                                                          bucket_size));
-
-    {
-        // sanity check, see that we can get the contigs back
-        vector<pair<string,size_t> > contigs_dbg;
-        H("read the contigs back from DB",
-          GLnexus::cli::utils::db_get_contigs(console, dbpath, contigs_dbg));
-        if (contigs_dbg != contigs)
-            return GLnexus::Status::Invalid("error, contigs read from DB do not match originals");
+    if (is_loaded_from_checkpoint) {
+        H("read the contigs from DB",
+          GLnexus::cli::utils::db_get_contigs(console, dbpath, contigs));
+    } else {
+        H("initialize database", GLnexus::cli::utils::db_init(console, dbpath, vcf_files[0], contigs,
+                                                              bucket_size));
+        {
+            // sanity check, see that we can get the contigs back
+            vector<pair<string,size_t> > contigs_dbg;
+            H("read the contigs back from DB",
+              GLnexus::cli::utils::db_get_contigs(console, dbpath, contigs_dbg));
+            if (contigs_dbg != contigs)
+                return GLnexus::Status::Invalid("error, contigs read from DB do not match originals");
+        }
     }
 
     if (nr_threads == 0) {
@@ -80,11 +106,13 @@ static int all_steps(const vector<string> &vcf_files,
 
     // Load the GVCFs into the database
     unique_ptr<GLnexus::KeyValue::DB> db;
-    {
+    if (!is_loaded_from_checkpoint) {
         // use an empty range filter
         vector<GLnexus::range> ranges;
         H("bulk load into DB",
           GLnexus::cli::utils::db_bulk_load(console, mem_budget, nr_threads, vcf_files, dbpath, ranges, contigs, &db, false));
+    } else {
+        H("open database", GLnexus::RocksKeyValue::DB::Open(dbpath, &db, nr_threads));
     }
     assert(db);
 
@@ -160,6 +188,14 @@ static int all_steps(const vector<string> &vcf_files,
     }
 
     console->info("Finishing database compaction...");
+    if (!checkpoint_out_path.empty()) {
+        console->info("Creating checkpoint at {}", checkpoint_out_path);
+        H("create checkpoint", db->CreateCheckpoint(checkpoint_out_path));
+        if (checkpoint_only) {
+            console->info("Checkpoint created. Exiting as requested by --checkpoint-only.");
+            return 0;
+        }
+    }
     db.reset();
 
     // genotype
@@ -174,7 +210,7 @@ static int all_steps(const vector<string> &vcf_files,
         // if running in DNAnexus, record job ID in header
         hdr_lines.push_back(string("##DX_JOB_ID=")+DX_JOB_ID);
     }
-    string outfile("-");
+    string outfile(output_filename);
     H("genotype",
       GLnexus::cli::utils::genotype(console, mem_budget, nr_threads, dbpath, genotyper_cfg, sites, hdr_lines, outfile));
 
@@ -186,18 +222,24 @@ void help(const char* prog) {
     cout << "Usage: " << prog << " [options] /vcf/file/1 .. /vcf/file/N" << endl
          << "Merge and joint-call input gVCF files, emitting multi-sample BCF on standard output." << endl << endl
          << "Options:" << endl
-         << "  --dir DIR, -d DIR              scratch directory path (mustn't already exist; default: ./GLnexus.DB)" << endl
+         << "  --dir DIR, -d DIR              scratch directory path (default: ./GLnexus.DB)" << endl
          << "  --config X, -c X               configuration preset name or .yml filename (default: gatk)" << endl
-         << "  --bed FILE, -b FILE            three-column BED file with ranges to analyze (if neither --range nor --bed: use full length of all contigs)" << endl
-         << "  --list, -l                     expect given files to contain lists of gVCF filenames, one per line" << endl << endl
+         << "  --bed FILE, -b FILE            three-column BED file with ranges to analyze" << endl << endl
+         << "gVCF Input (choose one):" << endl
+         << "  --list FILE, -l FILE           text file containing a list of gVCF filenames, one per line" << endl
+         << "  (or provide gVCF files directly on the command line)" << endl << endl
+         << "Checkpointing:" << endl
+         << "  --checkpoint-in PATH           load database from checkpoint at PATH (cannot be used with gVCF input)" << endl
+         << "  --checkpoint-out PATH          save database checkpoint to PATH after data loading (requires gVCF input)" << endl
+         << "  --checkpoint-only              exit after creating checkpoint (requires --checkpoint-out)" << endl << endl
 
+         << "Other Options:" << endl
          << "  --more-PL, -P                  include PL from reference bands and other cases omitted by default" << endl
          << "  --squeeze, -S                  reduce pVCF size by suppressing detail in cells derived from reference bands" << endl
-         << "  --trim-uncalled-alleles, -a    remove alleles with no output GT calls in postprocessing" << endl << endl
-
+         << "  --trim-uncalled-alleles, -a    remove alleles with no output GT calls in postprocessing" << endl
          << "  --mem-gbytes X, -m X           memory budget, in gbytes (default: most of system memory)" << endl
-         << "  --threads X, -t X              thread budget (default: all hardware threads)" << endl << endl
-
+         << "  --threads X, -t X              thread budget (default: all hardware threads)" << endl
+         << "  --output FILE, -o FILE         BCF output file (default: standard output)" << endl
          << "  --help, -h                     print this help message" << endl
          << endl << "Configuration presets:" << endl;
     cout << GLnexus::cli::utils::describe_config_presets() << endl;
@@ -237,6 +279,10 @@ int main(int argc, char *argv[]) {
         {"bucket_size", required_argument, 0, 'x'},
         {"debug", no_argument, 0, 'g'},
         {"iter_compare", no_argument, 0, 'i'},
+        {"output", required_argument, 0, 'o'},
+        {"checkpoint-out", required_argument, 0, 1},
+        {"checkpoint-in", required_argument, 0, 2},
+        {"checkpoint-only", no_argument, 0, 3},
         {0, 0, 0, 0}
     };
 
@@ -252,10 +298,29 @@ int main(int argc, char *argv[]) {
     string bedfilename;
     size_t mem_budget = 0, nr_threads = 0;
     size_t bucket_size = GLnexus::BCFKeyValueData::default_bucket_size;
+    string checkpoint_out_path, checkpoint_in_path;
+    bool checkpoint_only = false;
+    string output_filename = "-";
 
-    while (-1 != (c = getopt_long(argc, argv, "hPSadil:b:x:m:t:c:",
+    while (-1 != (c = getopt_long(argc, argv, "hPSadil:b:x:m:t:c:o:",
                                   long_options, nullptr))) {
         switch (c) {
+            case 1:
+                checkpoint_out_path = string(optarg);
+                break;
+
+            case 2:
+                checkpoint_in_path = string(optarg);
+                break;
+
+            case 3:
+                checkpoint_only = true;
+                break;
+
+            case 'o':
+                output_filename = string(optarg);
+                break;
+
             case 'd':
                 dbpath = string(optarg);
                 break;
@@ -332,8 +397,30 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    if (optind > argc-1) {
+    if (optind > argc-1 && checkpoint_in_path.empty()) {
         help(argv[0]);
+        return 1;
+    }
+
+    bool has_input_files = list_of_files || (optind < argc);
+
+    if (!checkpoint_in_path.empty() && has_input_files) {
+        console->error("Cannot provide input files when loading from a checkpoint with --checkpoint-in.");
+        return 1;
+    }
+
+    if (checkpoint_in_path.empty() && !has_input_files) {
+        console->error("Either provide input files or use --checkpoint-in to load from a checkpoint.");
+        return 1;
+    }
+
+    if (!checkpoint_out_path.empty() && !has_input_files) {
+        console->error("--checkpoint-out can only be used when providing input files.");
+        return 1;
+    }
+
+    if (checkpoint_only && checkpoint_out_path.empty()) {
+        console->error("--checkpoint-only can only be used with --checkpoint-out.");
         return 1;
     }
 
@@ -358,5 +445,5 @@ int main(int argc, char *argv[]) {
     }
 
     return all_steps(vcf_files, bedfilename, dbpath, config_name, more_PL, squeeze, trim_uncalled_alleles,
-                     mem_budget, nr_threads, debug, iter_compare, bucket_size);
+                     mem_budget, nr_threads, debug, iter_compare, bucket_size, checkpoint_out_path, checkpoint_in_path, checkpoint_only, output_filename);
 }

--- a/cli/glnexus_cli.cc
+++ b/cli/glnexus_cli.cc
@@ -18,6 +18,10 @@
 #include "spdlog/sinks/stdout_sinks.h"
 #include "cli_utils.h"
 
+// https://gcc.gnu.org/onlinedocs/cpp/Stringizing.html
+#define STRINGIFY(x) #x
+#define MACRO_TO_STRING(x) STRINGIFY(x)
+
 using namespace std;
 
 auto console = spdlog::stderr_logger_mt("GLnexus");
@@ -112,7 +116,9 @@ static int all_steps(const vector<string> &vcf_files,
         H("bulk load into DB",
           GLnexus::cli::utils::db_bulk_load(console, mem_budget, nr_threads, vcf_files, dbpath, ranges, contigs, &db, false));
     } else {
-        H("open database", GLnexus::RocksKeyValue::DB::Open(dbpath, &db, nr_threads));
+        GLnexus::RocksKeyValue::config cfg;
+        cfg.thread_budget = nr_threads;
+        H("open database", GLnexus::RocksKeyValue::Open(dbpath, cfg, db));
     }
     assert(db);
 
@@ -257,7 +263,7 @@ int main(int argc, char *argv[]) {
     #else
     #define BUILD_CONFIG "debug"
     #endif
-    console->info("glnexus_cli {} {} {}", BUILD_CONFIG, GIT_REVISION, __DATE__);
+    console->info("glnexus_cli {} {} {}", BUILD_CONFIG, MACRO_TO_STRING(GIT_REVISION), __DATE__);
     GLnexus::cli::utils::detect_jemalloc(console);
 
     if (argc < 2) {

--- a/include/KeyValue.h
+++ b/include/KeyValue.h
@@ -134,6 +134,9 @@ public:
 
     /// Ensure all writes are flushed to storage
     virtual Status flush() = 0;
+
+    /// Create a checkpoint of the database
+    virtual Status CreateCheckpoint(const std::string& checkpoint_dir) = 0;
 };
 
 }}

--- a/src/BCFKeyValueData.cc
+++ b/src/BCFKeyValueData.cc
@@ -12,7 +12,7 @@
 #include <thread>
 #include <mutex>
 #include <sys/time.h>
-#include "fcmm.hpp"
+#include "tbb/concurrent_hash_map.h"
 #include "khash.h"
 #include <regex>
 #include <endian.h>
@@ -50,11 +50,14 @@ struct ActiveMetadata {
 // std::hash<string> using the string hash function from htslib
 class KStringHash {
 public:
-    std::size_t operator()(string const& s) const  {
+    static size_t hash(const string& s) {
         return (size_t) kh_str_hash_func(s.c_str());
     }
+    static bool equal(const string& s1, const string& s2) {
+        return s1 == s2;
+    }
 };
-using BCFHeaderCache = fcmm::Fcmm<string,shared_ptr<const bcf_hdr_t>,hash<string>,KStringHash>;
+using BCFHeaderCache = tbb::concurrent_hash_map<string,shared_ptr<const bcf_hdr_t>,KStringHash>;
 // this is not a hard limit but the FCMM performance degrades if it's too low
 const size_t BCF_HEADER_CACHE_SIZE = 65536;
 
@@ -409,10 +412,10 @@ shared_ptr<StatsRangeQuery> BCFKeyValueData::getRangeStats() {
 
 Status BCFKeyValueData::dataset_header(const string& dataset,
                                        shared_ptr<const bcf_hdr_t>* hdr) {
-    auto cached = body_->header_cache->end();
-    if ((cached = body_->header_cache->find(dataset)) != body_->header_cache->end()) {
+    BCFHeaderCache::const_accessor accessor;
+    if (body_->header_cache->find(accessor, dataset)) {
         // Return memoized header
-        *hdr = cached->second;
+        *hdr = accessor->second;
         assert(hdr);
         return Status::OK();
     }

--- a/src/RocksKeyValue.cc
+++ b/src/RocksKeyValue.cc
@@ -19,6 +19,7 @@
 #include "rocksdb/memtablerep.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/slice_transform.h"
+#include "rocksdb/utilities/checkpoint.h"
 
 namespace GLnexus {
 namespace RocksKeyValue {
@@ -576,6 +577,17 @@ public:
             }
         }
         return Status::OK();
+    }
+
+    Status CreateCheckpoint(const std::string& checkpoint_dir) override {
+        rocksdb::Checkpoint* checkpoint;
+        rocksdb::Status s = rocksdb::Checkpoint::Create(db_, &checkpoint);
+        if (!s.ok()) {
+            return convertStatus(s);
+        }
+        std::unique_ptr<rocksdb::Checkpoint> checkpoint_ptr(checkpoint);
+        s = checkpoint_ptr->CreateCheckpoint(checkpoint_dir);
+        return convertStatus(s);
     }
 };
 

--- a/src/data.cc
+++ b/src/data.cc
@@ -1,6 +1,6 @@
 #include <assert.h>
 #include "data.h"
-#include "fcmm.hpp"
+#include "tbb/concurrent_hash_map.h"
 #include "khash.h"
 
 using namespace std;
@@ -10,12 +10,15 @@ namespace GLnexus {
 // hash<string> using the string hash function from htslib
 class KStringHash {
 public:
-    size_t operator()(string const& s) const  {
+    static size_t hash(const string& s) {
         return (size_t) kh_str_hash_func(s.c_str());
     }
+    static bool equal(const string& s1, const string& s2) {
+        return s1 == s2;
+    }
 };
-using StringCache = fcmm::Fcmm<string,string,hash<string>,KStringHash>;
-using StringSetCache = fcmm::Fcmm<string,shared_ptr<const set<string>>,hash<string>,KStringHash>;
+using StringCache = tbb::concurrent_hash_map<string,string,KStringHash>;
+using StringSetCache = tbb::concurrent_hash_map<string,shared_ptr<const set<string>>,KStringHash>;
 // this is not a hard limit but the FCMM performance degrades if it's too low
 const size_t CACHE_SIZE = 4096;
 
@@ -34,9 +37,9 @@ Status MetadataCache::Start(Metadata& inner, unique_ptr<MetadataCache>& ptr) {
     ptr.reset(new MetadataCache);
     ptr->body_.reset(new MetadataCache::body);
     ptr->body_->inner = &inner;
-    ptr->body_->sampleset_samples_cache = make_unique<StringSetCache>(CACHE_SIZE);
-    ptr->body_->sample_dataset_cache = make_unique<StringCache>(16 * CACHE_SIZE);
-    ptr->body_->sampleset_datasets_cache = make_unique<StringSetCache>(CACHE_SIZE);
+    ptr->body_->sampleset_samples_cache = make_unique<StringSetCache>();
+    ptr->body_->sample_dataset_cache = make_unique<StringCache>();
+    ptr->body_->sampleset_datasets_cache = make_unique<StringSetCache>();
     return ptr->body_->inner->contigs(ptr->body_->contigs);
 }
 
@@ -46,10 +49,9 @@ Status MetadataCache::contigs(vector<pair<string,size_t> >& ans) const {
 }
 
 Status MetadataCache::sampleset_samples(const string& sampleset, shared_ptr<const set<string> >& ans) const {
-    auto cached = body_->sampleset_samples_cache->end();
-    if ((cached = body_->sampleset_samples_cache->find(sampleset))
-            != body_->sampleset_samples_cache->end()) {
-        ans = cached->second;
+    StringSetCache::const_accessor accessor;
+    if (body_->sampleset_samples_cache->find(accessor, sampleset)) {
+        ans = accessor->second;
         assert(ans);
         return Status::OK();
     }
@@ -61,10 +63,9 @@ Status MetadataCache::sampleset_samples(const string& sampleset, shared_ptr<cons
 }
 
 Status MetadataCache::sample_dataset(const string& sample, string& ans) const {
-    auto cached = body_->sample_dataset_cache->end();
-    if ((cached = body_->sample_dataset_cache->find(sample))
-            != body_->sample_dataset_cache->end()) {
-        ans = cached->second;
+    StringCache::const_accessor accessor;
+    if (body_->sample_dataset_cache->find(accessor, sample)) {
+        ans = accessor->second;
         return Status::OK();
     }
 
@@ -93,10 +94,9 @@ Status MetadataCache::sampleset_datasets(const string& sampleset,
     Status s;
     S(sampleset_samples(sampleset, samples));
 
-    auto cached = body_->sampleset_datasets_cache->end();
-    if ((cached = body_->sampleset_datasets_cache->find(sampleset))
-            != body_->sampleset_datasets_cache->end()) {
-        datasets_out = cached->second;
+    StringSetCache::const_accessor accessor;
+    if (body_->sampleset_datasets_cache->find(accessor, sampleset)) {
+        datasets_out = accessor->second;
         assert(datasets_out);
         return Status::OK();
     }

--- a/src/service.cc
+++ b/src/service.cc
@@ -12,7 +12,11 @@
 #include <map>
 #include <assert.h>
 #include <tuple>
-#include "ctpl_stl.h"
+#include <ctpl_stl.h>
+
+// https://gcc.gnu.org/onlinedocs/cpp/Stringizing.html
+#define STRINGIFY(x) #x
+#define MACRO_TO_STRING(x) STRINGIFY(x)
 
 using namespace std;
 
@@ -193,7 +197,7 @@ static Status prepare_bcf_header(const vector<pair<string,size_t> >& contigs,
                                  const vector<string>& extra_header_lines,
                                  shared_ptr<bcf_hdr_t>& ans) {
     vector<string> hdr_lines;
-    hdr_lines.push_back("##GLnexusVersion=" + string(GIT_REVISION));
+    hdr_lines.push_back("##GLnexusVersion=" + string(MACRO_TO_STRING(GIT_REVISION)));
     for (const auto& line : extra_header_lines) {
         hdr_lines.push_back(line);
     }

--- a/src/service.cc
+++ b/src/service.cc
@@ -415,7 +415,24 @@ Status Service::genotype_sites(const genotyper_config& cfg, const string& sample
             abort = true;
         }
         results_retrieved++;
+
+        // show progress bar, updating every 100 sites or on the last site
+        if ((i + 1) % 100 == 0 || (i + 1) == sites.size()) {
+            const int BAR_WIDTH = 50;
+            float progress = (float)(i + 1) / sites.size();
+            int bar_position = BAR_WIDTH * progress;
+
+            std::cerr << "[";
+            for (int j = 0; j < BAR_WIDTH; ++j) {
+                if (j < bar_position) std::cerr << "=";
+                else if (j == bar_position) std::cerr << ">";
+                else std::cerr << " ";
+            }
+            std::cerr << "] " << int(progress * 100.0) << " % (" << (i+1) << "/" << sites.size() << ")\r";
+            std::cerr.flush();
+        }
     }
+    std::cerr << std::endl;
     if (s.bad()) {
         return s;
     }

--- a/test/BCFKeyValueData.cc
+++ b/test/BCFKeyValueData.cc
@@ -139,6 +139,10 @@ namespace KeyValueMem {
             return Status::OK();
         }
 
+        Status CreateCheckpoint(const std::string& checkpoint_dir) override {
+            return Status::NotImplemented("KeyValueMem::DB does not support CreateCheckpoint");
+        }
+
         void wipe() {
             collections_.clear();
             data_.clear();


### PR DESCRIPTION
This pull request introduces two major features and a series of build fixes:

1. Replaces `fcmm` with Intel TBB: The fcmm concurrent map dependency, which was causing build failures, has been replaced with Intel's Threading Building Blocks library (`tbb::concurrent_hash_map`).

2. Adds explicit RocksDB checkpointing: A new checkpointing feature has been added to allow saving and loading the state of the RocksDB database. This is useful for development and testing, as it avoids the need to re-ingest all gVCF files on every run.
   - New CLI flags: --checkpoint-in, --checkpoint-out, and --checkpoint-only.
   - A new --output flag was also added to direct the final BCF output to a specified file.

Also, a few docker build fixes:
   - Corrected quoting and macro expansion for the GIT_REVISION definition in CMakeLists.txt and C++ source files.
   - Adapted the custom KStringHash class to be compatible with the TBB API.
   - Implemented a stub for the CreateCheckpoint function in the in-memory database used for testing.

Thanks,
Steve


**Disclaimer: code changes are co-developed with Gemini CLI**